### PR TITLE
Improve docs publish flow and CLI guidance

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
               - '**'
               - '!docs/**'
               - '!website/**'
+              - '!README.md'
             docs:
               - 'docs/**'
             website:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
     name: Detect Docs/Website Changes
     runs-on: ubuntu-latest
     outputs:
+      code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
       website: ${{ steps.filter.outputs.website }}
     steps:
@@ -23,6 +24,10 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!website/**'
             docs:
               - 'docs/**'
             website:
@@ -31,6 +36,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: [changed-paths]
+    if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,6 +69,8 @@ jobs:
   test:
     name: Unit + Integration Tests
     runs-on: ubuntu-latest
+    needs: [changed-paths]
+    if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -112,7 +121,8 @@ jobs:
   e2e-kind:
     name: Kind E2E
     runs-on: ubuntu-24.04
-    needs: [lint, test]
+    needs: [changed-paths, lint, test]
+    if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     timeout-minutes: 90
     permissions:
       contents: read
@@ -175,6 +185,8 @@ jobs:
   benchmark:
     name: Benchmarks
     runs-on: ubuntu-latest
+    needs: [changed-paths]
+    if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -192,6 +204,8 @@ jobs:
   generated-drift:
     name: Generated File Drift
     runs-on: ubuntu-latest
+    needs: [changed-paths]
+    if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/security-gosec.yaml
+++ b/.github/workflows/security-gosec.yaml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+      - 'README.md'
   push:
     branches: [ "main" ]
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+      - 'README.md'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/security-gosec.yaml
+++ b/.github/workflows/security-gosec.yaml
@@ -3,8 +3,14 @@ name: Security - Gosec
 on:
   pull_request:
     branches: [ "*" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+      - 'README.md'
   push:
     branches: [ "main" ]
     paths-ignore:
       - 'docs/**'
       - 'website/**'
+      - 'README.md'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -3,8 +3,14 @@ name: Security - Trivy
 on:
   pull_request:
     branches: [ "*" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
   workflow_dispatch: {}
 
 jobs:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # MCP Runtime
 
-MCP Runtime is an open source control plane for operating company MCP servers on Kubernetes. It packages server deployment, registry workflows, gateway routing, access policy, audit, and observability into one infrastructure layer.
+MCP Runtime is an open source, Kubernetes-native control plane for deploying, governing, and brokering MCP servers. It packages server deployment, registry workflows, gateway routing, access policy, audit, and observability into one operating surface for platform teams.
 
 <div class="docs-home">
 <section class="docs-hero">
   <div class="docs-hero-copy">
-  <p class="docs-eyebrow">MCP infrastructure for platform teams</p>
+  <p class="docs-eyebrow">Vendor-neutral MCP infrastructure for platform teams</p>
 
-  <p class="docs-lead">Deploy internal MCP servers, expose them through governed routes, and keep policy and telemetry attached to every agent call.</p>
+  <p class="docs-lead">Deploy MCP servers, expose them through governed routes, and keep policy, audit, and telemetry attached to every agent call.</p>
 
   <div class="docs-actions">
     <a class="docs-button docs-button-primary" href="getting-started.md">Get started</a>
@@ -41,13 +41,19 @@ MCP Runtime is an open source control plane for operating company MCP servers on
 <a class="docs-card" href="architecture.md">
   <span class="docs-card-kicker">Understand</span>
   <strong>Read the architecture</strong>
-  <span>Trace how the manager, registry, broker, operator, and Sentinel services fit together.</span>
+  <span>Trace how the control plane, registry, broker, operator, and Sentinel services fit together.</span>
 </a>
 
 <a class="docs-card" href="cluster-readiness.md">
   <span class="docs-card-kicker">Prepare</span>
   <strong>Check your cluster</strong>
   <span>Review prerequisites for k3s, kind, minikube, Docker Desktop Kubernetes, kubeadm, and EKS.</span>
+</a>
+
+<a class="docs-card" href="publish-mcp-server.md">
+  <span class="docs-card-kicker">Ship</span>
+  <strong>Publish an MCP server</strong>
+  <span>Write a manifest or `.mcp` metadata, push an image, deploy it, and verify what the platform creates.</span>
 </a>
 </div>
 
@@ -83,7 +89,7 @@ MCP Runtime is an open source control plane for operating company MCP servers on
 
 | Workflow | Start here |
 |---|---|
-| Evaluate MCP Runtime for a company platform | [Getting started](getting-started.md), then [Architecture](architecture.md) |
+| Evaluate MCP Runtime for a private MCP platform | [Getting started](getting-started.md), then [Architecture](architecture.md) |
 | Run MCP Runtime on a real cluster | [Cluster readiness](cluster-readiness.md), then [Runtime](runtime.md) |
 | Govern tools and sessions | [Sentinel](sentinel.md), then [API reference](api.md) |
 | Integrate from automation | [CLI](cli.md), then [API reference](api.md) |
@@ -91,4 +97,4 @@ MCP Runtime is an open source control plane for operating company MCP servers on
 
 ## Project status
 
-MCP Runtime is alpha. The architecture is stable enough to evaluate as internal MCP infrastructure, but API and UX details are still evolving. Treat the `v1alpha1` types as the source of truth.
+MCP Runtime is alpha. The architecture is stable enough to evaluate as governed MCP infrastructure, but API and UX details are still evolving. Treat the `v1alpha1` types as the source of truth.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-MCP Runtime is a Kubernetes-native manager, registry, broker, and infrastructure layer for internal MCP servers. It gives companies one platform surface for deploying servers, publishing images, brokering agent access, and keeping policy, consent, audit, and observability on the request path.
+MCP Runtime is a Kubernetes-native control plane for MCP servers. It gives platform teams one operating surface for deploying servers, publishing images, brokering agent access, and keeping policy, consent, audit, and observability on the live request path across vendor-neutral Kubernetes environments.
 
 ```mermaid
 flowchart LR
@@ -59,6 +59,6 @@ Sentinel services receive those events, process them for analytics, and expose t
 
 `setup` installs the runtime namespaces, CRDs, registry, operator, ingress wiring, and the Sentinel stack unless explicitly disabled. In development, Kind and path-based localhost ingress are enough. In production, `MCP_PLATFORM_DOMAIN` can derive `registry.<domain>`, `mcp.<domain>`, and `platform.<domain>` so registry pulls, MCP traffic, and the dashboard each have stable hostnames.
 
-The intended company workflow is straightforward: platform teams install the stack, application teams publish MCP servers, security teams define grants and sessions, and agents call tools through the governed broker path.
+The intended workflow is straightforward: platform teams install the stack, application teams publish MCP servers, security teams define grants and sessions, and agents call tools through the governed broker path.
 
 For routing details and field semantics, see [Runtime](runtime.md) and [API reference](api.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,9 @@ make build
 ./bin/mcp-runtime setup
 ./bin/mcp-runtime status
 
+./bin/mcp-runtime auth login --api-url https://platform.example.com --token-stdin < token.txt
+./bin/mcp-runtime auth status
+
 ./bin/mcp-runtime registry push --image my-server:v1.0.0
 ./bin/mcp-runtime pipeline generate --dir .mcp --output manifests/
 ./bin/mcp-runtime pipeline deploy --dir manifests/
@@ -37,6 +40,7 @@ For a new workstation, run `make deps-install` first where supported, then `STRI
 |---|---|---|
 | `bootstrap` | Preflight checks for cluster prerequisites (DNS, default StorageClass, ingress class, MetalLB). With `--apply` on k3s only, install bundled CoreDNS + local-path manifests. | `bootstrap`, `--apply`, `--provider auto\|k3s\|rke2\|kubeadm\|generic` |
 | `setup` | Install the platform stack, wire registry and ingress, deploy the operator, optionally include sentinel. | `setup`, `--with-tls`, `--without-sentinel` |
+| `auth` | Save and inspect platform API credentials for non-kubeconfig platform flows. | `login`, `logout`, `status` |
 | `cluster` | Initialize clusters, inspect health, configure kubeconfig and ingress, provision clusters, manage cert-manager. | `init`, `status`, `config`, `provision`, `cert status\|apply\|wait`, `doctor` |
 | `registry` | Inspect the internal registry, configure an external one, push images. | `status`, `info`, `provision`, `push` |
 | `server` | Manage `MCPServer` resources and operator-facing actions. | `list`, `get`, `create`, `apply`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
@@ -72,6 +76,60 @@ mcp-runtime setup --test-mode                  # use kind-loaded operator image
 ```
 
 Flags: `--registry-type`, `--registry-storage`, `--ingress`, `--ingress-manifest`, `--force-ingress-install`, `--with-tls`, `--test-mode`, `--without-sentinel`, plus operator overrides `--operator-leader-elect`, `--operator-metrics-addr`, `--operator-probe-addr`.
+
+## auth
+
+Use `auth` for platform API credentials, not for Kubernetes cluster access.
+
+Use cases:
+
+- saving a platform API token locally for day-to-day platform flows
+- recording a registry host alongside that token
+- checking whether local platform credentials are already configured
+
+Do not use `auth` for:
+
+- `setup`
+- cluster bootstrap
+- cluster admin operations
+- raw Kubernetes access
+
+Examples:
+
+```bash
+# Save a token interactively
+mcp-runtime auth login --api-url https://platform.example.com
+
+# Save a token non-interactively
+cat token.txt | mcp-runtime auth login \
+  --api-url https://platform.example.com \
+  --token-stdin
+
+# Email/password login when the platform supports it
+mcp-runtime auth login \
+  --api-url https://platform.example.com \
+  --email admin@example.com \
+  --password '...'
+
+# Record the platform registry host too
+mcp-runtime auth login \
+  --api-url https://platform.example.com \
+  --token-stdin \
+  --registry-host registry.example.com < token.txt
+
+# Check current auth state
+mcp-runtime auth status
+
+# Remove saved local credentials
+mcp-runtime auth logout
+```
+
+Notes:
+
+- saved credentials are local to the workstation
+- `MCP_PLATFORM_API_TOKEN` overrides any saved token when set
+- `MCP_PLATFORM_API_URL` can provide the default API base URL
+- kubeconfig-based cluster commands are separate from platform auth
 
 ## status
 
@@ -110,6 +168,8 @@ mcp-runtime pipeline generate --file .mcp/payments.yaml --output manifests
 mcp-runtime pipeline deploy --dir manifests
 mcp-runtime pipeline deploy --dir manifests --namespace mcp-servers
 ```
+
+For the full build, push, deploy, and verify flow, see [Publish an MCP Server](publish-mcp-server.md).
 
 ## access
 
@@ -152,6 +212,8 @@ mcp-runtime registry push --image payments:v1
 ```
 
 `server patch` accepts inline `--patch` or `--patch-file` with `merge`, `json`, or `strategic` modes.
+
+`server build image` updates matching `.mcp` metadata when you use the metadata-driven pipeline. It does not deploy by itself; push and deploy are separate steps.
 
 ## sentinel
 
@@ -234,5 +296,6 @@ mcp-runtime status
 ## Next
 
 - [API](api.md) — exact resource fields the CLI is wrapping.
+- [Publish an MCP Server](publish-mcp-server.md) — manifest, metadata, image push, deploy, and verification flow.
 - [Sentinel](sentinel.md) — how `sentinel logs / events / restart` map to the bundled stack.
 - [Cluster readiness](cluster-readiness.md) — distro-specific prerequisites.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,7 +125,7 @@ Common edits:
 
 - Set `spec.ingressHost` if you use host-based routing instead of the default path-based shape.
 - Set `spec.servicePort` if you need a Service port other than `80`.
-- Add `spec.env` or `spec.envFromSecret` when the server needs configuration or credentials.
+- Add `spec.envVars` or `spec.secretEnvVars` when the server needs configuration or credentials.
 - Add `spec.imagePullSecrets` if the image registry requires explicit pull auth.
 - Add `spec.tools`, `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you are ready to describe stricter governance or delivery behavior.
 
@@ -136,7 +136,7 @@ For the full field surface, use the [API reference](api.md).
 Author lightweight metadata YAML, generate CRDs, and deploy:
 
 ```bash
-./bin/mcp-runtime server build image my-server
+./bin/mcp-runtime server build image my-server --tag v1.0.0
 ./bin/mcp-runtime registry push --image my-server:v1.0.0
 ./bin/mcp-runtime pipeline generate --dir .mcp --output manifests/
 ./bin/mcp-runtime pipeline deploy --dir manifests/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The shortest path from an empty Kubernetes cluster to a company-ready MCP endpoint: install the manager, registry, broker, and Sentinel stack; deploy one MCP server; grant access; and observe live traffic.
+The shortest path from an empty Kubernetes cluster to a governed MCP endpoint: install the control plane, registry, broker, and Sentinel stack; deploy one MCP server; grant access; and observe live traffic.
 
 ## Prerequisites
 
@@ -89,17 +89,103 @@ spec:
 ./bin/mcp-runtime server status
 ```
 
+#### How to write the manifest
+
+Start with the smallest useful `MCPServer` and add features only when you need them.
+
+- `metadata.name` becomes the server identity inside the platform.
+- `metadata.namespace` is usually `mcp-servers`.
+- `spec.image` points at the container image the platform should run.
+- `spec.imageTag` sets the tag when you do not include one directly in `spec.image`.
+- `spec.port` is the port your MCP server process listens on inside the container.
+- `spec.publicPathPrefix` controls the public route prefix. `payments` becomes `/payments/mcp`.
+- `spec.gateway.enabled` turns on brokered access and policy enforcement.
+- `spec.analytics.enabled` turns on audit and analytics emission for governed traffic.
+
+Use this minimal pattern for most first deployments:
+
+```yaml
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPServer
+metadata:
+  name: my-server
+  namespace: mcp-servers
+spec:
+  image: registry.example.com/my-server
+  imageTag: v1.0.0
+  port: 8088
+  publicPathPrefix: my-server
+  gateway:
+    enabled: true
+  analytics:
+    enabled: true
+```
+
+Common edits:
+
+- Set `spec.ingressHost` if you use host-based routing instead of the default path-based shape.
+- Set `spec.servicePort` if you need a Service port other than `80`.
+- Add `spec.env` or `spec.envFromSecret` when the server needs configuration or credentials.
+- Add `spec.imagePullSecrets` if the image registry requires explicit pull auth.
+- Add `spec.tools`, `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you are ready to describe stricter governance or delivery behavior.
+
+For the full field surface, use the [API reference](api.md).
+
 ### Option B — metadata-driven pipeline
 
 Author lightweight metadata YAML, generate CRDs, and deploy:
 
 ```bash
+./bin/mcp-runtime server build image my-server
 ./bin/mcp-runtime registry push --image my-server:v1.0.0
 ./bin/mcp-runtime pipeline generate --dir .mcp --output manifests/
 ./bin/mcp-runtime pipeline deploy --dir manifests/
 ```
 
-The server lands at `/{server-name}/mcp` on the configured ingress host, behind the same platform surface you use for future company MCP servers.
+The server lands at `/{server-name}/mcp` on the configured ingress host, behind the same platform surface you use for future MCP servers.
+
+#### Publish to the platform: what to do, and what happens next
+
+There are two ways to get a server into the platform:
+
+1. Build and push an image, then apply an `MCPServer` manifest directly.
+2. Build and push an image, then generate and deploy `MCPServer` manifests from `.mcp` metadata.
+
+The end-to-end flow is the same either way:
+
+1. Build the image for your server.
+2. Push that image to the platform registry or another registry the cluster can pull from.
+3. Apply an `MCPServer` resource that points at the image.
+4. Let the operator reconcile the runtime objects for that server.
+
+After the manifest is applied, the platform does the following:
+
+1. Validates and stores the `MCPServer` resource in Kubernetes.
+2. Resolves the final image reference using `spec.image`, `spec.imageTag`, and any registry override behavior.
+3. Creates or updates a `Deployment` for the MCP server.
+4. Creates or updates a `Service` for in-cluster traffic.
+5. Creates or updates an `Ingress` so the server is reachable at `/{publicPathPrefix}/mcp` or the configured ingress path.
+6. If `gateway.enabled` is set, wires traffic through the broker path and renders policy from matching grants and sessions.
+7. If analytics are enabled, emits audit and traffic events into the Sentinel stack.
+8. Reports readiness and status through `MCPServer.status`, `mcp-runtime server status`, and the platform UI.
+
+Useful checks after publish:
+
+```bash
+./bin/mcp-runtime server status
+./bin/mcp-runtime server get payments
+./bin/mcp-runtime server policy inspect payments
+./bin/mcp-runtime status
+```
+
+If the server does not come up, stay in the CLI first:
+
+```bash
+./bin/mcp-runtime server get payments
+./bin/mcp-runtime server logs payments --follow
+./bin/mcp-runtime sentinel logs gateway --follow
+./bin/mcp-runtime status
+```
 
 ## 6. Grant governed access (for gateway-enabled servers)
 
@@ -171,6 +257,7 @@ flowchart LR
 
 ## Next steps
 
+- [Publish an MCP Server](publish-mcp-server.md) — write manifests or `.mcp` metadata, build, push, deploy, and verify.
 - [Architecture](architecture.md) — how the pieces fit together.
 - [CLI](cli.md) — full command reference.
 - [API](api.md) — every CRD field and HTTP endpoint.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ extra_css:
 nav:
   - Home: README.md
   - Getting Started: getting-started.md
+  - Publish an MCP Server: publish-mcp-server.md
   - Architecture: architecture.md
   - Runtime: runtime.md
   - CLI: cli.md

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -1,0 +1,261 @@
+# Publish an MCP Server
+
+This guide covers the user-facing path for getting an MCP server into MCP Runtime:
+
+1. write an `MCPServer` manifest or `.mcp` metadata
+2. build the server image
+3. push the image to the platform registry
+4. deploy the server into the platform
+5. verify that the server is reachable and governed
+
+Use this guide after [Getting started](getting-started.md) once the platform stack is already installed.
+
+## Choose a description format
+
+You can describe a server in two ways:
+
+- `MCPServer` manifest
+  Best when you want direct control over the Kubernetes resource the operator will reconcile.
+- `.mcp` metadata
+  Best when you want a lighter authoring format and a CLI pipeline that generates `MCPServer` manifests for you.
+
+The platform outcome is the same in both cases: the operator reconciles a server deployment, service, route, and optional governed request path.
+
+## Option A: write an `MCPServer` manifest
+
+Start with a minimal manifest:
+
+```yaml
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPServer
+metadata:
+  name: payments
+  namespace: mcp-servers
+spec:
+  image: registry.example.com/payments
+  imageTag: v1.0.0
+  port: 8088
+  publicPathPrefix: payments
+  gateway:
+    enabled: true
+  analytics:
+    enabled: true
+```
+
+### What each field does
+
+- `metadata.name`
+  The server name inside the platform. This is also the default public route prefix when you do not override it.
+- `metadata.namespace`
+  Usually `mcp-servers`.
+- `spec.image`
+  The image repository to run.
+- `spec.imageTag`
+  The image tag when the tag is not embedded directly in `spec.image`.
+- `spec.port`
+  The port your MCP process listens on inside the container.
+- `spec.publicPathPrefix`
+  The public route prefix. `payments` becomes `/payments/mcp`.
+- `spec.gateway.enabled`
+  Sends requests through the broker path so policy and session checks run before tool calls.
+- `spec.analytics.enabled`
+  Emits governed request data into the Sentinel stack.
+
+### Common edits
+
+- Add `spec.ingressHost` for host-based routing instead of path-based routing.
+- Add `spec.servicePort` when you want a Service port other than `80`.
+- Add `spec.env` or `spec.envFromSecret` for runtime configuration.
+- Add `spec.imagePullSecrets` if your registry requires explicit pull credentials.
+- Add `spec.tools`, `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you want stricter governance or more delivery control.
+
+Apply the manifest:
+
+```bash
+./bin/mcp-runtime server apply --file payments.yaml
+./bin/mcp-runtime server status
+```
+
+## Option B: write `.mcp` metadata
+
+The metadata-driven pipeline uses YAML files under `.mcp/` and generates `MCPServer` manifests for you.
+
+Example:
+
+```yaml
+version: v1
+servers:
+  - name: payments
+    image: registry.example.com/payments
+    imageTag: v1.0.0
+    route: /payments
+    port: 8088
+    replicas: 1
+    namespace: mcp-servers
+```
+
+### Metadata fields
+
+- `name`
+  The server name.
+- `image`
+  The image repository.
+- `imageTag`
+  The image tag.
+- `route`
+  The public path prefix that will become the server ingress path.
+- `port`
+  The container port.
+- `replicas`
+  The desired replica count.
+- `namespace`
+  The target namespace.
+
+### Metadata defaults
+
+If fields are omitted, the loader applies defaults:
+
+- image defaults toward the platform registry path
+- tag defaults to `latest`
+- route is normalized with a leading `/`
+- port defaults to `8088`
+- replicas default to `1`
+- namespace defaults to `mcp-servers`
+
+Generate and deploy manifests:
+
+```bash
+./bin/mcp-runtime pipeline generate --dir .mcp --output manifests/
+./bin/mcp-runtime pipeline deploy --dir manifests/
+```
+
+## Build and push the server image
+
+For the direct manifest path, build the image with your normal container workflow:
+
+```bash
+docker build -t payments:v1.0.0 .
+```
+
+For the metadata-driven path, use the CLI helper:
+
+```bash
+./bin/mcp-runtime server build image payments --tag v1.0.0
+```
+
+This command builds a Docker image and updates the matching metadata entry. It is meant for the `.mcp` pipeline flow.
+
+Then push the image:
+
+```bash
+./bin/mcp-runtime registry push --image payments:v1.0.0
+```
+
+Typical user flow:
+
+```bash
+docker build -t payments:v1.0.0 .
+./bin/mcp-runtime registry push --image payments:v1.0.0
+./bin/mcp-runtime server apply --file payments.yaml
+```
+
+Or, with metadata:
+
+```bash
+./bin/mcp-runtime server build image payments --tag v1.0.0
+./bin/mcp-runtime registry push --image payments:v1.0.0
+./bin/mcp-runtime pipeline generate --dir .mcp --output manifests/
+./bin/mcp-runtime pipeline deploy --dir manifests/
+```
+
+## What happens after deploy
+
+After the server description reaches the platform, the operator does the following:
+
+1. stores the `MCPServer` resource in Kubernetes
+2. resolves the final image reference
+3. creates or updates a `Deployment`
+4. creates or updates a `Service`
+5. creates or updates an `Ingress`
+6. renders gateway policy when governed access is enabled
+7. updates `MCPServer.status` with readiness and progress
+
+With the default path-based shape, the server becomes available at:
+
+```text
+/{publicPathPrefix}/mcp
+```
+
+For the example above, that is:
+
+```text
+/payments/mcp
+```
+
+## Verify from the CLI
+
+Check server state:
+
+```bash
+./bin/mcp-runtime server status
+./bin/mcp-runtime server get payments
+./bin/mcp-runtime status
+```
+
+If the server uses governed access:
+
+```bash
+./bin/mcp-runtime server policy inspect payments
+./bin/mcp-runtime sentinel status
+```
+
+If traffic is failing:
+
+```bash
+./bin/mcp-runtime server logs payments --follow
+./bin/mcp-runtime sentinel logs gateway --follow
+```
+
+## Common failure points
+
+### Image built, but deploy still points at the wrong image
+
+Check:
+
+- the `spec.image` and `spec.imageTag` in your manifest
+- the metadata entry updated by `server build image`
+- whether you pushed the same tag you applied
+
+### Image pushed, but server never becomes ready
+
+Check:
+
+- `./bin/mcp-runtime server get <name>`
+- `./bin/mcp-runtime server status`
+- `./bin/mcp-runtime status`
+
+Most often this is an image reference, image-pull, or routing mismatch.
+
+### Route exists, but governed calls fail
+
+Check:
+
+- `./bin/mcp-runtime server policy inspect <name>`
+- your grant and session objects
+- `./bin/mcp-runtime sentinel logs gateway --follow`
+
+### Analytics enabled, but no request history appears
+
+Check:
+
+- `./bin/mcp-runtime sentinel status`
+- `./bin/mcp-runtime sentinel logs ingest --follow`
+- `./bin/mcp-runtime sentinel logs processor --follow`
+
+## Related docs
+
+- [Getting Started](getting-started.md)
+- [CLI](cli.md)
+- [Runtime](runtime.md)
+- [API](api.md)
+- [Sentinel](sentinel.md)

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -65,7 +65,7 @@ spec:
 
 - Add `spec.ingressHost` for host-based routing instead of path-based routing.
 - Add `spec.servicePort` when you want a Service port other than `80`.
-- Add `spec.env` or `spec.envFromSecret` for runtime configuration.
+- Add `spec.envVars` or `spec.secretEnvVars` for runtime configuration.
 - Add `spec.imagePullSecrets` if your registry requires explicit pull credentials.
 - Add `spec.tools`, `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you want stricter governance or more delivery control.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,6 +1,6 @@
 # Runtime
 
-The runtime is the Kubernetes control plane for internal MCP servers. It owns the manager, registry, broker wiring, cluster bootstrap, ingress setup, operator reconciliation, deployment resources, rollout, and the access model that sits beside each server before requests reach the [Sentinel](sentinel.md) request path.
+The runtime is the Kubernetes-native control plane for MCP servers. It owns the manager, registry, broker wiring, cluster bootstrap, ingress setup, operator reconciliation, deployment resources, rollout, and the access model that sits beside each server before requests reach the [Sentinel](sentinel.md) request path.
 
 > Higher-level than ingress and service mesh. The runtime sits **above** lower-level networking infrastructure and models MCP-specific delivery, access, and rollout concerns. It is not a generic data plane for arbitrary cluster traffic.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New guide for publishing and deploying MCP servers into MCP Runtime
  * Expanded CLI documentation with new auth command workflows
  * Enhanced getting-started guide with detailed manifest configuration and pipeline instructions
  * Updated product positioning terminology and architecture descriptions

* **Chores**
  * Optimized CI workflows to skip documentation-only changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->