### PR TITLE
Fix docs routes and internals onboarding

### DIFF
--- a/.codex/skills/sync-docs-agents/SKILL.md
+++ b/.codex/skills/sync-docs-agents/SKILL.md
@@ -19,6 +19,7 @@ Use this skill to decide what documentation must change after a code, design, or
 2. Classify required doc updates.
    - User-facing product change: update README, docs guides, CLI examples, API/reference pages, screenshots or UI copy references if present.
    - Developer workflow change: update AGENTS.md, build/test instructions, local setup notes, failure modes, environment variables, or repo map entries.
+   - Codebase architecture or contributor-flow change: review `docs/internals/` and decide whether the overview, package tours, or Mermaid diagrams need updates. Add or revise diagrams only when they clarify package boundaries, request flow, reconciliation flow, service interactions, or contributor decision points.
    - Design change: update design-system rules, component guidance, UX behavior notes, or docs that describe screens/workflows.
    - Operational change: update install, deployment, TLS, registry, Kubernetes, observability, and rollback/debug instructions.
    - Schema/contract change: update CRD/API docs, examples, generated docs if the repo owns them, and any golden snapshots tied to CLI help.
@@ -31,6 +32,7 @@ Use this skill to decide what documentation must change after a code, design, or
 4. Edit with the right scope.
    - Keep docs concise and task-oriented; remove stale claims instead of layering caveats.
    - Preserve the repo's voice, terminology, command style, and existing document structure.
+   - For `docs/internals/`, prefer updating the nearest existing walkthrough, mental model, or diagram over adding a new page. Use diagrams for relationships and flows, not for listing files that a table can express more clearly.
    - Update AGENTS.md only for durable contributor or agent guidance, not one-off implementation details.
    - Keep examples copy-pasteable: include required tags, namespaces, paths, auth headers, and prerequisite environment variables.
    - Update links and table-of-contents entries when adding or renaming pages.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,9 +10,9 @@ MCP Runtime is an open source, Kubernetes-native control plane for deploying, go
   <p class="docs-lead">Deploy MCP servers, expose them through governed routes, and keep policy, audit, and telemetry attached to every agent call.</p>
 
   <div class="docs-actions">
-    <a class="docs-button docs-button-primary" href="getting-started.md">Get started</a>
-    <a class="docs-button" href="architecture.md">Architecture</a>
-    <a class="docs-button" href="api.md">API reference</a>
+    <a class="docs-button docs-button-primary" href="getting-started/">Get started</a>
+    <a class="docs-button" href="architecture/">Architecture</a>
+    <a class="docs-button" href="api/">API reference</a>
   </div>
   </div>
 
@@ -32,25 +32,25 @@ MCP Runtime is an open source, Kubernetes-native control plane for deploying, go
 ## Choose a path
 
 <div class="docs-grid docs-grid-3">
-<a class="docs-card" href="getting-started.md">
+<a class="docs-card" href="getting-started/">
   <span class="docs-card-kicker">Start</span>
   <strong>Install the platform</strong>
   <span>Build the CLI, run preflight checks, install the stack, and deploy the first server.</span>
 </a>
 
-<a class="docs-card" href="architecture.md">
+<a class="docs-card" href="architecture/">
   <span class="docs-card-kicker">Understand</span>
   <strong>Read the architecture</strong>
   <span>Trace how the control plane, registry, broker, operator, and Sentinel services fit together.</span>
 </a>
 
-<a class="docs-card" href="cluster-readiness.md">
+<a class="docs-card" href="cluster-readiness/">
   <span class="docs-card-kicker">Prepare</span>
   <strong>Check your cluster</strong>
   <span>Review prerequisites for k3s, kind, minikube, Docker Desktop Kubernetes, kubeadm, and EKS.</span>
 </a>
 
-<a class="docs-card" href="publish-mcp-server.md">
+<a class="docs-card" href="publish-mcp-server/">
   <span class="docs-card-kicker">Ship</span>
   <strong>Publish an MCP server</strong>
   <span>Write a manifest or `.mcp` metadata, push an image, deploy it, and verify what the platform creates.</span>
@@ -60,25 +60,25 @@ MCP Runtime is an open source, Kubernetes-native control plane for deploying, go
 ## Operate MCP Runtime
 
 <div class="docs-grid docs-grid-2">
-<a class="docs-card" href="runtime.md">
+<a class="docs-card" href="runtime/">
   <span class="docs-card-kicker">Runtime</span>
   <strong>Control plane</strong>
   <span>CRDs, reconciliation outputs, image resolution, ingress wiring, and rollout flow.</span>
 </a>
 
-<a class="docs-card" href="sentinel.md">
+<a class="docs-card" href="sentinel/">
   <span class="docs-card-kicker">Governance</span>
   <strong>Sentinel request path</strong>
   <span>Gateway policy, grant/session evaluation, analytics, audit events, and dashboard services.</span>
 </a>
 
-<a class="docs-card" href="cli.md">
+<a class="docs-card" href="cli/">
   <span class="docs-card-kicker">CLI</span>
   <strong>Command reference</strong>
   <span>Setup, status, registry, server, access, pipeline, and Sentinel commands.</span>
 </a>
 
-<a class="docs-card" href="api.md">
+<a class="docs-card" href="api/">
   <span class="docs-card-kicker">Reference</span>
   <strong>API and CRDs</strong>
   <span><code>MCPServer</code>, access grants, sessions, gateway headers, and HTTP APIs.</span>

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,19 +1,150 @@
 # Internals
 
-Source-tree walkthroughs for contributors. These are written as line-referenced tours of the actual code in this repo and are most useful when you are reading `git blame`-adjacent or modifying the implementation.
+This section teaches the MCP Runtime codebase from the inside out. Use it when you want to modify the CLI, operator, Kubernetes API types, Sentinel services, manifests, or tests without reverse-engineering the repository from scratch.
 
-For platform usage, start with the [user docs](../README.md) instead.
+For platform usage, start with the [user docs](../README.md). For guided contributor onboarding, use the Tessl skill [codebase-onboarding-check](https://tessl.io/registry/skills/github/Agent-Hellboy/codebase-onboarding-check/codebase-onboarding-check) with this repository; it can turn these docs into comprehension checks and a contribution readiness plan.
 
-## Files
+## Mental model
 
-| File | Covers |
-|---|---|
-| [`cmd-mcp-runtime.md`](cmd-mcp-runtime.md) | CLI entrypoint (`cmd/mcp-runtime/main.go`). |
-| [`cmd-operator.md`](cmd-operator.md) | Operator entrypoint (`cmd/operator/main.go`) and `internal/operator` controller logic. |
-| [`internal-cli.md`](internal-cli.md) | Cobra command implementations under `internal/cli/`. |
-| [`pkg-metadata.md`](pkg-metadata.md) | Metadata parsing and CRD generation helpers. |
-| [`api-types.md`](api-types.md) | CRD type definitions in `api/v1alpha1`. |
-| [`config-and-examples.md`](config-and-examples.md) | Kustomize manifests, example apps, supporting scripts. |
-| [`tests.md`](tests.md) | Test layout, golden fixtures, e2e flows. |
+MCP Runtime is a Kubernetes-native control plane for MCP servers. Most changes touch one of four surfaces:
 
-> Line references match the repository at the time of writing; they are 1-based and may drift after refactors.
+1. The CLI turns user intent into Kubernetes manifests, registry actions, cluster checks, and API calls.
+2. The CRDs define the durable contract: `MCPServer`, `MCPAccessGrant`, and `MCPAgentSession`.
+3. The operator reconciles those CRDs into Deployments, Services, Ingress routes, status, and policy materialization.
+4. Sentinel services provide the runtime gateway, governance APIs, analytics ingest, processing, and UI.
+
+```mermaid
+flowchart LR
+    User[User or automation] --> CLI[mcp-runtime CLI]
+    CLI --> K8s[Kubernetes API]
+    CLI --> Registry[Container registry]
+    K8s --> CRDs[MCP Runtime CRDs]
+    CRDs --> Operator[Operator controller]
+    Operator --> Workloads[MCP server Deployments and Services]
+    Operator --> Ingress[Ingress and gateway routes]
+    Operator --> Policy[Grant/session policy state]
+    Client[MCP client] --> Gateway[Sentinel gateway]
+    Gateway --> Policy
+    Gateway --> Workloads
+    Gateway --> Ingest[Analytics ingest]
+    Ingest --> Processor[Processor]
+    Processor --> Store[(ClickHouse/Postgres)]
+    UI[Sentinel UI] --> API[Sentinel API]
+    API --> K8s
+    API --> Store
+```
+
+## Repository map
+
+| Area | Start here | Why it matters |
+|---|---|---|
+| CLI entrypoint | [`cmd-mcp-runtime.md`](cmd-mcp-runtime.md) | Shows how the binary starts, wires Cobra commands, and reports errors. |
+| CLI implementation | [`internal-cli.md`](internal-cli.md) | Covers setup, bootstrap, registry, server, access, status, sentinel, auth, and pipeline commands. |
+| Kubernetes API types | [`api-types.md`](api-types.md) | Defines the public CRD shapes consumed by users, tests, and the operator. |
+| Operator | [`cmd-operator.md`](cmd-operator.md) | Explains manager startup and reconciliation from desired state to Kubernetes resources. |
+| Metadata helpers | [`pkg-metadata.md`](pkg-metadata.md) | Covers `.mcp` metadata loading, host resolution, and CRD generation helpers. |
+| Manifests and examples | [`config-and-examples.md`](config-and-examples.md) | Explains Kustomize overlays, registry/ingress config, and example MCP servers. |
+| Tests | [`tests.md`](tests.md) | Maps unit, golden, integration, and Kind e2e coverage. |
+
+## Control-plane flow
+
+A normal deployment starts in the CLI, passes through the Kubernetes API, and is completed by reconciliation.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CLI as mcp-runtime CLI
+    participant K as Kubernetes API
+    participant O as Operator
+    participant R as Registry
+    participant W as Workloads
+
+    U->>CLI: setup / server apply / pipeline deploy
+    CLI->>K: apply CRDs, manifests, MCPServer
+    CLI->>R: build or push images when requested
+    K-->>O: watch MCPServer changes
+    O->>K: create or update Deployment, Service, Ingress
+    O->>K: update MCPServer status
+    K-->>CLI: status and resource queries
+    O-->>W: desired state becomes running pods
+```
+
+When changing this path, check the relevant CLI command, the `api/v1alpha1` contract, the operator reconciliation code, and at least one test that proves the generated or reconciled resource shape.
+
+## Runtime request flow
+
+At request time, clients do not call server pods directly. Traffic flows through the gateway, which checks grants and sessions before forwarding MCP JSON-RPC calls.
+
+```mermaid
+flowchart TD
+    Client[MCP client] --> Route[Ingress route]
+    Route --> Gateway[Sentinel gateway or proxy]
+    Gateway --> Authz[Grant/session evaluation]
+    Authz -->|allow| Server[MCP server pod]
+    Authz -->|deny| Deny[JSON-RPC error]
+    Gateway --> Events[Audit and analytics event]
+    Events --> Ingest[services/ingest]
+    Ingest --> Processor[services/processor]
+    Processor --> Analytics[(analytics store)]
+    API[services/api] --> Grants[MCPAccessGrant]
+    API --> Sessions[MCPAgentSession]
+    Grants --> Authz
+    Sessions --> Authz
+```
+
+Governance-related changes usually span `api/v1alpha1/access_types.go`, `pkg/access/`, `services/api`, `services/mcp-proxy`, `services/ingest`, and the e2e policy scenarios.
+
+## Package dependency guide
+
+```mermaid
+flowchart TB
+    Cmd[cmd/mcp-runtime] --> InternalCLI[internal/cli]
+    InternalCLI --> Metadata[pkg/metadata]
+    InternalCLI --> Manifest[pkg/manifest]
+    InternalCLI --> K8sClient[pkg/k8sclient]
+    InternalCLI --> Access[pkg/access]
+    CmdOp[cmd/operator] --> Operator[internal/operator]
+    Operator --> API[api/v1alpha1]
+    Operator --> K8sClient
+    Operator --> Manifest
+    Operator --> Access
+    Services[services/*] --> ServiceUtil[pkg/serviceutil]
+    Services --> Access
+    Services --> ClickHouse[pkg/clickhouse]
+    Metadata --> API
+```
+
+Keep shared behavior in `pkg/` only when multiple binaries or services need it. CLI-only behavior belongs in `internal/cli`; reconciliation behavior belongs in `internal/operator`; HTTP service glue belongs near the service that owns the endpoint.
+
+## Learning path
+
+1. Read [API types](api-types.md) first. The CRDs are the contract that every other subsystem follows.
+2. Read [CLI internals](internal-cli.md) and [cmd/mcp-runtime](cmd-mcp-runtime.md) to see how users create, inspect, and deploy resources.
+3. Read [operator internals](cmd-operator.md) to understand how `MCPServer` state becomes Kubernetes workloads and ingress.
+4. Read [config and examples](config-and-examples.md), then run or inspect the example server manifests.
+5. Read [tests](tests.md) before making changes; it shows the fastest feedback loop and the broader CI safety net.
+6. Use the Tessl [codebase-onboarding-check skill](https://tessl.io/registry/skills/github/Agent-Hellboy/codebase-onboarding-check/codebase-onboarding-check) to quiz yourself on the architecture, identify weak spots, and produce a focused contribution plan.
+
+## Change playbooks
+
+| Change | Read first | Verify with |
+|---|---|---|
+| Add or change a CLI flag | `internal/cli`, `cmd/mcp-runtime`, golden CLI tests | `go test ./internal/cli/... ./test/golden/... -count=1` |
+| Change a CRD field | `api/v1alpha1`, CRD YAML, operator reconciliation, docs/API reference | `go test ./api/v1alpha1/... ./internal/operator/... -count=1` |
+| Change generated manifests | `pkg/metadata`, `pkg/manifest`, `config/`, examples | targeted package tests plus manifest diff review |
+| Change reconciliation behavior | `internal/operator`, API types, k8s helpers | `go test ./internal/operator/... -race -count=1` |
+| Change governance policy | `pkg/access`, `services/api`, `services/mcp-proxy`, access CRDs | targeted service tests plus e2e policy scenario |
+| Change docs site behavior | `docs/mkdocs.yml`, `docs/nginx.conf`, Markdown pages | MkDocs build or docs container build |
+
+## Contributor checklist
+
+Before opening a change, confirm:
+
+- The code follows the closest existing package pattern.
+- Public behavior is reflected in `docs/`, `README.md`, or `AGENTS.md` when relevant.
+- CRD changes update both Go types and generated YAML.
+- CLI help changes update golden snapshots intentionally.
+- Narrow tests pass for touched packages.
+- Full `go test ./... -count=1 -race` is run before merge when the change touches shared behavior.
+
+> Line references in the linked internals pages match the repository at the time of writing; they are 1-based and may drift after refactors.

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -55,6 +55,18 @@ http {
             try_files $uri $uri/ =404;
         }
 
+        location = /README.md {
+            return 301 /;
+        }
+
+        location ~ ^/(.+)/README\.md$ {
+            return 301 /$1/;
+        }
+
+        location ~ ^/(.+)\.md$ {
+            return 301 /$1/;
+        }
+
         location = /404.html {
             internal;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured internal architecture documentation with comprehensive mental models, deployment reconciliation diagrams, and contributor guidance
  * Updated main documentation navigation links to use directory-style routing instead of markdown filenames
  * Implemented URL canonicalization to redirect markdown URLs to their directory equivalents for improved navigation consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->