### PR TITLE
cli: improve registry pusher diagnostics and timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,29 @@ PY
 - Status table: `./bin/mcp-runtime status`
 - Grafana/Prometheus reachable via the ingress base URL.
 
-## 8) Reference Links
+## 8) Clean Start (keep cluster, wipe workloads)
+Use this when you want a “fresh start” without uninstalling k3s/kind itself.
+
+⚠️ Destructive: deletes resources cluster-wide.
+
+```bash
+# sanity: confirm you are targeting the intended cluster
+kubectl config current-context
+kubectl get nodes
+
+# delete everything in every namespace (pods/deployments/jobs/services/ingresses/etc.)
+kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob --all -A
+
+# delete all non-system namespaces (wipes everything inside them)
+kubectl get ns --no-headers | awk '{print $1}' \
+  | egrep -v '^(kube-system|kube-public|kube-node-lease|default)$' \
+  | xargs -r kubectl delete ns
+
+# optional: also wipe the default namespace
+kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob --all -n default
+```
+
+## 9) Reference Links
 - Project README: `README.md`
 - K8s manifests: `k8s/`
 - Sample MCP server: `examples/go-mcp-server/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,15 +127,16 @@ kubectl config current-context
 kubectl get nodes
 
 # delete everything in every namespace (pods/deployments/jobs/services/ingresses/etc.)
-kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob --all -A
+kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob,pvc,pv,crd,clusterrole,clusterrolebinding,validatingwebhookconfigurations,mutatingwebhookconfigurations,networkpolicy,podsecuritypolicy --all -A --ignore-not-found --grace-period=0 --force
 
 # delete all non-system namespaces (wipes everything inside them)
-kubectl get ns --no-headers | awk '{print $1}' \
-  | egrep -v '^(kube-system|kube-public|kube-node-lease|default)$' \
-  | xargs -r kubectl delete ns
+ns_to_delete="$(kubectl get ns --no-headers | awk '{print $1}' | grep -E -v '^(kube-system|kube-public|kube-node-lease|default)$')"
+if [ -n "$ns_to_delete" ]; then
+  printf '%s\n' "$ns_to_delete" | xargs kubectl delete ns
+fi
 
 # optional: also wipe the default namespace
-kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob --all -n default
+kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob,pvc --all -n default --ignore-not-found --grace-period=0 --force
 ```
 
 ## 9) Reference Links

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,16 @@ kubectl config current-context
 kubectl get nodes
 
 # delete everything in every namespace (pods/deployments/jobs/services/ingresses/etc.)
-kubectl delete all,cm,secret,ing,svc,sa,role,rolebinding,deploy,ds,sts,job,cronjob,pvc,pv,crd,clusterrole,clusterrolebinding,validatingwebhookconfigurations,mutatingwebhookconfigurations,networkpolicy,podsecuritypolicy --all -A --ignore-not-found --grace-period=0 --force
+# NOTE: build deletable resource list dynamically to avoid errors on clusters where some optional APIs (e.g. PodSecurityPolicy) are absent.
+to_delete="$(kubectl api-resources --verbs=delete --namespaced -o name | paste -sd, -)"
+if [ -n "$to_delete" ]; then
+  kubectl delete "$to_delete" --all -A --ignore-not-found --grace-period=0 --force
+fi
+
+# cluster-scoped resources (best-effort; some may not exist depending on cluster/version)
+for r in $(kubectl api-resources --verbs=delete --namespaced=false -o name); do
+  kubectl delete "$r" --all --ignore-not-found --grace-period=0 --force || true
+done
 
 # delete all non-system namespaces (wipes everything inside them)
 ns_to_delete="$(kubectl get ns --no-headers | awk '{print $1}' | grep -E -v '^(kube-system|kube-public|kube-node-lease|default)$')"

--- a/cmd/mcp-runtime/main.go
+++ b/cmd/mcp-runtime/main.go
@@ -58,6 +58,7 @@ func initCommands(logger *zap.Logger) {
 	rootCmd.AddCommand(cli.NewRegistryCmd(logger))
 	rootCmd.AddCommand(cli.NewServerCmd(logger))
 	rootCmd.AddCommand(cli.NewAccessCmd(logger))
+	rootCmd.AddCommand(cli.NewBootstrapCmd(logger))
 	rootCmd.AddCommand(cli.NewSetupCmd(logger))
 	rootCmd.AddCommand(cli.NewStatusCmd(logger))
 	rootCmd.AddCommand(cli.NewSentinelCmd(logger))

--- a/config/registry/overlays/hostpath-tls/ingress-tls.yaml
+++ b/config/registry/overlays/hostpath-tls/ingress-tls.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: registry
+  namespace: registry
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    cert-manager.io/cluster-issuer: mcp-runtime-ca
+spec:
+  tls:
+  - hosts:
+    - registry.local
+    secretName: registry-tls
+  rules:
+  - host: registry.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: registry
+            port:
+              number: 5000

--- a/config/registry/overlays/hostpath-tls/kustomization.yaml
+++ b/config/registry/overlays/hostpath-tls/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../hostpath
+patchesStrategicMerge:
+  - ../tls/ingress-tls.yaml

--- a/config/registry/overlays/hostpath-tls/kustomization.yaml
+++ b/config/registry/overlays/hostpath-tls/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../hostpath
-patchesStrategicMerge:
-  - ../tls/ingress-tls.yaml
+patches:
+  - path: ingress-tls.yaml

--- a/config/registry/overlays/hostpath/deployment-hostpath.yaml
+++ b/config/registry/overlays/hostpath/deployment-hostpath.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: registry
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: init-perms
+        image: alpine:3.23
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "-c", "chown -R 1000:1000 /var/lib/registry"]
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - name: registry-storage
+          mountPath: /var/lib/registry

--- a/config/registry/overlays/hostpath/kustomization.yaml
+++ b/config/registry/overlays/hostpath/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - pv.yaml
+patchesStrategicMerge:
+  - pvc-hostpath.yaml
+  - deployment-hostpath.yaml

--- a/config/registry/overlays/hostpath/kustomization.yaml
+++ b/config/registry/overlays/hostpath/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - ../../base
   - pv.yaml
-patchesStrategicMerge:
-  - pvc-hostpath.yaml
-  - deployment-hostpath.yaml
+patches:
+  - path: pvc-hostpath.yaml
+  - path: deployment-hostpath.yaml

--- a/config/registry/overlays/hostpath/pv.yaml
+++ b/config/registry/overlays/hostpath/pv.yaml
@@ -11,7 +11,14 @@ spec:
     - ReadWriteOnce
   volumeMode: Filesystem
   storageClassName: local-path
-  persistentVolumeReclaimPolicy: Delete
-  hostPath:
+  persistentVolumeReclaimPolicy: Retain
+  local:
     path: /var/lib/mcp-runtime/registry
-    type: DirectoryOrCreate
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: mcp-runtime.org/local-storage
+              operator: In
+              values:
+                - "true"

--- a/config/registry/overlays/hostpath/pv.yaml
+++ b/config/registry/overlays/hostpath/pv.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: registry-pv
+  labels:
+    app: registry
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: local-path
+  persistentVolumeReclaimPolicy: Delete
+  hostPath:
+    path: /var/lib/mcp-runtime/registry
+    type: DirectoryOrCreate

--- a/config/registry/overlays/hostpath/pvc-hostpath.yaml
+++ b/config/registry/overlays/hostpath/pvc-hostpath.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-storage
+  namespace: registry
+spec:
+  storageClassName: local-path
+  volumeName: registry-pv

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
@@ -24,16 +23,18 @@ func NewBootstrapCmd(logger *zap.Logger) *cobra.Command {
 		Long: `Bootstrap validates and (optionally) installs cluster prerequisites needed by mcp-runtime setup.
 
 By design, this does not provision Kubernetes clusters end-to-end across all distributions.
-Use this to prepare an existing cluster for running 'mcp-runtime setup'.`,
+Use this to prepare an existing cluster for running 'mcp-runtime setup'.
+
+Note: bootstrap --apply is automated for k3s only and must be executed on the k3s server node (it expects local manifests under /var/lib/rancher/k3s/server/manifests).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			Section("MCP Runtime Bootstrap")
 
-			detectedProvider, err := detectProvider(kubectlClient)
-			if err != nil {
-				return err
-			}
 			chosenProvider := provider
 			if chosenProvider == "" || chosenProvider == "auto" {
+				detectedProvider, err := detectProvider(kubectlClient)
+				if err != nil {
+					return err
+				}
 				chosenProvider = detectedProvider
 			}
 			Info(fmt.Sprintf("Provider: %s", chosenProvider))
@@ -65,7 +66,7 @@ Use this to prepare an existing cluster for running 'mcp-runtime setup'.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&apply, "apply", false, "Apply safe bootstrap fixes when possible (k3s only today)")
+	cmd.Flags().BoolVar(&apply, "apply", false, "Apply safe bootstrap fixes when possible (k3s only today; run on the k3s server node)")
 	cmd.Flags().StringVar(&provider, "provider", "auto", "Cluster provider hint (auto|k3s|rke2|kubeadm|generic)")
 	return cmd
 }
@@ -172,9 +173,7 @@ func bootstrapApplyK3s(kubectl KubectlRunner) error {
 	Info("Node disk-pressure check")
 	cond, err := kubectlOutput(kubectl, []string{"get", "nodes", "-o", "jsonpath={range .items[*]}{.metadata.name}{\" \"}{range .status.conditions[?(@.type==\"DiskPressure\")]}{.status}{end}{\"\\n\"}{end}"})
 	if err == nil {
-		var buf bytes.Buffer
-		buf.Write(cond)
-		Info(strings.TrimSpace(buf.String()))
+		Info(strings.TrimSpace(string(cond)))
 	}
 
 	return nil

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+// NewBootstrapCmd provides an on-prem focused bootstrap workflow.
+//
+// Production note: this intentionally does not attempt to provision clusters across all distributions.
+// It performs preflights and (optionally) applies a small set of safe, local-distro-specific fixes.
+func NewBootstrapCmd(logger *zap.Logger) *cobra.Command {
+	var apply bool
+	var provider string
+
+	cmd := &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Bootstrap cluster prerequisites (on-prem focused)",
+		Long: `Bootstrap validates and (optionally) installs cluster prerequisites needed by mcp-runtime setup.
+
+By design, this does not provision Kubernetes clusters end-to-end across all distributions.
+Use this to prepare an existing cluster for running 'mcp-runtime setup'.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			Section("MCP Runtime Bootstrap")
+
+			detectedProvider, err := detectProvider(kubectlClient)
+			if err != nil {
+				return err
+			}
+			chosenProvider := provider
+			if chosenProvider == "" || chosenProvider == "auto" {
+				chosenProvider = detectedProvider
+			}
+			Info(fmt.Sprintf("Provider: %s", chosenProvider))
+
+			if err := runBootstrapPreflight(kubectlClient); err != nil {
+				return err
+			}
+
+			if !apply {
+				Success("Bootstrap preflight complete (no changes applied)")
+				Info("Next: run `./bin/mcp-runtime setup` (or `./bin/mcp-runtime setup --storage-mode hostpath` for single-node dev)")
+				return nil
+			}
+
+			switch chosenProvider {
+			case "k3s":
+				if err := bootstrapApplyK3s(kubectlClient); err != nil {
+					return err
+				}
+			case "rke2", "kubeadm", "generic":
+				Warn("Apply mode is currently only automated for k3s. For other distributions, use the preflight output and install DNS/storage/ingress/load-balancer via your standard platform tooling.")
+			default:
+				Warn(fmt.Sprintf("Unknown provider %q; skipping apply", chosenProvider))
+			}
+
+			Success("Bootstrap complete")
+			Info("Next: run `./bin/mcp-runtime setup`")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&apply, "apply", false, "Apply safe bootstrap fixes when possible (k3s only today)")
+	cmd.Flags().StringVar(&provider, "provider", "auto", "Cluster provider hint (auto|k3s|rke2|kubeadm|generic)")
+	return cmd
+}
+
+func detectProvider(kubectl KubectlRunner) (string, error) {
+	out, err := kubectlOutput(kubectl, []string{"get", "nodes", "-o", "jsonpath={range .items[*]}{.status.nodeInfo.kubeletVersion}{\"\\n\"}{end}"})
+	if err != nil {
+		return "generic", wrapWithSentinel(ErrClusterNotAccessible, err, fmt.Sprintf("kubectl get nodes failed: %v", err))
+	}
+	lower := strings.ToLower(string(out))
+	switch {
+	case strings.Contains(lower, "k3s"):
+		return "k3s", nil
+	case strings.Contains(lower, "rke2"):
+		return "rke2", nil
+	default:
+		return "generic", nil
+	}
+}
+
+func runBootstrapPreflight(kubectl KubectlRunner) error {
+	Info("Preflight: kubectl connectivity")
+	if err := kubectl.Run([]string{"version", "--client=true"}); err != nil {
+		return wrapWithSentinel(ErrClusterNotAccessible, err, fmt.Sprintf("kubectl not available: %v", err))
+	}
+	if err := kubectl.Run([]string{"get", "nodes"}); err != nil {
+		return wrapWithSentinel(ErrClusterNotAccessible, err, fmt.Sprintf("kubectl cannot reach cluster: %v", err))
+	}
+
+	Info("Preflight: CoreDNS")
+	if err := checkDeploymentExists(kubectl, "kube-system", "coredns"); err != nil {
+		Warn("CoreDNS not detected (kube-system/deployment coredns). Cluster DNS must be installed for in-cluster service discovery.")
+	}
+
+	Info("Preflight: Default StorageClass")
+	if err := checkHasDefaultStorageClass(kubectl); err != nil {
+		Warn(fmt.Sprintf("No default StorageClass detected: %v", err))
+	}
+
+	Info("Preflight: IngressClass traefik")
+	if err := kubectl.Run([]string{"get", "ingressclass", "traefik"}); err != nil {
+		Warn("IngressClass traefik not found. If you plan to use Traefik, install it before running setup (or let setup install it when configured).")
+	}
+
+	Info("Preflight: MetalLB")
+	if err := kubectl.Run([]string{"get", "ns", "metallb-system"}); err != nil {
+		Warn("MetalLB not detected (namespace metallb-system). If you need LoadBalancer services on bare metal, install MetalLB.")
+	}
+
+	return nil
+}
+
+func checkDeploymentExists(kubectl KubectlRunner, namespace, name string) error {
+	return kubectl.Run([]string{"get", "deployment", name, "-n", namespace})
+}
+
+func checkHasDefaultStorageClass(kubectl KubectlRunner) error {
+	out, err := kubectlOutput(kubectl, []string{"get", "storageclass", "-o", "jsonpath={range .items[*]}{.metadata.name}{\" \"}{.metadata.annotations.storageclass\\.kubernetes\\.io/is-default-class}{\"\\n\"}{end}"})
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "true" {
+			return nil
+		}
+	}
+	return fmt.Errorf("no StorageClass annotated with storageclass.kubernetes.io/is-default-class=true")
+}
+
+func bootstrapApplyK3s(kubectl KubectlRunner) error {
+	Info("Applying k3s addons: CoreDNS + local-path provisioner (if missing)")
+
+	// Apply only when the manifests exist on disk (k3s server).
+	paths := []string{
+		"/var/lib/rancher/k3s/server/manifests/coredns.yaml",
+		"/var/lib/rancher/k3s/server/manifests/local-storage.yaml",
+	}
+	var missing []string
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("k3s manifests missing on disk (%s); bootstrap --apply expects to run on the k3s server node", strings.Join(missing, ", "))
+	}
+
+	for _, p := range paths {
+		if err := kubectl.Run([]string{"apply", "-f", p}); err != nil {
+			return wrapWithSentinel(ErrClusterConfigFailed, err, fmt.Sprintf("failed to apply %s: %v", p, err))
+		}
+	}
+
+	Info("Waiting for kube-system addons to be ready")
+	if err := kubectl.Run([]string{"rollout", "status", "deployment/coredns", "-n", "kube-system", "--timeout=180s"}); err != nil {
+		return err
+	}
+	if err := kubectl.Run([]string{"rollout", "status", "deployment/local-path-provisioner", "-n", "kube-system", "--timeout=180s"}); err != nil {
+		return err
+	}
+
+	// Best-effort: show disk-pressure so users don't get surprised by evictions.
+	Info("Node disk-pressure check")
+	cond, err := kubectlOutput(kubectl, []string{"get", "nodes", "-o", "jsonpath={range .items[*]}{.metadata.name}{\" \"}{range .status.conditions[?(@.type==\"DiskPressure\")]}{.status}{end}{\"\\n\"}{end}"})
+	if err == nil {
+		var buf bytes.Buffer
+		buf.Write(cond)
+		Info(strings.TrimSpace(buf.String()))
+	}
+
+	return nil
+}
+
+func kubectlOutput(kubectl KubectlRunner, args []string) ([]byte, error) {
+	cmd, err := kubectl.CommandArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return cmd.Output()
+}

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -74,7 +74,7 @@ Note: bootstrap --apply is automated for k3s only and must be executed on the k3
 func detectProvider(kubectl KubectlRunner) (string, error) {
 	out, err := kubectlOutput(kubectl, []string{"get", "nodes", "-o", "jsonpath={range .items[*]}{.status.nodeInfo.kubeletVersion}{\"\\n\"}{end}"})
 	if err != nil {
-		return "generic", wrapWithSentinel(ErrClusterNotAccessible, err, fmt.Sprintf("kubectl get nodes failed: %v", err))
+		return "", wrapWithSentinel(ErrClusterNotAccessible, err, fmt.Sprintf("kubectl get nodes failed: %v", err))
 	}
 	lower := strings.ToLower(string(out))
 	switch {
@@ -152,7 +152,8 @@ func bootstrapApplyK3s(kubectl KubectlRunner) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("k3s manifests missing on disk (%s); bootstrap --apply expects to run on the k3s server node", strings.Join(missing, ", "))
+		msg := fmt.Sprintf("k3s manifests missing on disk (%s); bootstrap --apply expects to run on the k3s server node", strings.Join(missing, ", "))
+		return wrapWithSentinel(ErrClusterConfigFailed, fmt.Errorf("missing manifests"), msg)
 	}
 
 	for _, p := range paths {
@@ -163,10 +164,10 @@ func bootstrapApplyK3s(kubectl KubectlRunner) error {
 
 	Info("Waiting for kube-system addons to be ready")
 	if err := kubectl.Run([]string{"rollout", "status", "deployment/coredns", "-n", "kube-system", "--timeout=180s"}); err != nil {
-		return err
+		return wrapWithSentinel(ErrDeploymentTimeout, err, fmt.Sprintf("coredns rollout failed: %v", err))
 	}
 	if err := kubectl.Run([]string{"rollout", "status", "deployment/local-path-provisioner", "-n", "kube-system", "--timeout=180s"}); err != nil {
-		return err
+		return wrapWithSentinel(ErrDeploymentTimeout, err, fmt.Sprintf("local-path-provisioner rollout failed: %v", err))
 	}
 
 	// Best-effort: show disk-pressure so users don't get surprised by evictions.

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -15,6 +15,7 @@ type CLIConfig struct {
 	// Timeouts
 	DeploymentTimeout time.Duration
 	CertTimeout       time.Duration
+	HelperPodTimeout  time.Duration
 
 	// Registry settings
 	RegistryPort        int
@@ -39,6 +40,7 @@ type CLIConfig struct {
 const (
 	defaultDeploymentTimeout   = 5 * time.Minute
 	defaultCertTimeout         = 60 * time.Second
+	defaultHelperPodTimeout    = 3 * time.Minute
 	defaultRegistryPort        = 5000
 	defaultRegistryEndpoint    = "registry.local"
 	defaultRegistryIngressHost = "registry.local"
@@ -62,6 +64,7 @@ func LoadCLIConfig() *CLIConfig {
 	return &CLIConfig{
 		DeploymentTimeout:           parseDurationEnv("MCP_DEPLOYMENT_TIMEOUT", defaultDeploymentTimeout),
 		CertTimeout:                 parseDurationEnv("MCP_CERT_TIMEOUT", defaultCertTimeout),
+		HelperPodTimeout:            parseDurationEnv("MCP_HELPER_POD_TIMEOUT", defaultHelperPodTimeout),
 		RegistryPort:                parseIntEnv("MCP_REGISTRY_PORT", defaultRegistryPort),
 		RegistryEndpoint:            registryEndpoint,
 		RegistryIngressHost:         registryIngressHost,
@@ -124,6 +127,11 @@ func GetDeploymentTimeout() time.Duration {
 // GetCertTimeout returns the certificate issuance timeout.
 func GetCertTimeout() time.Duration {
 	return DefaultCLIConfig.CertTimeout
+}
+
+// GetHelperPodTimeout returns the helper pod ready timeout (e.g. registry pusher pod).
+func GetHelperPodTimeout() time.Duration {
+	return DefaultCLIConfig.HelperPodTimeout
 }
 
 // GetRegistryPort returns the registry port.

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -817,12 +817,19 @@ func (m *RegistryManager) PushInCluster(source, target, helperNS string) error {
 	}()
 
 	// #nosec G204 -- command arguments are built from trusted inputs and fixed verbs.
-	if err := m.kubectl.RunWithOutput([]string{"wait", "--for=condition=Ready", "pod/" + helperName, "-n", helperNS, "--timeout=60s"}, os.Stdout, os.Stderr); err != nil {
+	timeout := GetHelperPodTimeout()
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	if err := m.kubectl.RunWithOutput([]string{"wait", "--for=condition=Ready", "pod/" + helperName, "-n", helperNS, "--timeout=" + timeout.String()}, os.Stdout, os.Stderr); err != nil {
+		// Best-effort diagnostics for common real-cluster failures (DiskPressure, taints, quotas, etc).
+		_ = m.kubectl.RunWithOutput([]string{"describe", "pod", helperName, "-n", helperNS}, os.Stderr, os.Stderr)
+		_ = m.kubectl.RunWithOutput([]string{"get", "events", "-n", helperNS, "--field-selector", "involvedObject.name=" + helperName, "--sort-by=.lastTimestamp"}, os.Stderr, os.Stderr)
 		wrappedErr := wrapWithSentinelAndContext(
 			ErrHelperPodNotReady,
 			err,
 			fmt.Sprintf("helper pod not ready: %v", err),
-			map[string]any{"pod": helperName, "namespace": helperNS, "component": "registry"},
+			map[string]any{"pod": helperName, "namespace": helperNS, "timeout": timeout.String(), "component": "registry"},
 		)
 		Error("Helper pod not ready")
 		logStructuredError(m.logger, wrappedErr, "Helper pod not ready")

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -821,14 +821,14 @@ func (m *RegistryManager) PushInCluster(source, target, helperNS string) error {
 	if timeout <= 0 {
 		timeout = 60 * time.Second
 	}
-	if err := m.kubectl.RunWithOutput([]string{"wait", "--for=condition=Ready", "pod/" + helperName, "-n", helperNS, "--timeout=" + timeout.String()}, os.Stdout, os.Stderr); err != nil {
-		// Best-effort diagnostics for common real-cluster failures (DiskPressure, taints, quotas, etc).
-		_ = m.kubectl.RunWithOutput([]string{"describe", "pod", helperName, "-n", helperNS}, os.Stderr, os.Stderr)
-		_ = m.kubectl.RunWithOutput([]string{"get", "events", "-n", helperNS, "--field-selector", "involvedObject.name=" + helperName, "--sort-by=.lastTimestamp"}, os.Stderr, os.Stderr)
-		wrappedErr := wrapWithSentinelAndContext(
-			ErrHelperPodNotReady,
-			err,
-			fmt.Sprintf("helper pod not ready: %v", err),
+		if err := m.kubectl.RunWithOutput([]string{"wait", "--for=condition=Ready", "pod/" + helperName, "-n", helperNS, "--timeout=" + timeout.String()}, os.Stdout, os.Stderr); err != nil {
+			// Best-effort diagnostics for common real-cluster failures (DiskPressure, taints, quotas, etc).
+			_ = m.kubectl.RunWithOutput([]string{"describe", "pod", helperName, "-n", helperNS, "--request-timeout=10s"}, os.Stderr, os.Stderr)
+			_ = m.kubectl.RunWithOutput([]string{"get", "events", "-n", helperNS, "--request-timeout=10s", "--field-selector", "involvedObject.name=" + helperName, "--sort-by=.lastTimestamp"}, os.Stderr, os.Stderr)
+			wrappedErr := wrapWithSentinelAndContext(
+				ErrHelperPodNotReady,
+				err,
+				fmt.Sprintf("helper pod not ready: %v", err),
 			map[string]any{"pod": helperName, "namespace": helperNS, "timeout": timeout.String(), "component": "registry"},
 		)
 		Error("Helper pod not ready")

--- a/internal/cli/registry.go
+++ b/internal/cli/registry.go
@@ -821,14 +821,14 @@ func (m *RegistryManager) PushInCluster(source, target, helperNS string) error {
 	if timeout <= 0 {
 		timeout = 60 * time.Second
 	}
-		if err := m.kubectl.RunWithOutput([]string{"wait", "--for=condition=Ready", "pod/" + helperName, "-n", helperNS, "--timeout=" + timeout.String()}, os.Stdout, os.Stderr); err != nil {
-			// Best-effort diagnostics for common real-cluster failures (DiskPressure, taints, quotas, etc).
-			_ = m.kubectl.RunWithOutput([]string{"describe", "pod", helperName, "-n", helperNS, "--request-timeout=10s"}, os.Stderr, os.Stderr)
-			_ = m.kubectl.RunWithOutput([]string{"get", "events", "-n", helperNS, "--request-timeout=10s", "--field-selector", "involvedObject.name=" + helperName, "--sort-by=.lastTimestamp"}, os.Stderr, os.Stderr)
-			wrappedErr := wrapWithSentinelAndContext(
-				ErrHelperPodNotReady,
-				err,
-				fmt.Sprintf("helper pod not ready: %v", err),
+	if err := m.kubectl.RunWithOutput([]string{"wait", "--for=condition=Ready", "pod/" + helperName, "-n", helperNS, "--timeout=" + timeout.String()}, os.Stdout, os.Stderr); err != nil {
+		// Best-effort diagnostics for common real-cluster failures (DiskPressure, taints, quotas, etc).
+		_ = m.kubectl.RunWithOutput([]string{"describe", "pod", helperName, "-n", helperNS, "--request-timeout=10s"}, os.Stdout, os.Stderr)
+		_ = m.kubectl.RunWithOutput([]string{"get", "events", "-n", helperNS, "--request-timeout=10s", "--field-selector", "involvedObject.name=" + helperName, "--sort-by=.lastTimestamp"}, os.Stdout, os.Stderr)
+		wrappedErr := wrapWithSentinelAndContext(
+			ErrHelperPodNotReady,
+			err,
+			fmt.Sprintf("helper pod not ready: %v", err),
 			map[string]any{"pod": helperName, "namespace": helperNS, "timeout": timeout.String(), "component": "registry"},
 		)
 		Error("Helper pod not ready")

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -243,6 +243,10 @@ func NewSetupCmd(logger *zap.Logger) *cobra.Command {
 The platform deploys an internal Docker registry by default, which teams
 will use to push and pull container images.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateStorageMode(storageMode); err != nil {
+				return err
+			}
+
 			// Build operator args from flags
 			operatorArgs := buildOperatorArgs(
 				operatorMetricsAddr,
@@ -272,7 +276,7 @@ will use to push and pull container images.`,
 
 	cmd.Flags().StringVar(&registryType, "registry-type", "docker", "Registry type (docker; harbor coming soon)")
 	cmd.Flags().StringVar(&registryStorageSize, "registry-storage", "20Gi", "Registry storage size (default: 20Gi)")
-	cmd.Flags().StringVar(&storageMode, "storage-mode", "dynamic", "Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube without a provisioner.")
+	cmd.Flags().StringVar(&storageMode, "storage-mode", "dynamic", "Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube/kind without a provisioner.")
 	cmd.Flags().StringVar(&ingressMode, "ingress", "traefik", "Ingress controller to install automatically during setup (traefik|none)")
 	cmd.Flags().StringVar(&ingressManifest, "ingress-manifest", "config/ingress/overlays/http", "Manifest to apply when installing the ingress controller")
 	cmd.Flags().BoolVar(&forceIngressInstall, "force-ingress-install", false, "Force ingress install even if an ingress class already exists")
@@ -305,6 +309,15 @@ func buildOperatorArgs(metricsAddr, probeAddr string, leaderElect, leaderElectCh
 	}
 
 	return args
+}
+
+func validateStorageMode(mode string) error {
+	switch mode {
+	case StorageModeDynamic, StorageModeHostpath:
+		return nil
+	default:
+		return wrapWithSentinel(ErrFieldRequired, fmt.Errorf("invalid storage mode %q", mode), "invalid --storage-mode; expected dynamic or hostpath")
+	}
 }
 
 func setupPlatform(logger *zap.Logger, plan SetupPlan) error {
@@ -1497,7 +1510,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logg
 
 	clickhouseManifest := "k8s/03-clickhouse.yaml"
 	kafkaManifest := "k8s/05-kafka.yaml"
-	if storageMode == "hostpath" {
+	if storageMode == StorageModeHostpath {
 		clickhouseManifest = "k8s/03-clickhouse-hostpath.yaml"
 		kafkaManifest = "k8s/05-kafka-hostpath.yaml"
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -118,7 +118,7 @@ type SetupDeps struct {
 	PushGatewayProxyImageToInternal func(logger *zap.Logger, sourceImage, targetImage, helperNamespace string) error
 	PushAnalyticsImageToInternal    func(logger *zap.Logger, sourceImage, targetImage, helperNamespace string) error
 	DeployOperatorManifests         func(logger *zap.Logger, operatorImage, gatewayProxyImage string, operatorArgs []string) error
-	DeployAnalyticsManifests        func(logger *zap.Logger, images AnalyticsImageSet) error
+	DeployAnalyticsManifests        func(logger *zap.Logger, images AnalyticsImageSet, storageMode string) error
 	ConfigureProvisionedRegistryEnv func(ext *ExternalRegistryConfig, secretName string) error
 	RestartDeployment               func(name, namespace string) error
 	CheckCRDInstalled               func(name string) error
@@ -220,6 +220,7 @@ func (d SetupDeps) withDefaults(logger *zap.Logger) SetupDeps {
 func NewSetupCmd(logger *zap.Logger) *cobra.Command {
 	var registryType string
 	var registryStorageSize string
+	var storageMode string
 	var ingressMode string
 	var ingressManifest string
 	var forceIngressInstall bool
@@ -253,6 +254,7 @@ will use to push and pull container images.`,
 			plan := BuildSetupPlan(SetupPlanInput{
 				RegistryType:           registryType,
 				RegistryStorageSize:    registryStorageSize,
+				StorageMode:            storageMode,
 				IngressMode:            ingressMode,
 				IngressManifest:        ingressManifest,
 				IngressManifestChanged: cmd.Flags().Changed("ingress-manifest"),
@@ -270,6 +272,7 @@ will use to push and pull container images.`,
 
 	cmd.Flags().StringVar(&registryType, "registry-type", "docker", "Registry type (docker; harbor coming soon)")
 	cmd.Flags().StringVar(&registryStorageSize, "registry-storage", "20Gi", "Registry storage size (default: 20Gi)")
+	cmd.Flags().StringVar(&storageMode, "storage-mode", "dynamic", "Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube without a provisioner.")
 	cmd.Flags().StringVar(&ingressMode, "ingress", "traefik", "Ingress controller to install automatically during setup (traefik|none)")
 	cmd.Flags().StringVar(&ingressManifest, "ingress-manifest", "config/ingress/overlays/http", "Manifest to apply when installing the ingress controller")
 	cmd.Flags().BoolVar(&forceIngressInstall, "force-ingress-install", false, "Force ingress install even if an ingress class already exists")
@@ -802,9 +805,9 @@ func prepareAnalyticsImages(logger *zap.Logger, extRegistry *ExternalRegistryCon
 	return images, nil
 }
 
-func deployAnalyticsStepCmd(logger *zap.Logger, images AnalyticsImageSet, deps SetupDeps) error {
+func deployAnalyticsStepCmd(logger *zap.Logger, images AnalyticsImageSet, storageMode string, deps SetupDeps) error {
 	Info("Deploying mcp-sentinel manifests")
-	if err := deps.DeployAnalyticsManifests(logger, images); err != nil {
+	if err := deps.DeployAnalyticsManifests(logger, images, storageMode); err != nil {
 		wrappedErr := wrapWithSentinelAndContext(
 			ErrOperatorDeploymentFailed,
 			err,
@@ -1462,11 +1465,11 @@ func deployOperatorManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logge
 	return nil
 }
 
-func deployAnalyticsManifests(logger *zap.Logger, images AnalyticsImageSet) error {
-	return deployAnalyticsManifestsWithKubectl(kubectlClient, logger, images)
+func deployAnalyticsManifests(logger *zap.Logger, images AnalyticsImageSet, storageMode string) error {
+	return deployAnalyticsManifestsWithKubectl(kubectlClient, logger, images, storageMode)
 }
 
-func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logger, images AnalyticsImageSet) error {
+func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logger, images AnalyticsImageSet, storageMode string) error {
 	Info("Applying mcp-sentinel namespace and config")
 	manifests := []string{
 		"k8s/00-namespace.yaml",
@@ -1492,10 +1495,17 @@ func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logg
 		return err
 	}
 
+	clickhouseManifest := "k8s/03-clickhouse.yaml"
+	kafkaManifest := "k8s/05-kafka.yaml"
+	if storageMode == "hostpath" {
+		clickhouseManifest = "k8s/03-clickhouse-hostpath.yaml"
+		kafkaManifest = "k8s/05-kafka-hostpath.yaml"
+	}
+
 	Info("Applying analytics storage and messaging components")
 	for _, manifest := range []string{
-		"k8s/03-clickhouse.yaml",
-		"k8s/05-kafka.yaml",
+		clickhouseManifest,
+		kafkaManifest,
 	} {
 		if err := applyRenderedManifest(kubectl, manifest, images, imagePullSecretName); err != nil {
 			return err

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -221,6 +221,8 @@ func NewSetupCmd(logger *zap.Logger) *cobra.Command {
 	var registryType string
 	var registryStorageSize string
 	var storageMode string
+	var kubeconfig string
+	var kubeContext string
 	var ingressMode string
 	var ingressManifest string
 	var forceIngressInstall bool
@@ -256,6 +258,8 @@ will use to push and pull container images.`,
 			)
 
 			plan := BuildSetupPlan(SetupPlanInput{
+				Kubeconfig:             kubeconfig,
+				Context:                kubeContext,
 				RegistryType:           registryType,
 				RegistryStorageSize:    registryStorageSize,
 				StorageMode:            storageMode,
@@ -277,6 +281,8 @@ will use to push and pull container images.`,
 	cmd.Flags().StringVar(&registryType, "registry-type", "docker", "Registry type (docker; harbor coming soon)")
 	cmd.Flags().StringVar(&registryStorageSize, "registry-storage", "20Gi", "Registry storage size (default: 20Gi)")
 	cmd.Flags().StringVar(&storageMode, "storage-mode", "dynamic", "Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube/kind without a provisioner.")
+	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig file (default: ~/.kube/config)")
+	cmd.Flags().StringVar(&kubeContext, "context", "", "Kubernetes context to use")
 	cmd.Flags().StringVar(&ingressMode, "ingress", "traefik", "Ingress controller to install automatically during setup (traefik|none)")
 	cmd.Flags().StringVar(&ingressManifest, "ingress-manifest", "config/ingress/overlays/http", "Manifest to apply when installing the ingress controller")
 	cmd.Flags().BoolVar(&forceIngressInstall, "force-ingress-install", false, "Force ingress install even if an ingress class already exists")
@@ -472,11 +478,11 @@ func setupImageTag() string {
 	return setupImageTagResolver()
 }
 
-func setupClusterSteps(logger *zap.Logger, ingressOpts ingressOptions, deps SetupDeps) error {
+func setupClusterSteps(logger *zap.Logger, kubeconfig, context string, ingressOpts ingressOptions, deps SetupDeps) error {
 	// Step 1: Initialize cluster
 	Step("Step 1: Initialize cluster")
 	Info("Installing CRD")
-	if err := deps.ClusterManager.InitCluster("", ""); err != nil {
+	if err := deps.ClusterManager.InitCluster(kubeconfig, context); err != nil {
 		wrappedErr := wrapWithSentinel(ErrClusterInitFailed, err, fmt.Sprintf("failed to initialize cluster: %v", err))
 		Error("Cluster initialization failed")
 		logStructuredError(logger, wrappedErr, "Cluster initialization failed")

--- a/internal/cli/setup_helpers_test.go
+++ b/internal/cli/setup_helpers_test.go
@@ -806,7 +806,7 @@ func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 		API:       "example.com/mcp-sentinel-api:latest",
 		Processor: "example.com/mcp-sentinel-processor:latest",
 		UI:        "example.com/mcp-sentinel-ui:latest",
-	})
+	}, "dynamic")
 	if err == nil {
 		t.Fatal("expected rollout failure")
 	}

--- a/internal/cli/setup_helpers_test.go
+++ b/internal/cli/setup_helpers_test.go
@@ -759,8 +759,10 @@ func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 		"00-namespace.yaml",
 		"01-config.yaml",
 		"03-clickhouse.yaml",
+		"03-clickhouse-hostpath.yaml",
 		"04-clickhouse-init.yaml",
 		"05-kafka.yaml",
+		"05-kafka-hostpath.yaml",
 		"06-ingest.yaml",
 		"07-processor.yaml",
 		"08-api.yaml",
@@ -786,10 +788,17 @@ func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 		_ = os.Chdir(cwd)
 	})
 
+	var applied []string
 	mock := &MockExecutor{
 		CommandFunc: func(spec ExecSpec) *MockCommand {
 			cmd := &MockCommand{Args: spec.Args}
 			switch {
+			case contains(spec.Args, "apply") && contains(spec.Args, "-f"):
+				for i := 0; i+1 < len(spec.Args); i++ {
+					if spec.Args[i] == "-f" {
+						applied = append(applied, spec.Args[i+1])
+					}
+				}
 			case contains(spec.Args, "get") && contains(spec.Args, "secret"):
 				cmd.OutputData = []byte("Error from server (NotFound): secrets \"mcp-sentinel-secrets\" not found")
 				cmd.OutputErr = errors.New("not found")
@@ -806,12 +815,78 @@ func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 		API:       "example.com/mcp-sentinel-api:latest",
 		Processor: "example.com/mcp-sentinel-processor:latest",
 		UI:        "example.com/mcp-sentinel-ui:latest",
-	}, "dynamic")
+	}, "")
 	if err == nil {
 		t.Fatal("expected rollout failure")
 	}
 	if !strings.Contains(err.Error(), "deployment/mcp-sentinel-api") {
 		t.Fatalf("expected failing workload in error, got %v", err)
+	}
+}
+
+func TestDeployAnalyticsManifestsWithKubectl_HostpathUsesHostpathManifests(t *testing.T) {
+	orig := DefaultCLIConfig
+	t.Cleanup(func() { DefaultCLIConfig = orig })
+	DefaultCLIConfig = &CLIConfig{}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	manifestDir := filepath.Join(root, "k8s")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatalf("failed to create manifest dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "services"), 0o755); err != nil {
+		t.Fatalf("failed to create services dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	manifestContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: fixture\n  namespace: mcp-sentinel\n"
+	for _, name := range []string{
+		"00-namespace.yaml",
+		"01-config.yaml",
+		"03-clickhouse-hostpath.yaml",
+		"04-clickhouse-init.yaml",
+		"05-kafka-hostpath.yaml",
+	} {
+		if err := os.WriteFile(filepath.Join(manifestDir, name), []byte(manifestContent), 0o644); err != nil {
+			t.Fatalf("failed to write fixture manifest %s: %v", name, err)
+		}
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to fixture root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	mock := &MockExecutor{
+		CommandFunc: func(spec ExecSpec) *MockCommand {
+			cmd := &MockCommand{Args: spec.Args}
+			if contains(spec.Args, "get") && contains(spec.Args, "secret") {
+				cmd.OutputData = []byte("Error from server (NotFound): secrets \"mcp-sentinel-secrets\" not found")
+				cmd.OutputErr = errors.New("not found")
+			}
+			if contains(spec.Args, "rollout") && contains(spec.Args, "statefulset") && contains(spec.Args, "clickhouse") {
+				cmd.RunErr = errors.New("rollout timeout")
+			}
+			return cmd
+		},
+	}
+	kubectl := &KubectlClient{exec: mock, validators: nil}
+
+	err = deployAnalyticsManifestsWithKubectl(kubectl, zap.NewNop(), AnalyticsImageSet{
+		Ingest:    "example.com/mcp-sentinel-ingest:latest",
+		API:       "example.com/mcp-sentinel-api:latest",
+		Processor: "example.com/mcp-sentinel-processor:latest",
+		UI:        "example.com/mcp-sentinel-ui:latest",
+	}, StorageModeHostpath)
+	if err == nil {
+		t.Fatal("expected failure from rollout timeout")
+	}
+	if strings.Contains(err.Error(), "03-clickhouse.yaml") || strings.Contains(err.Error(), "05-kafka.yaml") {
+		t.Fatalf("expected hostpath manifests to be used (default manifests are not present), got err=%v", err)
 	}
 }
 

--- a/internal/cli/setup_plan.go
+++ b/internal/cli/setup_plan.go
@@ -8,6 +8,7 @@ package cli
 type SetupPlanInput struct {
 	RegistryType           string
 	RegistryStorageSize    string
+	StorageMode            string
 	IngressMode            string
 	IngressManifest        string
 	IngressManifestChanged bool
@@ -23,6 +24,7 @@ type SetupPlanInput struct {
 type SetupPlan struct {
 	RegistryType        string
 	RegistryStorageSize string
+	StorageMode         string
 	Ingress             ingressOptions
 	RegistryManifest    string
 	TLSEnabled          bool
@@ -44,13 +46,20 @@ func BuildSetupPlan(input SetupPlanInput) SetupPlan {
 	}
 
 	registryManifest := "config/registry"
-	if input.TLSEnabled {
+	if input.StorageMode == "hostpath" {
+		if input.TLSEnabled {
+			registryManifest = "config/registry/overlays/hostpath-tls"
+		} else {
+			registryManifest = "config/registry/overlays/hostpath"
+		}
+	} else if input.TLSEnabled {
 		registryManifest = "config/registry/overlays/tls"
 	}
 
 	return SetupPlan{
 		RegistryType:        input.RegistryType,
 		RegistryStorageSize: input.RegistryStorageSize,
+		StorageMode:         input.StorageMode,
 		Ingress: ingressOptions{
 			mode:     input.IngressMode,
 			manifest: manifestPath,

--- a/internal/cli/setup_plan.go
+++ b/internal/cli/setup_plan.go
@@ -4,6 +4,11 @@ package cli
 // SetupPlanInput captures raw CLI inputs, and BuildSetupPlan resolves them into a concrete SetupPlan
 // that determines which manifests and configurations to use during setup.
 
+const (
+	StorageModeDynamic  = "dynamic"
+	StorageModeHostpath = "hostpath"
+)
+
 // SetupPlanInput captures the raw CLI inputs for setup.
 type SetupPlanInput struct {
 	RegistryType           string
@@ -36,6 +41,10 @@ type SetupPlan struct {
 
 // BuildSetupPlan resolves CLI inputs into a concrete setup plan.
 func BuildSetupPlan(input SetupPlanInput) SetupPlan {
+	if input.StorageMode == "" {
+		input.StorageMode = StorageModeDynamic
+	}
+
 	manifestPath := input.IngressManifest
 	if !input.IngressManifestChanged {
 		if input.TLSEnabled {
@@ -46,7 +55,7 @@ func BuildSetupPlan(input SetupPlanInput) SetupPlan {
 	}
 
 	registryManifest := "config/registry"
-	if input.StorageMode == "hostpath" {
+	if input.StorageMode == StorageModeHostpath {
 		if input.TLSEnabled {
 			registryManifest = "config/registry/overlays/hostpath-tls"
 		} else {

--- a/internal/cli/setup_plan.go
+++ b/internal/cli/setup_plan.go
@@ -11,6 +11,8 @@ const (
 
 // SetupPlanInput captures the raw CLI inputs for setup.
 type SetupPlanInput struct {
+	Kubeconfig             string
+	Context                string
 	RegistryType           string
 	RegistryStorageSize    string
 	StorageMode            string
@@ -27,6 +29,8 @@ type SetupPlanInput struct {
 
 // SetupPlan captures the resolved setup decisions.
 type SetupPlan struct {
+	Kubeconfig          string
+	Context             string
 	RegistryType        string
 	RegistryStorageSize string
 	StorageMode         string
@@ -66,6 +70,8 @@ func BuildSetupPlan(input SetupPlanInput) SetupPlan {
 	}
 
 	return SetupPlan{
+		Kubeconfig:          input.Kubeconfig,
+		Context:             input.Context,
 		RegistryType:        input.RegistryType,
 		RegistryStorageSize: input.RegistryStorageSize,
 		StorageMode:         input.StorageMode,

--- a/internal/cli/setup_plan_test.go
+++ b/internal/cli/setup_plan_test.go
@@ -105,7 +105,7 @@ func TestBuildSetupPlan_HostpathRegistryManifest(t *testing.T) {
 	plan := BuildSetupPlan(SetupPlanInput{
 		RegistryType:           "docker",
 		RegistryStorageSize:    "20Gi",
-		StorageMode:            "hostpath",
+		StorageMode:            StorageModeHostpath,
 		IngressMode:            "traefik",
 		IngressManifest:        "config/ingress/overlays/http",
 		IngressManifestChanged: false,
@@ -115,6 +115,23 @@ func TestBuildSetupPlan_HostpathRegistryManifest(t *testing.T) {
 
 	if plan.RegistryManifest != "config/registry/overlays/hostpath" {
 		t.Fatalf("expected hostpath registry manifest, got %q", plan.RegistryManifest)
+	}
+}
+
+func TestBuildSetupPlan_HostpathRegistryManifest_TLS(t *testing.T) {
+	plan := BuildSetupPlan(SetupPlanInput{
+		RegistryType:           "docker",
+		RegistryStorageSize:    "20Gi",
+		StorageMode:            StorageModeHostpath,
+		IngressMode:            "traefik",
+		IngressManifest:        "config/ingress/overlays/http",
+		IngressManifestChanged: false,
+		ForceIngressInstall:    false,
+		TLSEnabled:             true,
+	})
+
+	if plan.RegistryManifest != "config/registry/overlays/hostpath-tls" {
+		t.Fatalf("expected hostpath tls registry manifest, got %q", plan.RegistryManifest)
 	}
 }
 

--- a/internal/cli/setup_plan_test.go
+++ b/internal/cli/setup_plan_test.go
@@ -13,6 +13,7 @@ func TestBuildSetupPlan_DefaultHTTP(t *testing.T) {
 	plan := BuildSetupPlan(SetupPlanInput{
 		RegistryType:           "docker",
 		RegistryStorageSize:    "20Gi",
+		StorageMode:            "dynamic",
 		IngressMode:            "traefik",
 		IngressManifest:        "config/ingress/overlays/http",
 		IngressManifestChanged: false,
@@ -32,6 +33,7 @@ func TestBuildSetupPlan_DefaultTLS(t *testing.T) {
 	plan := BuildSetupPlan(SetupPlanInput{
 		RegistryType:           "docker",
 		RegistryStorageSize:    "20Gi",
+		StorageMode:            "dynamic",
 		IngressMode:            "traefik",
 		IngressManifest:        "config/ingress/overlays/http",
 		IngressManifestChanged: false,
@@ -51,6 +53,7 @@ func TestBuildSetupPlan_CustomIngressManifest(t *testing.T) {
 	plan := BuildSetupPlan(SetupPlanInput{
 		RegistryType:           "docker",
 		RegistryStorageSize:    "20Gi",
+		StorageMode:            "dynamic",
 		IngressMode:            "traefik",
 		IngressManifest:        "custom/manifest",
 		IngressManifestChanged: true,
@@ -71,6 +74,7 @@ func TestBuildSetupPlan_PreservesTestModeAndOperatorArgs(t *testing.T) {
 	plan := BuildSetupPlan(SetupPlanInput{
 		RegistryType:           "docker",
 		RegistryStorageSize:    "20Gi",
+		StorageMode:            "dynamic",
 		IngressMode:            "traefik",
 		IngressManifest:        "config/ingress/overlays/http",
 		IngressManifestChanged: false,
@@ -94,6 +98,23 @@ func TestBuildSetupPlan_PreservesTestModeAndOperatorArgs(t *testing.T) {
 		if plan.OperatorArgs[i] != operatorArgs[i] {
 			t.Fatalf("expected operator arg %d to be %q, got %q", i, operatorArgs[i], plan.OperatorArgs[i])
 		}
+	}
+}
+
+func TestBuildSetupPlan_HostpathRegistryManifest(t *testing.T) {
+	plan := BuildSetupPlan(SetupPlanInput{
+		RegistryType:           "docker",
+		RegistryStorageSize:    "20Gi",
+		StorageMode:            "hostpath",
+		IngressMode:            "traefik",
+		IngressManifest:        "config/ingress/overlays/http",
+		IngressManifestChanged: false,
+		ForceIngressInstall:    false,
+		TLSEnabled:             false,
+	})
+
+	if plan.RegistryManifest != "config/registry/overlays/hostpath" {
+		t.Fatalf("expected hostpath registry manifest, got %q", plan.RegistryManifest)
 	}
 }
 

--- a/internal/cli/setup_plan_test.go
+++ b/internal/cli/setup_plan_test.go
@@ -11,6 +11,8 @@ import (
 
 func TestBuildSetupPlan_DefaultHTTP(t *testing.T) {
 	plan := BuildSetupPlan(SetupPlanInput{
+		Kubeconfig:             "/tmp/kubeconfig",
+		Context:                "my-context",
 		RegistryType:           "docker",
 		RegistryStorageSize:    "20Gi",
 		StorageMode:            "dynamic",
@@ -23,6 +25,12 @@ func TestBuildSetupPlan_DefaultHTTP(t *testing.T) {
 
 	if plan.Ingress.manifest != "config/ingress/overlays/http" {
 		t.Fatalf("expected http ingress manifest, got %q", plan.Ingress.manifest)
+	}
+	if plan.Kubeconfig != "/tmp/kubeconfig" {
+		t.Fatalf("expected kubeconfig to be preserved, got %q", plan.Kubeconfig)
+	}
+	if plan.Context != "my-context" {
+		t.Fatalf("expected context to be preserved, got %q", plan.Context)
 	}
 	if plan.RegistryManifest != "config/registry" {
 		t.Fatalf("expected default registry manifest, got %q", plan.RegistryManifest)

--- a/internal/cli/setup_steps.go
+++ b/internal/cli/setup_steps.go
@@ -138,7 +138,7 @@ type deployAnalyticsStep struct{}
 
 func (s deployAnalyticsStep) Name() string { return "analytics-deploy" }
 func (s deployAnalyticsStep) Run(logger *zap.Logger, deps SetupDeps, ctx *SetupContext) error {
-	return deployAnalyticsStepCmd(logger, ctx.AnalyticsImages, deps)
+	return deployAnalyticsStepCmd(logger, ctx.AnalyticsImages, ctx.Plan.StorageMode, deps)
 }
 
 type verifyStep struct{}

--- a/internal/cli/setup_steps.go
+++ b/internal/cli/setup_steps.go
@@ -55,7 +55,7 @@ type clusterStep struct{}
 
 func (s clusterStep) Name() string { return "cluster" }
 func (s clusterStep) Run(logger *zap.Logger, deps SetupDeps, ctx *SetupContext) error {
-	return setupClusterSteps(logger, ctx.Plan.Ingress, deps)
+	return setupClusterSteps(logger, ctx.Plan.Kubeconfig, ctx.Plan.Context, ctx.Plan.Ingress, deps)
 }
 
 type tlsStep struct{}

--- a/internal/cli/setup_steps_test.go
+++ b/internal/cli/setup_steps_test.go
@@ -21,6 +21,19 @@ func (f *fakeRegistryManagerForSteps) PushInCluster(_, _, _ string) error {
 	return nil
 }
 
+type fakeClusterManagerForKubeconfig struct {
+	init func(kubeconfig, context string) error
+}
+
+func (f *fakeClusterManagerForKubeconfig) InitCluster(kubeconfig, context string) error {
+	if f.init != nil {
+		return f.init(kubeconfig, context)
+	}
+	return nil
+}
+
+func (f *fakeClusterManagerForKubeconfig) ConfigureCluster(ingressOptions) error { return nil }
+
 func TestBuildSetupStepsOrderWithTLS(t *testing.T) {
 	ctx := &SetupContext{
 		Plan: SetupPlan{
@@ -227,6 +240,8 @@ func TestNewSetupCmdIncludesFeatureFlags(t *testing.T) {
 	cmd := NewSetupCmd(zap.NewNop())
 
 	for _, name := range []string{
+		"kubeconfig",
+		"context",
 		"test-mode",
 		"strict-prod",
 		"operator-metrics-addr",
@@ -236,6 +251,43 @@ func TestNewSetupCmdIncludesFeatureFlags(t *testing.T) {
 		if flag := cmd.Flags().Lookup(name); flag == nil {
 			t.Fatalf("expected %q flag to exist", name)
 		}
+	}
+}
+
+func TestClusterStepPassesKubeconfigAndContext(t *testing.T) {
+	var gotKubeconfig string
+	var gotContext string
+
+	deps := SetupDeps{
+		ClusterManager: &fakeClusterManagerForKubeconfig{
+			init: func(kubeconfig, context string) error {
+				gotKubeconfig = kubeconfig
+				gotContext = context
+				return nil
+			},
+		},
+	}
+
+	ctx := &SetupContext{
+		Plan: SetupPlan{
+			Kubeconfig: "/etc/rancher/k3s/k3s.yaml",
+			Context:    "k3s",
+			Ingress: ingressOptions{
+				mode:     "traefik",
+				manifest: "config/ingress/overlays/http",
+			},
+		},
+	}
+
+	step := clusterStep{}
+	if err := step.Run(zap.NewNop(), deps, ctx); err != nil {
+		t.Fatalf("cluster step failed: %v", err)
+	}
+	if gotKubeconfig != ctx.Plan.Kubeconfig {
+		t.Fatalf("expected kubeconfig %q, got %q", ctx.Plan.Kubeconfig, gotKubeconfig)
+	}
+	if gotContext != ctx.Plan.Context {
+		t.Fatalf("expected context %q, got %q", ctx.Plan.Context, gotContext)
 	}
 }
 

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -10,6 +10,7 @@ func TestLoadCLIConfig(t *testing.T) {
 	// Save original env vars
 	origDeployTimeout := os.Getenv("MCP_DEPLOYMENT_TIMEOUT")
 	origCertTimeout := os.Getenv("MCP_CERT_TIMEOUT")
+	origHelperTimeout := os.Getenv("MCP_HELPER_POD_TIMEOUT")
 	origRegistryPort := os.Getenv("MCP_REGISTRY_PORT")
 	origSkopeoImage := os.Getenv("MCP_SKOPEO_IMAGE")
 	origOperatorImage := os.Getenv("MCP_OPERATOR_IMAGE")
@@ -19,6 +20,7 @@ func TestLoadCLIConfig(t *testing.T) {
 	defer func() {
 		os.Setenv("MCP_DEPLOYMENT_TIMEOUT", origDeployTimeout)
 		os.Setenv("MCP_CERT_TIMEOUT", origCertTimeout)
+		os.Setenv("MCP_HELPER_POD_TIMEOUT", origHelperTimeout)
 		os.Setenv("MCP_REGISTRY_PORT", origRegistryPort)
 		os.Setenv("MCP_SKOPEO_IMAGE", origSkopeoImage)
 		os.Setenv("MCP_OPERATOR_IMAGE", origOperatorImage)
@@ -28,6 +30,7 @@ func TestLoadCLIConfig(t *testing.T) {
 	t.Run("uses defaults when env vars not set", func(t *testing.T) {
 		os.Unsetenv("MCP_DEPLOYMENT_TIMEOUT")
 		os.Unsetenv("MCP_CERT_TIMEOUT")
+		os.Unsetenv("MCP_HELPER_POD_TIMEOUT")
 		os.Unsetenv("MCP_REGISTRY_PORT")
 		os.Unsetenv("MCP_SKOPEO_IMAGE")
 		os.Unsetenv("MCP_OPERATOR_IMAGE")
@@ -41,6 +44,7 @@ func TestLoadCLIConfig(t *testing.T) {
 		assertCLIConfig(t, *cfg, cliConfigExpectation{
 			deploymentTimeout: defaultDeploymentTimeout,
 			certTimeout:       defaultCertTimeout,
+			helperPodTimeout:  defaultHelperPodTimeout,
 			registryPort:      defaultRegistryPort,
 			skopeoImage:       defaultSkopeoImage,
 			operatorImage:     "",
@@ -51,6 +55,7 @@ func TestLoadCLIConfig(t *testing.T) {
 	t.Run("reads env vars when set", func(t *testing.T) {
 		os.Setenv("MCP_DEPLOYMENT_TIMEOUT", "10m")
 		os.Setenv("MCP_CERT_TIMEOUT", "2m")
+		os.Setenv("MCP_HELPER_POD_TIMEOUT", "4m")
 		os.Setenv("MCP_REGISTRY_PORT", "5001")
 		os.Setenv("MCP_SKOPEO_IMAGE", "custom/skopeo:v2")
 		os.Setenv("MCP_OPERATOR_IMAGE", "custom/operator:v1")
@@ -64,6 +69,7 @@ func TestLoadCLIConfig(t *testing.T) {
 		assertCLIConfig(t, *cfg, cliConfigExpectation{
 			deploymentTimeout: 10 * time.Minute,
 			certTimeout:       2 * time.Minute,
+			helperPodTimeout:  4 * time.Minute,
 			registryPort:      5001,
 			skopeoImage:       "custom/skopeo:v2",
 			operatorImage:     "custom/operator:v1",
@@ -74,6 +80,7 @@ func TestLoadCLIConfig(t *testing.T) {
 	t.Run("handles invalid values gracefully", func(t *testing.T) {
 		os.Setenv("MCP_DEPLOYMENT_TIMEOUT", "invalid")
 		os.Setenv("MCP_CERT_TIMEOUT", "invalid")
+		os.Setenv("MCP_HELPER_POD_TIMEOUT", "invalid")
 		os.Setenv("MCP_REGISTRY_PORT", "not-a-number")
 		os.Setenv("MCP_DEFAULT_SERVER_PORT", "-1")
 		os.Setenv("MCP_SKOPEO_IMAGE", "")
@@ -87,6 +94,7 @@ func TestLoadCLIConfig(t *testing.T) {
 		assertCLIConfig(t, *cfg, cliConfigExpectation{
 			deploymentTimeout: defaultDeploymentTimeout,
 			certTimeout:       defaultCertTimeout,
+			helperPodTimeout:  defaultHelperPodTimeout,
 			registryPort:      defaultRegistryPort,
 			skopeoImage:       defaultSkopeoImage,
 			operatorImage:     "",
@@ -126,6 +134,7 @@ func TestProvisionedRegistryConfig(t *testing.T) {
 type cliConfigExpectation struct {
 	deploymentTimeout time.Duration
 	certTimeout       time.Duration
+	helperPodTimeout  time.Duration
 	registryPort      int
 	skopeoImage       string
 	operatorImage     string
@@ -139,6 +148,9 @@ func assertCLIConfig(t *testing.T, cfg CLIConfig, want cliConfigExpectation) {
 	}
 	if cfg.CertTimeout != want.certTimeout {
 		t.Errorf("CertTimeout = %v, want %v", cfg.CertTimeout, want.certTimeout)
+	}
+	if cfg.HelperPodTimeout != want.helperPodTimeout {
+		t.Errorf("HelperPodTimeout = %v, want %v", cfg.HelperPodTimeout, want.helperPodTimeout)
 	}
 	if cfg.RegistryPort != want.registryPort {
 		t.Errorf("RegistryPort = %v, want %v", cfg.RegistryPort, want.registryPort)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -170,14 +170,16 @@ func clusterSetupHint(detail string) (string, bool) {
 
 	switch {
 	case strings.Contains(lower, "executable file not found"),
-		strings.Contains(lower, "no such file or directory"):
-		return "Cluster not set up yet: kubectl is not installed. Install kubectl and run './bin/mcp-runtime setup --test-mode --ingress-manifest config/ingress/overlays/http'", true
+		strings.Contains(lower, "kubectl: not found"):
+		return "kubectl is missing. Install kubectl and re-run the command.", true
+	case strings.Contains(lower, "kubeconfig"),
+		strings.Contains(lower, "no configuration has been provided"):
+		return "kubeconfig is missing or not readable. Either copy your cluster kubeconfig to ~/.kube/config, or re-run with `./bin/mcp-runtime setup --kubeconfig /etc/rancher/k3s/k3s.yaml` (for k3s) and optionally `--context <name>`.", true
 	case strings.Contains(lower, "connection refused"),
 		strings.Contains(lower, "unable to connect to the server"),
-		strings.Contains(lower, "no configuration has been provided"),
 		strings.Contains(lower, "context deadline exceeded"),
 		strings.Contains(lower, "the connection to the server"):
-		return "Cluster not set up yet: no Kubernetes API reachable. Run './bin/mcp-runtime setup --test-mode --ingress-manifest config/ingress/overlays/http' to create the local Kind cluster", true
+		return "no Kubernetes API reachable. Verify your kubeconfig/context (or pass `--kubeconfig`/`--context` to setup) and ensure the cluster control plane is reachable.", true
 	default:
 		return "", false
 	}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -134,11 +134,12 @@ func TestShowPlatformStatus(t *testing.T) {
 		}
 
 		output := runShowPlatformStatus(t, responses)
-		if !strings.Contains(strings.ToLower(output), "not set up yet") {
-			t.Fatalf("expected setup hint when cluster missing, got output: %s", output)
+		lower := strings.ToLower(output)
+		if !strings.Contains(lower, "kubectl is missing") {
+			t.Fatalf("expected kubectl missing hint when cluster missing, got output: %s", output)
 		}
-		if !strings.Contains(output, "setup") {
-			t.Fatalf("expected setup guidance in output, got: %s", output)
+		if !strings.Contains(lower, "install kubectl") {
+			t.Fatalf("expected install guidance in output, got: %s", output)
 		}
 	})
 

--- a/k8s/03-clickhouse-hostpath.yaml
+++ b/k8s/03-clickhouse-hostpath.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: clickhouse-pv
+  labels:
+    app: clickhouse
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: local-path
+  persistentVolumeReclaimPolicy: Delete
+  claimRef:
+    namespace: mcp-sentinel
+    name: data-clickhouse-0
+  hostPath:
+    path: /var/lib/mcp-runtime/clickhouse
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: mcp-sentinel
+spec:
+  selector:
+    app: clickhouse
+  ports:
+    - name: native
+      port: 9000
+      targetPort: 9000
+    - name: http
+      port: 8123
+      targetPort: 8123
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+  namespace: mcp-sentinel
+spec:
+  serviceName: clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      initContainers:
+        - name: init-perms
+          image: alpine:3.23
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "chown -R 101:101 /var/lib/clickhouse"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:23.8
+          ports:
+            - containerPort: 9000
+            - containerPort: 8123
+          env:
+            - name: CLICKHOUSE_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: mcp-sentinel-config
+                  key: CLICKHOUSE_DB
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/03-clickhouse-hostpath.yaml
+++ b/k8s/03-clickhouse-hostpath.yaml
@@ -11,13 +11,20 @@ spec:
     - ReadWriteOnce
   volumeMode: Filesystem
   storageClassName: local-path
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: Retain
   claimRef:
     namespace: mcp-sentinel
     name: data-clickhouse-0
-  hostPath:
+  local:
     path: /var/lib/mcp-runtime/clickhouse
-    type: DirectoryOrCreate
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: mcp-runtime.org/local-storage
+              operator: In
+              values:
+                - "true"
 ---
 apiVersion: v1
 kind: Service
@@ -67,15 +74,38 @@ spec:
       containers:
         - name: clickhouse
           image: clickhouse/clickhouse-server:23.8
+          securityContext:
+            runAsUser: 101
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: 9000
             - containerPort: 8123
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 10
           env:
             - name: CLICKHOUSE_DB
               valueFrom:
                 configMapKeyRef:
                   name: mcp-sentinel-config
                   key: CLICKHOUSE_DB
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
           volumeMounts:
             - name: data
               mountPath: /var/lib/clickhouse
@@ -83,6 +113,7 @@ spec:
     - metadata:
         name: data
       spec:
+        storageClassName: local-path
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/k8s/05-kafka-hostpath.yaml
+++ b/k8s/05-kafka-hostpath.yaml
@@ -129,6 +129,8 @@ metadata:
   name: zookeeper
   namespace: mcp-sentinel
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/k8s/05-kafka-hostpath.yaml
+++ b/k8s/05-kafka-hostpath.yaml
@@ -124,13 +124,12 @@ spec:
       targetPort: 2181
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: zookeeper
   namespace: mcp-sentinel
 spec:
-  strategy:
-    type: Recreate
+  serviceName: zookeeper
   replicas: 1
   selector:
     matchLabels:

--- a/k8s/05-kafka-hostpath.yaml
+++ b/k8s/05-kafka-hostpath.yaml
@@ -11,13 +11,104 @@ spec:
     - ReadWriteOnce
   volumeMode: Filesystem
   storageClassName: local-path
-  persistentVolumeReclaimPolicy: Delete
+  persistentVolumeReclaimPolicy: Retain
   claimRef:
     namespace: mcp-sentinel
     name: kafka-data-kafka-0
-  hostPath:
+  local:
     path: /var/lib/mcp-runtime/kafka
-    type: DirectoryOrCreate
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: mcp-runtime.org/local-storage
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: zookeeper-data-pv
+  labels:
+    app: zookeeper
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: local-path
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    namespace: mcp-sentinel
+    name: zookeeper-data-pvc
+  local:
+    path: /var/lib/mcp-runtime/zookeeper/data
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: mcp-runtime.org/local-storage
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: zookeeper-log-pv
+  labels:
+    app: zookeeper
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: local-path
+  persistentVolumeReclaimPolicy: Retain
+  claimRef:
+    namespace: mcp-sentinel
+    name: zookeeper-log-pvc
+  local:
+    path: /var/lib/mcp-runtime/zookeeper/log
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: mcp-runtime.org/local-storage
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zookeeper-data-pvc
+  namespace: mcp-sentinel
+spec:
+  storageClassName: local-path
+  volumeName: zookeeper-data-pv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zookeeper-log-pvc
+  namespace: mcp-sentinel
+spec:
+  storageClassName: local-path
+  volumeName: zookeeper-log-pv
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: Service
@@ -47,6 +138,21 @@ spec:
       labels:
         app: zookeeper
     spec:
+      initContainers:
+        - name: init-perms
+          image: alpine:3.23
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "chown -R 1000:1000 /var/lib/zookeeper/data /var/lib/zookeeper/log"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: zookeeper-data
+              mountPath: /var/lib/zookeeper/data
+            - name: zookeeper-log
+              mountPath: /var/lib/zookeeper/log
       containers:
         - name: zookeeper
           image: confluentinc/cp-zookeeper:7.5.1
@@ -55,8 +161,24 @@ spec:
               value: "2181"
             - name: ZOOKEEPER_TICK_TIME
               value: "2000"
+            - name: ZOOKEEPER_DATA_DIR
+              value: /var/lib/zookeeper/data
+            - name: ZOOKEEPER_LOG_DIR
+              value: /var/lib/zookeeper/log
           ports:
             - containerPort: 2181
+          volumeMounts:
+            - name: zookeeper-data
+              mountPath: /var/lib/zookeeper/data
+            - name: zookeeper-log
+              mountPath: /var/lib/zookeeper/log
+      volumes:
+        - name: zookeeper-data
+          persistentVolumeClaim:
+            claimName: zookeeper-data-pvc
+        - name: zookeeper-log
+          persistentVolumeClaim:
+            claimName: zookeeper-log-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -140,6 +262,7 @@ spec:
     - metadata:
         name: kafka-data
       spec:
+        storageClassName: local-path
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/k8s/05-kafka-hostpath.yaml
+++ b/k8s/05-kafka-hostpath.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kafka-pv
+  labels:
+    app: kafka
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  storageClassName: local-path
+  persistentVolumeReclaimPolicy: Delete
+  claimRef:
+    namespace: mcp-sentinel
+    name: kafka-data-kafka-0
+  hostPath:
+    path: /var/lib/mcp-runtime/kafka
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  namespace: mcp-sentinel
+spec:
+  selector:
+    app: zookeeper
+  ports:
+    - name: client
+      port: 2181
+      targetPort: 2181
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+  namespace: mcp-sentinel
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: confluentinc/cp-zookeeper:7.5.1
+          env:
+            - name: ZOOKEEPER_CLIENT_PORT
+              value: "2181"
+            - name: ZOOKEEPER_TICK_TIME
+              value: "2000"
+          ports:
+            - containerPort: 2181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: mcp-sentinel
+spec:
+  selector:
+    app: kafka
+  ports:
+    - name: broker
+      port: 9092
+      targetPort: 9092
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  namespace: mcp-sentinel
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+        - name: init-perms
+          image: alpine:3.23
+          imagePullPolicy: IfNotPresent
+          command: ["sh", "-c", "chown -R 1000:1000 /var/lib/kafka/data"]
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: kafka-data
+              mountPath: /var/lib/kafka/data
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.5.1
+          ports:
+            - containerPort: 9092
+          env:
+            - name: KAFKA_BROKER_ID
+              value: "1"
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: zookeeper:2181
+            - name: KAFKA_LISTENERS
+              value: PLAINTEXT://0.0.0.0:9092
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://kafka.mcp-sentinel.svc.cluster.local:9092
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: PLAINTEXT:PLAINTEXT
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: PLAINTEXT
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            - name: KAFKA_LOG_DIRS
+              value: /var/lib/kafka/data
+            - name: KAFKA_HEAP_OPTS
+              value: "-Xms256m -Xmx256m"
+          volumeMounts:
+            - name: kafka-data
+              mountPath: /var/lib/kafka/data
+  volumeClaimTemplates:
+    - metadata:
+        name: kafka-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 20Gi

--- a/test/golden/cli/cli_golden_test.go
+++ b/test/golden/cli/cli_golden_test.go
@@ -51,6 +51,7 @@ func TestCLIHelpGoldens(t *testing.T) {
 		{name: "registry_info_help", args: []string{"registry", "info", "--help"}, golden: "mcp-runtime_registry_info_help.golden"},
 		{name: "registry_provision_help", args: []string{"registry", "provision", "--help"}, golden: "mcp-runtime_registry_provision_help.golden"},
 		{name: "registry_push_help", args: []string{"registry", "push", "--help"}, golden: "mcp-runtime_registry_push_help.golden"},
+		{name: "bootstrap_help", args: []string{"bootstrap", "--help"}, golden: "mcp-runtime_bootstrap_help.golden"},
 		{name: "setup_help", args: []string{"setup", "--help"}, golden: "mcp-runtime_setup_help.golden"},
 		{name: "pipeline_help", args: []string{"pipeline", "--help"}, golden: "mcp-runtime_pipeline_help.golden"},
 		{name: "pipeline_generate_help", args: []string{"pipeline", "generate", "--help"}, golden: "mcp-runtime_pipeline_generate_help.golden"},

--- a/test/golden/cli/testdata/mcp-runtime_bootstrap_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_bootstrap_help.golden
@@ -1,0 +1,15 @@
+Bootstrap validates and (optionally) installs cluster prerequisites needed by mcp-runtime setup.
+
+By design, this does not provision Kubernetes clusters end-to-end across all distributions.
+Use this to prepare an existing cluster for running 'mcp-runtime setup'.
+
+Usage:
+  mcp-runtime bootstrap [flags]
+
+Flags:
+      --apply             Apply safe bootstrap fixes when possible (k3s only today)
+  -h, --help              help for bootstrap
+      --provider string   Cluster provider hint (auto|k3s|rke2|kubeadm|generic) (default "auto")
+
+Global Flags:
+      --debug   Enable debug mode with structured error logging

--- a/test/golden/cli/testdata/mcp-runtime_bootstrap_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_bootstrap_help.golden
@@ -3,11 +3,13 @@ Bootstrap validates and (optionally) installs cluster prerequisites needed by mc
 By design, this does not provision Kubernetes clusters end-to-end across all distributions.
 Use this to prepare an existing cluster for running 'mcp-runtime setup'.
 
+Note: bootstrap --apply is automated for k3s only and must be executed on the k3s server node (it expects local manifests under /var/lib/rancher/k3s/server/manifests).
+
 Usage:
   mcp-runtime bootstrap [flags]
 
 Flags:
-      --apply             Apply safe bootstrap fixes when possible (k3s only today)
+      --apply             Apply safe bootstrap fixes when possible (k3s only today; run on the k3s server node)
   -h, --help              help for bootstrap
       --provider string   Cluster provider hint (auto|k3s|rke2|kubeadm|generic) (default "auto")
 

--- a/test/golden/cli/testdata/mcp-runtime_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_help.golden
@@ -9,6 +9,7 @@ Usage:
 
 Available Commands:
   access      Manage grants and agent sessions
+  bootstrap   Bootstrap cluster prerequisites (on-prem focused)
   cluster     Manage Kubernetes cluster
   completion  Generate the autocompletion script for the specified shell
   help        Help about any command

--- a/test/golden/cli/testdata/mcp-runtime_setup_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_setup_help.golden
@@ -11,10 +11,12 @@ Usage:
   mcp-runtime setup [flags]
 
 Flags:
+      --context string                 Kubernetes context to use
       --force-ingress-install          Force ingress install even if an ingress class already exists
   -h, --help                           help for setup
       --ingress string                 Ingress controller to install automatically during setup (traefik|none) (default "traefik")
       --ingress-manifest string        Manifest to apply when installing the ingress controller (default "config/ingress/overlays/http")
+      --kubeconfig string              Path to kubeconfig file (default: ~/.kube/config)
       --operator-leader-elect          Override operator leader election when set
       --operator-metrics-addr string   Operator metrics bind address (default: :8080 from manager.yaml)
       --operator-probe-addr string     Operator health probe bind address (default: :8081 from manager.yaml)

--- a/test/golden/cli/testdata/mcp-runtime_setup_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_setup_help.golden
@@ -20,6 +20,7 @@ Flags:
       --operator-probe-addr string     Operator health probe bind address (default: :8081 from manager.yaml)
       --registry-storage string        Registry storage size (default: 20Gi) (default "20Gi")
       --registry-type string           Registry type (docker; harbor coming soon) (default "docker")
+      --storage-mode string            Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube without a provisioner. (default "dynamic")
       --strict-prod                    Require production-style registry and TLS validation for non-test setup
       --test-mode                      Test mode: skip operator/gateway image builds and use kind-loaded images
       --with-tls                       Enable TLS overlays (ingress/registry); default is HTTP for dev

--- a/test/golden/cli/testdata/mcp-runtime_setup_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_setup_help.golden
@@ -20,7 +20,7 @@ Flags:
       --operator-probe-addr string     Operator health probe bind address (default: :8081 from manager.yaml)
       --registry-storage string        Registry storage size (default: 20Gi) (default "20Gi")
       --registry-type string           Registry type (docker; harbor coming soon) (default "docker")
-      --storage-mode string            Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube without a provisioner. (default "dynamic")
+      --storage-mode string            Storage mode for local/dev clusters (dynamic|hostpath). Use hostpath for single-node k3s/minikube/kind without a provisioner. (default "dynamic")
       --strict-prod                    Require production-style registry and TLS validation for non-test setup
       --test-mode                      Test mode: skip operator/gateway image builds and use kind-loaded images
       --with-tls                       Enable TLS overlays (ingress/registry); default is HTTP for dev


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level "bootstrap" CLI command to validate and optionally remediate cluster prerequisites
  * Added `--storage-mode` option (dynamic|hostpath) to choose hostpath-backed deployments
  * Added configurable helper-pod timeout via `MCP_HELPER_POD_TIMEOUT`

* **New Deployments**
  * Added hostpath-backed manifests for registry, ClickHouse, Kafka/ZooKeeper, and an HTTPS registry ingress

* **Documentation**
  * Added a "Clean Start" cluster cleanup procedure guide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->