### PR TITLE
Add codex skills with .claude symlink

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,19 @@
+# Claude and Codex Skills
+
+The `.claude/` directory contains repo-local configuration for Claude-based development tools. `.claude/settings.json` enables the plugins expected for this repository, and `.claude/skills` exposes the same skills that Codex uses.
+
+`skills` should be a symlink:
+
+```text
+.claude/skills -> ../.codex/skills
+```
+
+Keep `.codex/skills` as the canonical skills directory. The symlink lets Claude Desktop, Claude Code, and the Codex CLI discover the same local skill definitions, which keeps documentation and agent workflows consistent across tools.
+
+Create or refresh the symlink from the repo root if it is missing or points somewhere else:
+
+```bash
+ln -sfn ../.codex/skills .claude/skills
+```
+
+Do not replace the symlink with a copied directory. CI and contributors should treat `.claude/skills` as a pointer to the canonical skills tree; update files under `.codex/skills` when changing shared skills.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.codex/skills

--- a/.codex/skills/sync-docs-agents/SKILL.md
+++ b/.codex/skills/sync-docs-agents/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: sync-docs-agents
+description: Keep repository documentation and AGENTS.md aligned with code, design, and product changes. Use when Codex changes or reviews behavior that affects user-facing docs, developer runbooks, architecture notes, CLI/API references, setup instructions, design-system guidance, operational commands, or agent instructions; when a user asks to update docs after implementation; or when stale docs/AGENTS.md could mislead future contributors.
+---
+
+# Sync Docs and AGENTS
+
+## Overview
+
+Use this skill to decide what documentation must change after a code, design, or product update, then make those edits in the right files with verifiable links back to source behavior.
+
+## Workflow
+
+1. Identify the change surface.
+   - Inspect the diff, touched packages, new commands, config flags, UI behavior, API shapes, CRDs, generated schemas, deployment manifests, and tests.
+   - Search for existing docs before adding new files: `rg -n "<command|field|feature|concept>" README.md AGENTS.md docs website config api internal services`.
+   - Prefer updating the nearest existing guide, reference, or runbook over creating a new document.
+
+2. Classify required doc updates.
+   - User-facing product change: update README, docs guides, CLI examples, API/reference pages, screenshots or UI copy references if present.
+   - Developer workflow change: update AGENTS.md, build/test instructions, local setup notes, failure modes, environment variables, or repo map entries.
+   - Design change: update design-system rules, component guidance, UX behavior notes, or docs that describe screens/workflows.
+   - Operational change: update install, deployment, TLS, registry, Kubernetes, observability, and rollback/debug instructions.
+   - Schema/contract change: update CRD/API docs, examples, generated docs if the repo owns them, and any golden snapshots tied to CLI help.
+
+3. Verify source truth before writing.
+   - Treat code, tests, CRD types, OpenAPI specs, CLI definitions, workflow files, and manifests as source of truth.
+   - For commands and examples, confirm exact flags, defaults, resource names, paths, and environment variables from implementation.
+   - Avoid inventing roadmap promises or behavior not present in code unless the user explicitly asks for planned-product wording.
+
+4. Edit with the right scope.
+   - Keep docs concise and task-oriented; remove stale claims instead of layering caveats.
+   - Preserve the repo's voice, terminology, command style, and existing document structure.
+   - Update AGENTS.md only for durable contributor or agent guidance, not one-off implementation details.
+   - Keep examples copy-pasteable: include required tags, namespaces, paths, auth headers, and prerequisite environment variables.
+   - Update links and table-of-contents entries when adding or renaming pages.
+
+5. Validate.
+   - Run the narrowest relevant checks: markdown/docs build if available, golden tests for CLI help changes, generated-doc drift checks when docs are generated, and targeted code tests if examples exercise behavior.
+   - At minimum, run searches for old field names, commands, or stale wording that the change replaces.
+   - If validation cannot be run, state the blocker and what was manually checked.
+
+## AGENTS.md Rules
+
+Update AGENTS.md when a change affects how future agents or contributors should work in the repo. Good reasons include new required checks, changed setup commands, new failure modes, changed repository layout, new service ownership, changed CLI workflows, or new operational safety rules.
+
+Do not put product marketing, exhaustive API reference, release notes, or transient PR context in AGENTS.md. Link or summarize stable docs instead.
+
+## Output Standard
+
+When finished, summarize:
+- docs and AGENTS.md files changed
+- source behavior each update reflects
+- validation run, including searches for stale terms
+- known doc gaps left intentionally open

--- a/.codex/skills/sync-docs-agents/agents/openai.yaml
+++ b/.codex/skills/sync-docs-agents/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Sync Docs and AGENTS"
+  short_description: "Keep docs and AGENTS.md aligned with changes"
+  default_prompt: "Use $sync-docs-agents to update documentation and AGENTS.md for the recent code, design, or product changes."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ If instructions conflict, prefer **this repo** (`README`, CRDs, `v1alpha1` types
 | Traefik plugins (dev) | `services/traefik-plugins/` | e.g. PII redactor source for local overlays |
 | Site / public docs (if editing) | `website/` | Not required for control-plane work |
 | E2E | `test/e2e/`, `test/integration/` | Kind script and envtest-based integration tests |
+| Agent tool config | `.claude/`, `.codex/skills/` | `.claude/skills` should symlink to `../.codex/skills` so Claude Desktop and the Codex CLI use the same local skills |
 
 **Patterns worth mirroring:** search for similar packages before adding new abstractions; keep CLI errors consistent with `internal/cli/errors.go` and `pkg/errx/`.
 
@@ -54,6 +55,7 @@ Optional but used in CI: `staticcheck ./...` (install: `go install honnef.co/go/
 - **Tests:** Add or adjust tests in the same package when behavior changes. For CLI output, expect golden file updates.
 - **Docs you were not asked to edit:** Avoid adding new top-level docs unless the task needs them; this file, `README`, and existing doc trees are the defaults for agents.
 - **Secrets and prod:** This repo is **alpha**; do not hardcode real credentials. Use the existing secret and env patterns documented below.
+- **Agent skills:** Keep `.claude/skills` as a symlink to `../.codex/skills`; see `.claude/README.md` before changing local agent-tool configuration.
 
 ## Local dev setup (Kind and CLI)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ go vet ./...
 
 For targeted tests, e2e setup, and debugging runbooks, use [`AGENTS.md`](AGENTS.md) and the docs site.
 
+## Agent tool configuration
+
+The repo keeps Claude-specific local configuration in [`.claude/`](.claude/README.md). Its `skills` entry is expected to be a symlink to `../.codex/skills`, so Claude Desktop and the Codex CLI discover the same repository skills during local development.
+
 ## License
 
 MIT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Claude environment configuration with plugin support and unified local agent skill setup for shared tooling.
* **Documentation**
  * Added agent onboarding and repo-local configuration guidance and a documentation-sync workflow to keep docs aligned with code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->