### PR TITLE
Fix Postgres storage mode selection for setup

### DIFF
--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestVerifyPlatformAPIToken(t *testing.T) {
-	t.Parallel()
 	prevHook := authHTTPDoHook
 	authHTTPDoHook = func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path != "/api/auth/me" {
@@ -38,7 +37,6 @@ func TestVerifyPlatformAPIToken(t *testing.T) {
 }
 
 func TestVerifyPlatformAPIToken_Unauthorized(t *testing.T) {
-	t.Parallel()
 	prevHook := authHTTPDoHook
 	authHTTPDoHook = func(_ *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(bytes.NewReader(nil))}, nil

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1816,9 +1816,11 @@ func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logg
 
 	clickhouseManifest := "k8s/03-clickhouse.yaml"
 	kafkaManifest := "k8s/05-kafka.yaml"
+	postgresManifest := "k8s/20-postgres.yaml"
 	if storageMode == StorageModeHostpath {
 		clickhouseManifest = "k8s/03-clickhouse-hostpath.yaml"
 		kafkaManifest = "k8s/05-kafka-hostpath.yaml"
+		postgresManifest = "k8s/20-postgres-hostpath.yaml"
 	}
 
 	Info("Applying analytics storage and messaging components")
@@ -1851,7 +1853,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logg
 
 	Info("Applying analytics services")
 	for _, manifest := range []string{
-		"k8s/20-postgres.yaml",
+		postgresManifest,
 		"k8s/06-ingest.yaml",
 		"k8s/07-processor.yaml",
 		"k8s/08-api.yaml",

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1879,7 +1879,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl KubectlRunner, logger *zap.Logg
 
 	Info(fmt.Sprintf("Waiting for mcp-sentinel workload rollouts (per-resource timeout %s; override with MCP_DEPLOYMENT_TIMEOUT)", rolloutTimeout))
 	targets := []struct{ kind, name string }{
-		{kind: "deployment", name: "mcp-sentinel-postgres"},
+		{kind: "statefulset", name: "mcp-sentinel-postgres"},
 		{kind: "deployment", name: "mcp-sentinel-ingest"},
 		{kind: "deployment", name: "mcp-sentinel-processor"},
 		{kind: "deployment", name: "mcp-sentinel-api"},

--- a/internal/cli/setup_helpers_test.go
+++ b/internal/cli/setup_helpers_test.go
@@ -891,6 +891,91 @@ func TestDeployAnalyticsManifestsWithKubectl_HostpathUsesHostpathManifests(t *te
 	}
 }
 
+func TestDeployAnalyticsManifestsWithKubectl_WaitsForPostgresStatefulSet(t *testing.T) {
+	orig := DefaultCLIConfig
+	t.Cleanup(func() { DefaultCLIConfig = orig })
+	DefaultCLIConfig = &CLIConfig{}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	manifestDir := filepath.Join(root, "k8s")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatalf("failed to create manifest dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "services"), 0o755); err != nil {
+		t.Fatalf("failed to create services dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	manifestContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: fixture\n  namespace: mcp-sentinel\n"
+	for _, name := range []string{
+		"00-namespace.yaml",
+		"01-config.yaml",
+		"03-clickhouse.yaml",
+		"04-clickhouse-init.yaml",
+		"05-kafka.yaml",
+		"06-ingest.yaml",
+		"07-processor.yaml",
+		"08-api.yaml",
+		"08-api-rbac.yaml",
+		"09-ui.yaml",
+		"10-gateway.yaml",
+		"11-prometheus.yaml",
+		"12-grafana.yaml",
+		"15-otel-collector.yaml",
+		"16-tempo.yaml",
+		"17-loki.yaml",
+		"18-promtail.yaml",
+		"19-grafana-datasources.yaml",
+		"20-postgres.yaml",
+	} {
+		if err := os.WriteFile(filepath.Join(manifestDir, name), []byte(manifestContent), 0o644); err != nil {
+			t.Fatalf("failed to write fixture manifest %s: %v", name, err)
+		}
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to fixture root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	var sawPostgresStatefulSet bool
+	mock := &MockExecutor{
+		CommandFunc: func(spec ExecSpec) *MockCommand {
+			cmd := &MockCommand{Args: spec.Args}
+			if contains(spec.Args, "get") && contains(spec.Args, "secret") {
+				cmd.OutputData = []byte("Error from server (NotFound): secrets \"mcp-sentinel-secrets\" not found")
+				cmd.OutputErr = errors.New("not found")
+			}
+			if contains(spec.Args, "rollout") && contains(spec.Args, "statefulset/mcp-sentinel-postgres") {
+				sawPostgresStatefulSet = true
+				cmd.RunErr = errors.New("rollout timeout")
+			}
+			return cmd
+		},
+	}
+	kubectl := &KubectlClient{exec: mock, validators: nil}
+
+	err = deployAnalyticsManifestsWithKubectl(kubectl, zap.NewNop(), AnalyticsImageSet{
+		Ingest:    "example.com/mcp-sentinel-ingest:latest",
+		API:       "example.com/mcp-sentinel-api:latest",
+		Processor: "example.com/mcp-sentinel-processor:latest",
+		UI:        "example.com/mcp-sentinel-ui:latest",
+	}, "")
+	if err == nil {
+		t.Fatal("expected failure from postgres rollout timeout")
+	}
+	if !sawPostgresStatefulSet {
+		t.Fatal("expected setup to wait on statefulset/mcp-sentinel-postgres")
+	}
+	if !strings.Contains(err.Error(), "statefulset/mcp-sentinel-postgres") {
+		t.Fatalf("expected statefulset postgres in error, got %v", err)
+	}
+}
+
 func TestSetupDepsWithDefaultsSetsNil(t *testing.T) {
 	deps := SetupDeps{}.withDefaults(zap.NewNop())
 	if deps.ResolveExternalRegistryConfig == nil {

--- a/internal/cli/setup_helpers_test.go
+++ b/internal/cli/setup_helpers_test.go
@@ -775,6 +775,7 @@ func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 		"18-promtail.yaml",
 		"19-grafana-datasources.yaml",
 		"20-postgres.yaml",
+		"20-postgres-hostpath.yaml",
 	} {
 		if err := os.WriteFile(filepath.Join(manifestDir, name), []byte(manifestContent), 0o644); err != nil {
 			t.Fatalf("failed to write fixture manifest %s: %v", name, err)
@@ -850,6 +851,7 @@ func TestDeployAnalyticsManifestsWithKubectl_HostpathUsesHostpathManifests(t *te
 		"03-clickhouse-hostpath.yaml",
 		"04-clickhouse-init.yaml",
 		"05-kafka-hostpath.yaml",
+		"20-postgres-hostpath.yaml",
 	} {
 		if err := os.WriteFile(filepath.Join(manifestDir, name), []byte(manifestContent), 0o644); err != nil {
 			t.Fatalf("failed to write fixture manifest %s: %v", name, err)

--- a/k8s/20-postgres-hostpath.yaml
+++ b/k8s/20-postgres-hostpath.yaml
@@ -94,6 +94,7 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        storageClassName: local-path
         resources:
           requests:
             storage: 5Gi

--- a/pkg/clickhouse/client_test.go
+++ b/pkg/clickhouse/client_test.go
@@ -1,0 +1,139 @@
+package clickhouse
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubRowScanner struct {
+	values []any
+	err    error
+}
+
+func (s stubRowScanner) Scan(dest ...any) error {
+	if s.err != nil {
+		return s.err
+	}
+	for i := range dest {
+		switch ptr := dest[i].(type) {
+		case *time.Time:
+			*ptr = s.values[i].(time.Time)
+		case *string:
+			*ptr = s.values[i].(string)
+		default:
+			return errors.New("unsupported scan target")
+		}
+	}
+	return nil
+}
+
+func TestValidateDBName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "valid", input: "analytics_events", wantErr: false},
+		{name: "empty", input: "", wantErr: true},
+		{name: "starts with digit", input: "1events", wantErr: true},
+		{name: "contains dash", input: "analytics-events", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDBName(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+		})
+	}
+}
+
+func TestNormalizeEventLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input int
+		want  int
+	}{
+		{input: 0, want: 100},
+		{input: -5, want: 100},
+		{input: 25, want: 25},
+		{input: 2000, want: 1000},
+	}
+
+	for _, tc := range tests {
+		if got := normalizeEventLimit(tc.input); got != tc.want {
+			t.Fatalf("normalizeEventLimit(%d) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestScanEventRow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	scanner := stubRowScanner{
+		values: []any{
+			now,
+			"gateway",
+			"tools/call",
+			"demo-one",
+			"mcp-servers",
+			"kind",
+			"user-123",
+			"ops-agent",
+			"sess-1",
+			"allow",
+			"add",
+			`{"value":1}`,
+		},
+	}
+
+	var row EventRow
+	if err := scanEventRow(scanner, &row); err != nil {
+		t.Fatalf("scanEventRow returned error: %v", err)
+	}
+	if row.Timestamp != now {
+		t.Fatalf("unexpected timestamp: got %v want %v", row.Timestamp, now)
+	}
+	if string(row.Payload) != `{"value":1}` {
+		t.Fatalf("unexpected payload: %s", row.Payload)
+	}
+}
+
+func TestScanEventRowWrapsInvalidJSONPayload(t *testing.T) {
+	t.Parallel()
+
+	scanner := stubRowScanner{
+		values: []any{
+			time.Unix(1_700_000_000, 0).UTC(),
+			"gateway",
+			"tools/call",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"",
+			"plain-text",
+		},
+	}
+
+	var row EventRow
+	if err := scanEventRow(scanner, &row); err != nil {
+		t.Fatalf("scanEventRow returned error: %v", err)
+	}
+	if string(row.Payload) != `"plain-text"` {
+		t.Fatalf("unexpected wrapped payload: %s", row.Payload)
+	}
+}

--- a/pkg/operatorutil/status_test.go
+++ b/pkg/operatorutil/status_test.go
@@ -1,0 +1,57 @@
+package operatorutil
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetConditionAppendsNewCondition(t *testing.T) {
+	t.Parallel()
+
+	var conditions []metav1.Condition
+	SetCondition(&conditions, DeploymentReady, true, "Ready", "deployment is ready", 7)
+
+	if len(conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(conditions))
+	}
+	if conditions[0].Type != string(DeploymentReady) {
+		t.Fatalf("unexpected type: %s", conditions[0].Type)
+	}
+	if conditions[0].Status != metav1.ConditionTrue {
+		t.Fatalf("unexpected status: %s", conditions[0].Status)
+	}
+	if conditions[0].ObservedGeneration != 7 {
+		t.Fatalf("unexpected generation: %d", conditions[0].ObservedGeneration)
+	}
+}
+
+func TestSetConditionPreservesTransitionTimeWhenStatusUnchanged(t *testing.T) {
+	t.Parallel()
+
+	originalTime := metav1.NewTime(time.Unix(1_700_000_000, 0).UTC())
+	conditions := []metav1.Condition{{
+		Type:               string(ServiceReady),
+		Status:             metav1.ConditionTrue,
+		Reason:             "OldReason",
+		Message:            "old message",
+		LastTransitionTime: originalTime,
+		ObservedGeneration: 1,
+	}}
+
+	SetCondition(&conditions, ServiceReady, true, "NewReason", "new message", 2)
+
+	if len(conditions) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(conditions))
+	}
+	if !conditions[0].LastTransitionTime.Equal(&originalTime) {
+		t.Fatalf("expected transition time to be preserved: got %v want %v", conditions[0].LastTransitionTime, originalTime)
+	}
+	if conditions[0].Reason != "NewReason" {
+		t.Fatalf("unexpected reason: %s", conditions[0].Reason)
+	}
+	if conditions[0].ObservedGeneration != 2 {
+		t.Fatalf("unexpected generation: %d", conditions[0].ObservedGeneration)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hostpath storage mode option for analytics Postgres, enabling a single-node persistent data path.

* **Improvements**
  * Deployment now selects the appropriate Postgres manifest automatically based on storage mode.
  * Postgres manifest updated to rely on cluster defaults for storage when hostpath is not used.

* **Bug Fixes**
  * Rollout monitoring now watches the correct Postgres workload type for accurate readiness checks.

* **Tests**
  * Added coverage for Postgres hostpath selection and rollout-wait behavior; adjusted several test timings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->