### PR TITLE
[codex] clarify platform positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![Coverage](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Agent-Hellboy/mcp-runtime)](https://goreportcard.com/report/github.com/Agent-Hellboy/mcp-runtime)
 
-MCP Runtime is a self-hosted Kubernetes control plane for internal Model Context Protocol servers. It provides declarative MCP server deployment, registry workflows, operator reconciliation, request-path governance, access/session resources, audit, analytics, dashboards, and a platform UI for browsing and operating MCP servers.
+MCP Runtime is a self-hosted Kubernetes control plane for internal Model Context Protocol servers. It provides declarative MCP server deployment, registry workflows, operator reconciliation, request-path governance, access/session resources, audit, analytics, dashboards, and a platform control surface for operating MCP servers.
 
-The public platform at `platform.mcpruntime.org` is a live preview of the deployable platform experience. It is not a listing site for selling third-party products. Companies can deploy the same model in their own Kubernetes clusters and operate it through both the CLI and the platform UI.
+The public platform at `platform.mcpruntime.org` is a live preview of the deployable platform experience. It is not a public or private marketplace for MCP servers. Companies can deploy the same model in their own Kubernetes clusters and use it to host, manage, govern, and audit MCP servers for agents, IDEs, and direct human workflows.
 
 - Website: https://mcpruntime.org/
-- Platform: https://platform.mcpruntime.org/ for a preview of the platform control surface; companies can deploy the same platform model in their own clusters
+- Platform: https://platform.mcpruntime.org/ for a preview of the platform control surface; companies can deploy the same model in their own clusters
 - Docs: https://docs.mcpruntime.org/ and [`docs/`](docs/)
 - API reference: https://docs.mcpruntime.org/api and [`docs/api.md`](docs/api.md)
 
@@ -30,16 +30,16 @@ The public platform at `platform.mcpruntime.org` is a live preview of the deploy
 
 ## How it differs from MCP directories
 
-Public MCP directories and catalogs such as Glama, Smithery, Docker MCP Catalog, PulseMCP, mcp.so, and client-specific catalogs are useful discovery and installation surfaces. MCP Runtime is different: it is a deployable operating layer for MCP servers, not a listing business.
+Public MCP directories and catalogs such as Glama, Smithery, Docker MCP Catalog, PulseMCP, mcp.so, and client-specific catalogs are useful discovery and installation surfaces. MCP Runtime is different: it is a deployable operating layer for running MCP servers inside a company's own environment. It can provide an internal catalog-like view, but the main product is deployment, governance, brokered access, audit, compliance evidence, and day-two operations.
 
 | Public MCP directory or catalog | MCP Runtime |
 |---|---|
-| Helps users find or install public MCP servers | Helps companies deploy, approve, broker, observe, and audit internal MCP servers |
-| Optimizes for discovery metadata, popularity, and install snippets | Optimizes for runtime governance, Kubernetes reconciliation, policy, sessions, and audit |
+| Helps users find or install public MCP servers | Helps companies host, deploy, govern, observe, and audit their own MCP servers |
+| Optimizes for discovery metadata, popularity, and install snippets | Optimizes for deployment, runtime governance, Kubernetes reconciliation, policy, sessions, audit, and compliance |
 | Usually runs as a third-party hosted directory or client feature | Runs in the company's Kubernetes environment or in a hosted preview shape |
 | Stops at configuration or connection | Owns the governed request path through the broker/gateway |
 
-We have not found another open source MCP product that combines server discovery, deployable Kubernetes control plane, registry workflow, broker, access model, and audit path in one package.
+As of April 2026, we have not found another open-source MCP product that combines a deployable Kubernetes control plane, registry workflow, brokered request path, access/session model, audit path, and operational UI in one package.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Coverage](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Agent-Hellboy/mcp-runtime)](https://goreportcard.com/report/github.com/Agent-Hellboy/mcp-runtime)
 
-MCP Runtime is a self-hosted Kubernetes control plane for internal Model Context Protocol servers. It provides declarative MCP server deployment, registry workflows, operator reconciliation, request-path governance, access/session resources, audit, analytics, dashboards, and a platform control surface for operating MCP servers.
+MCP Runtime is a self-hosted Kubernetes control plane for internal Model Context Protocol servers. It provides declarative MCP server deployment, registry workflows, operator reconciliation, request-path governance, access/session resources, audit, analytics, dashboards, and a platform control surface for browsing and operating MCP servers.
 
-The public platform at `platform.mcpruntime.org` is a live preview of the deployable platform experience. It is not a public or private marketplace for MCP servers. Companies can deploy the same model in their own Kubernetes clusters and use it to host, manage, govern, and audit MCP servers for agents, IDEs, and direct human workflows.
+The public platform at `platform.mcpruntime.org` is a live preview of the deployable platform experience. It is not a public or private marketplace for MCP servers. Companies can deploy the same model in their own Kubernetes clusters, then host, manage, govern, and audit MCP servers through both the CLI and the platform control surface for agents, IDEs, and direct human workflows.
 
 - Website: https://mcpruntime.org/
 - Platform: https://platform.mcpruntime.org/ for a preview of the platform control surface; companies can deploy the same model in their own clusters
@@ -39,7 +39,7 @@ Public MCP directories and catalogs such as Glama, Smithery, Docker MCP Catalog,
 | Usually runs as a third-party hosted directory or client feature | Runs in the company's Kubernetes environment or in a hosted preview shape |
 | Stops at configuration or connection | Owns the governed request path through the broker/gateway |
 
-As of April 2026, we have not found another open-source MCP product that combines a deployable Kubernetes control plane, registry workflow, brokered request path, access/session model, audit path, and operational UI in one package.
+As of April 2026, we have not found another open-source MCP product that combines a deployable Kubernetes control plane, registry workflow, brokered request path, access/session model, audit pipeline, and operational control surface in one package.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![Coverage](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Agent-Hellboy/mcp-runtime)](https://goreportcard.com/report/github.com/Agent-Hellboy/mcp-runtime)
 
-MCP Runtime is a self-hosted Kubernetes control plane for internal Model Context Protocol servers. It provides declarative MCP server deployment, registry workflows, operator reconciliation, request-path governance, access/session resources, audit, analytics, dashboards, and a marketplace-style platform surface for browsing and operating MCP servers.
+MCP Runtime is a self-hosted Kubernetes control plane for internal Model Context Protocol servers. It provides declarative MCP server deployment, registry workflows, operator reconciliation, request-path governance, access/session resources, audit, analytics, dashboards, and a platform UI for browsing and operating MCP servers.
 
-The public platform at `platform.mcpruntime.org` shows the hosted experience. Companies can deploy the same model in their own Kubernetes clusters and operate it through both the CLI and the platform UI.
+The public platform at `platform.mcpruntime.org` is a live preview of the deployable platform experience. It is not a listing site for selling third-party products. Companies can deploy the same model in their own Kubernetes clusters and operate it through both the CLI and the platform UI.
 
 - Website: https://mcpruntime.org/
-- Platform: https://platform.mcpruntime.org/ for the public marketplace-style experience; companies can deploy the same platform model in their own clusters
+- Platform: https://platform.mcpruntime.org/ for a preview of the platform control surface; companies can deploy the same platform model in their own clusters
 - Docs: https://docs.mcpruntime.org/ and [`docs/`](docs/)
 - API reference: https://docs.mcpruntime.org/api and [`docs/api.md`](docs/api.md)
 
@@ -27,6 +27,19 @@ The public platform at `platform.mcpruntime.org` shows the hosted experience. Co
 - Internal or provisioned registry workflows
 - Optional gateway enforcement for identity, tool policy, trust, and audit emission
 - Bundled Sentinel stack for ingest, processing, API, UI, and observability
+
+## How it differs from MCP directories
+
+Public MCP directories and catalogs such as Glama, Smithery, Docker MCP Catalog, PulseMCP, mcp.so, and client-specific catalogs are useful discovery and installation surfaces. MCP Runtime is different: it is a deployable operating layer for MCP servers, not a listing business.
+
+| Public MCP directory or catalog | MCP Runtime |
+|---|---|
+| Helps users find or install public MCP servers | Helps companies deploy, approve, broker, observe, and audit internal MCP servers |
+| Optimizes for discovery metadata, popularity, and install snippets | Optimizes for runtime governance, Kubernetes reconciliation, policy, sessions, and audit |
+| Usually runs as a third-party hosted directory or client feature | Runs in the company's Kubernetes environment or in a hosted preview shape |
+| Stops at configuration or connection | Owns the governed request path through the broker/gateway |
+
+We have not found another open source MCP product that combines server discovery, deployable Kubernetes control plane, registry workflow, broker, access model, and audit path in one package.
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,15 @@
 # MCP Runtime
 
-MCP Runtime is an open source, Kubernetes-native control plane for deploying, governing, and brokering MCP servers. It packages server deployment, registry workflows, gateway routing, access policy, audit evidence, and observability into one operating surface for platform, security, and compliance teams.
+MCP Runtime is an open-source, Kubernetes-native control plane for deploying, governing, and brokering MCP servers. It packages server deployment, registry workflows, gateway routing, access policy, audit evidence, and observability into one operating surface for platform, security, and compliance teams.
 
 Unlike public MCP directories or client-specific catalogs, MCP Runtime is not
-just a place to discover servers. The UI is the front door to a deployable
-platform: internal server catalog, Kubernetes reconciliation, registry workflow,
-brokered tool calls, access grants, consented sessions, audit, and operational
+just a place to discover servers, and it is not a marketplace for MCP listings.
+The platform control surface is the front door to a deployable runtime:
+Kubernetes reconciliation, registry workflow, brokered tool calls, access
+grants, consented sessions, audit, compliance evidence, and operational
 visibility. The hosted platform shows what that experience looks like; companies
-can run the same model inside their own clusters.
+can run the same model inside their own clusters for agents, IDEs, and direct
+human workflows.
 
 <div class="docs-home">
 <section class="docs-hero">
@@ -51,19 +53,20 @@ ingest and processing, dashboard/API services, and observability components.
 Top MCP directories and catalogs such as Glama, Smithery, Docker MCP Catalog,
 PulseMCP, mcp.so, and client-specific catalogs are useful for public discovery,
 metadata, install snippets, or client onboarding. MCP Runtime is different: it
-is an open source control plane for operating governed MCP servers inside a
+is an open-source control plane for operating governed MCP servers inside a
 company environment.
 
 | Others usually provide | MCP Runtime provides |
 |---|---|
-| Public discovery and categories | Internal server catalog plus deployable runtime |
+| Public discovery and categories | Deployable runtime plus an internal server view when teams need one |
 | Install snippets and connection docs | Kubernetes `MCPServer` reconciliation and routes |
-| Popularity or metadata signals | Trust, grants, sessions, policy decisions, and audit |
+| Popularity or metadata signals | Trust, grants, sessions, policy decisions, audit, and compliance evidence |
 | Hosted directory or client-specific UX | Self-hosted, vendor-neutral Kubernetes control plane |
 
-We have not found another open source MCP product that combines server
-discovery with the deployable Kubernetes operator, registry workflow, brokered
-request path, access/session model, and audit pipeline in one system.
+As of April 2026, we have not found another open-source MCP product that
+combines a deployable Kubernetes operator, registry workflow, brokered request
+path, access/session model, audit pipeline, and operational control surface in
+one system.
 
 ## Governance, audit, and compliance
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,13 @@
 
 MCP Runtime is an open source, Kubernetes-native control plane for deploying, governing, and brokering MCP servers. It packages server deployment, registry workflows, gateway routing, access policy, audit evidence, and observability into one operating surface for platform, security, and compliance teams.
 
+Unlike public MCP directories or client-specific catalogs, MCP Runtime is not
+just a place to discover servers. The UI is the front door to a deployable
+platform: internal server catalog, Kubernetes reconciliation, registry workflow,
+brokered tool calls, access grants, consented sessions, audit, and operational
+visibility. The hosted platform shows what that experience looks like; companies
+can run the same model inside their own clusters.
+
 <div class="docs-home">
 <section class="docs-hero">
   <div class="docs-hero-copy">
@@ -38,6 +45,25 @@ MCP Runtime is an open source, Kubernetes-native control plane for deploying, go
 integration, ingress wiring, and the bundled Sentinel stack. Sentinel includes
 the gateway request path, grant/session policy materialization, analytics
 ingest and processing, dashboard/API services, and observability components.
+
+## Compared with MCP directories
+
+Top MCP directories and catalogs such as Glama, Smithery, Docker MCP Catalog,
+PulseMCP, mcp.so, and client-specific catalogs are useful for public discovery,
+metadata, install snippets, or client onboarding. MCP Runtime is different: it
+is an open source control plane for operating governed MCP servers inside a
+company environment.
+
+| Others usually provide | MCP Runtime provides |
+|---|---|
+| Public discovery and categories | Internal server catalog plus deployable runtime |
+| Install snippets and connection docs | Kubernetes `MCPServer` reconciliation and routes |
+| Popularity or metadata signals | Trust, grants, sessions, policy decisions, and audit |
+| Hosted directory or client-specific UX | Self-hosted, vendor-neutral Kubernetes control plane |
+
+We have not found another open source MCP product that combines server
+discovery with the deployable Kubernetes operator, registry workflow, brokered
+request path, access/session model, and audit pipeline in one system.
 
 ## Governance, audit, and compliance
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,11 +49,10 @@ platform looks after deployment. It is not a place for companies to list or sell
 products; it is a way to evaluate the governed control-plane model before
 installing it.
 
-As of April 2026, based on the currently visible open-source MCP ecosystem, MCP
-Runtime appears to fill a gap: an open-source MCP platform that combines a
-deployable Kubernetes runtime, brokered request path, access/session model,
-registry workflow, audit pipeline, and operational control surface in one
-system.
+As of April 2026, we have not found another open-source MCP product that
+combines a deployable Kubernetes runtime, registry workflow, brokered request
+path, access/session model, audit pipeline, and operational control surface in
+one system.
 
 ## Control Plane
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,28 +30,30 @@ flowchart LR
 
 ## Market Position
 
-MCP Runtime should be compared with MCP directories and catalogs, but it is not
-trying to be a listing site. Products such as Glama, Smithery, Docker MCP Catalog,
-PulseMCP, mcp.so, and client-specific catalogs are strongest at public
-discovery, metadata, installation snippets, or client onboarding. MCP Runtime
-uses a platform UI as the front door to a deployable runtime platform.
+MCP Runtime can be compared with MCP directories and catalogs, but it is not
+trying to be a listing site or marketplace. Products such as Glama, Smithery,
+Docker MCP Catalog, PulseMCP, mcp.so, and client-specific catalogs are strongest
+at public discovery, metadata, installation snippets, or client onboarding. MCP
+Runtime uses a platform control surface as the front door to a deployable
+runtime platform.
 
 | Market category | Typical scope | MCP Runtime difference |
 |---|---|---|
-| Public MCP directories | Search, categories, public server metadata, install snippets. | Adds a deployable Kubernetes control plane, internal server catalog, registry workflow, broker, policy, and audit path. |
+| Public MCP directories | Search, categories, public server metadata, install snippets. | Adds a deployable Kubernetes control plane, registry workflow, broker, policy, audit path, and operational control surface. |
 | Client catalogs | One-click install inside a specific MCP client. | Stays client-neutral and governs server access before tool calls reach the workload. |
 | Hosted registry/control-plane products | Hosted discovery, connectors, gateway, or publisher workflows. | Can run in the company's cluster with CRDs, operator reconciliation, and private infrastructure ownership. |
-| Container/catalog products | Trusted images, runtime packaging, and client connection profiles. | Extends beyond packaging into access grants, consented sessions, policy decisions, and compliance-oriented event history. |
+| Container/catalog products | Trusted images, runtime packaging, and client connection profiles. | Extends beyond packaging into access grants, consented sessions, policy decisions, audit evidence, and compliance-oriented event history. |
 
 The public `platform.mcpruntime.org` surface is therefore a preview of how the
 platform looks after deployment. It is not a place for companies to list or sell
 products; it is a way to evaluate the governed control-plane model before
 installing it.
 
-Based on the currently visible open source MCP ecosystem, MCP Runtime appears to
-fill a gap: an open source MCP platform that combines server discovery with the
+As of April 2026, based on the currently visible open-source MCP ecosystem, MCP
+Runtime appears to fill a gap: an open-source MCP platform that combines a
 deployable Kubernetes runtime, brokered request path, access/session model,
-registry workflow, and audit pipeline in one system.
+registry workflow, audit pipeline, and operational control surface in one
+system.
 
 ## Control Plane
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,31 @@ flowchart LR
 | Sentinel | Audit, analytics, API, UI, and operational visibility for governed MCP traffic. |
 | Infrastructure | Kubernetes-native routing, TLS/DNS integration, namespaces, services, and ingress ownership. |
 
+## Market Position
+
+MCP Runtime should be compared with MCP directories and catalogs, but it is not
+trying to be a listing site. Products such as Glama, Smithery, Docker MCP Catalog,
+PulseMCP, mcp.so, and client-specific catalogs are strongest at public
+discovery, metadata, installation snippets, or client onboarding. MCP Runtime
+uses a platform UI as the front door to a deployable runtime platform.
+
+| Market category | Typical scope | MCP Runtime difference |
+|---|---|---|
+| Public MCP directories | Search, categories, public server metadata, install snippets. | Adds a deployable Kubernetes control plane, internal server catalog, registry workflow, broker, policy, and audit path. |
+| Client catalogs | One-click install inside a specific MCP client. | Stays client-neutral and governs server access before tool calls reach the workload. |
+| Hosted registry/control-plane products | Hosted discovery, connectors, gateway, or publisher workflows. | Can run in the company's cluster with CRDs, operator reconciliation, and private infrastructure ownership. |
+| Container/catalog products | Trusted images, runtime packaging, and client connection profiles. | Extends beyond packaging into access grants, consented sessions, policy decisions, and compliance-oriented event history. |
+
+The public `platform.mcpruntime.org` surface is therefore a preview of how the
+platform looks after deployment. It is not a place for companies to list or sell
+products; it is a way to evaluate the governed control-plane model before
+installing it.
+
+Based on the currently visible open source MCP ecosystem, MCP Runtime appears to
+fill a gap: an open source MCP platform that combines server discovery with the
+deployable Kubernetes runtime, brokered request path, access/session model,
+registry workflow, and audit pipeline in one system.
+
 ## Control Plane
 
 The CLI owns workstation and cluster workflows: dependency checks, bootstrap preflights, setup, registry operations, manifest generation, and access-management commands. It writes Kubernetes resources rather than running the data path itself.

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -12,9 +12,10 @@
       </p>
       <p class="lede">
         The public entrypoint at <a href="{{ platform_url }}">platform.mcpruntime.org</a>
-        shows the marketplace-style experience. When a company deploys MCP Runtime in its
-        own cluster, it gets that same platform model on infrastructure it controls across
-        vendor-neutral Kubernetes distributions.
+        is not a listing site or sales catalog. It is a live preview of the control
+        surface companies get when they deploy MCP Runtime in their own cluster:
+        private discovery, governed access, brokered execution, and audit on infrastructure
+        they control.
       </p>
       <div class="hero-actions" aria-label="Primary actions">
         <a class="button primary" href="{{ platform_url }}">Open hosted platform</a>
@@ -121,7 +122,7 @@ spec:
       </article>
       <article class="feature-card">
         <h3>Hosted platform shape</h3>
-        <p>The public <code>platform.mcpruntime.org</code> experience works like a shared MCP marketplace, and the same surface can be deployed privately per company cluster.</p>
+        <p>The public <code>platform.mcpruntime.org</code> experience shows how the private platform looks after deployment. It is a product preview, not a vendor storefront or listing site.</p>
       </article>
       <article class="feature-card">
         <h3>Brokered tool calls</h3>
@@ -142,9 +143,38 @@ spec:
     </div>
   </section>
 
+  <section class="container pillars" aria-labelledby="market-title">
+    <div class="section-heading span-two">
+      <span class="section-label">04 / Market Position</span>
+      <h2 id="market-title">Not another public MCP directory.</h2>
+      <p>
+        Public MCP directories such as Glama, Smithery, Docker MCP Catalog, PulseMCP,
+        mcp.so, and client-specific catalogs help people discover or install MCP servers.
+        MCP Runtime is different: it is an open source runtime platform for companies that
+        need to deploy, approve, broker, observe, and audit MCP servers inside their own
+        Kubernetes environment.
+      </p>
+    </div>
+    <article>
+      <span class="card-index">D</span>
+      <h3>Discovery plus control</h3>
+      <p>Browse MCP servers, but keep routing, policy, grants, sessions, and audit attached to the same operating surface.</p>
+    </article>
+    <article>
+      <span class="card-index">E</span>
+      <h3>Open source runtime</h3>
+      <p>We have not found another open source MCP product that combines discovery with the deployable control plane, broker, registry workflow, and Kubernetes operator.</p>
+    </article>
+    <article>
+      <span class="card-index">F</span>
+      <h3>Private by design</h3>
+      <p>Companies can run the same platform experience internally so teams discover approved servers without depending on a third-party control plane.</p>
+    </article>
+  </section>
+
   <section class="container runbook" aria-labelledby="runbook-title">
     <div class="section-heading">
-      <span class="section-label">04 / Runbook</span>
+      <span class="section-label">05 / Runbook</span>
       <h2 id="runbook-title">Install the stack, then connect servers.</h2>
     </div>
     <ol class="runbook-steps">
@@ -169,7 +199,7 @@ spec:
 
   <section class="container use-cases" aria-labelledby="use-cases-title">
     <div class="section-heading">
-      <span class="section-label">05 / Use Cases</span>
+      <span class="section-label">06 / Use Cases</span>
       <h2 id="use-cases-title">Where companies put it to work.</h2>
     </div>
     <div class="use-cases-grid">
@@ -182,8 +212,8 @@ spec:
         <p>Give teams a shared place to publish, discover, and operate MCP servers instead of one-off sidecars.</p>
       </article>
       <article class="use-case">
-        <h3>Private MCP marketplace</h3>
-        <p>Mirror the public platform experience inside a company cluster so teams browse approved MCP servers without depending on a third-party control plane.</p>
+        <h3>Private platform preview</h3>
+        <p>Use the public platform to understand the deployed product, then run the same control surface inside a company cluster for approved internal servers.</p>
       </article>
       <article class="use-case">
         <h3>Cross-team governance</h3>
@@ -198,7 +228,7 @@ spec:
 
   <section class="container platforms" aria-labelledby="platforms-title">
     <div class="section-heading compact">
-      <span class="section-label">06 / Targets</span>
+      <span class="section-label">07 / Targets</span>
       <h2 id="platforms-title">Runs where your company already runs Kubernetes.</h2>
       <p>Kubernetes 1.25+. Self-hosted. Open source. Vendor-neutral across Kubernetes distributions. No proprietary control plane.</p>
     </div>
@@ -216,8 +246,8 @@ spec:
 
   <section class="container cta-band" aria-labelledby="cta-title">
     <span class="section-label">Next action</span>
-    <h2 id="cta-title">Try the hosted platform, then run the same model yourself.</h2>
-    <p>Open the public platform, then install MCP Runtime in your own cluster to give your company the same marketplace-style control surface with private infrastructure underneath.</p>
+    <h2 id="cta-title">Preview the platform, then run it yourself.</h2>
+    <p>Open the public platform to see the control surface. Install MCP Runtime to give your company that same experience on private infrastructure, with governance and audit built into the runtime path.</p>
     <div class="hero-actions">
       <a class="button primary" href="{{ platform_url }}">Open platform.mcpruntime.org</a>
       <a class="button primary" href="{{ docs_url }}getting-started/">Open install guide</a>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -164,7 +164,7 @@ spec:
     <article>
       <span class="card-index">E</span>
       <h3>Open source runtime</h3>
-      <p>As of April 2026, we have not found another open-source MCP product that combines a deployable control plane, brokered request path, access/session model, audit pipeline, registry workflow, and Kubernetes operator.</p>
+      <p>As of April 2026, we have not found another open-source MCP product that combines a deployable Kubernetes control plane, registry workflow, brokered request path, access/session model, audit pipeline, and operational control surface.</p>
     </article>
     <article>
       <span class="card-index">F</span>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -8,14 +8,15 @@
       <p class="lede">
         MCP Runtime gives platform teams one place to deploy, route, govern, and observe
         Model Context Protocol servers. Define services once, enforce policy on the live
-        request path, and give AI agents a controlled way to reach internal tools.
+        request path, and give AI agents, IDE users, and direct human workflows a
+        controlled way to reach internal tools.
       </p>
       <p class="lede">
         The public entrypoint at <a href="{{ platform_url }}">platform.mcpruntime.org</a>
-        is not a listing site or sales catalog. It is a live preview of the control
+        is not a public or private marketplace. It is a live preview of the control
         surface companies get when they deploy MCP Runtime in their own cluster:
-        private discovery, governed access, brokered execution, and audit on infrastructure
-        they control.
+        easy deployment, governed access, brokered execution, audit, compliance
+        evidence, and operations on infrastructure they control.
       </p>
       <div class="hero-actions" aria-label="Primary actions">
         <a class="button primary" href="{{ platform_url }}">Open hosted platform</a>
@@ -122,7 +123,7 @@ spec:
       </article>
       <article class="feature-card">
         <h3>Hosted platform shape</h3>
-        <p>The public <code>platform.mcpruntime.org</code> experience shows how the private platform looks after deployment. It is a product preview, not a vendor storefront or listing site.</p>
+        <p>The public <code>platform.mcpruntime.org</code> experience shows how the platform looks after deployment. It is a product preview, not a vendor storefront, listing site, or MCP marketplace.</p>
       </article>
       <article class="feature-card">
         <h3>Brokered tool calls</h3>
@@ -145,30 +146,30 @@ spec:
 
   <section class="container pillars" aria-labelledby="market-title">
     <div class="section-heading span-two">
-      <span class="section-label">04 / Market Position</span>
-      <h2 id="market-title">Not another public MCP directory.</h2>
+      <span class="section-label">04 / Position</span>
+      <h2 id="market-title">More than discovery.</h2>
       <p>
         Public MCP directories such as Glama, Smithery, Docker MCP Catalog, PulseMCP,
         mcp.so, and client-specific catalogs help people discover or install MCP servers.
-        MCP Runtime is different: it is an open source runtime platform for companies that
-        need to deploy, approve, broker, observe, and audit MCP servers inside their own
-        Kubernetes environment.
+        MCP Runtime is different: it is an open-source runtime platform for companies
+        that need to host, deploy, govern, audit, and operate MCP servers inside their
+        own Kubernetes environment.
       </p>
     </div>
     <article>
       <span class="card-index">D</span>
-      <h3>Discovery plus control</h3>
-      <p>Browse MCP servers, but keep routing, policy, grants, sessions, and audit attached to the same operating surface.</p>
+      <h3>Deployment first</h3>
+      <p>Define MCP servers as Kubernetes resources and let the platform handle routes, rollouts, registry wiring, and status.</p>
     </article>
     <article>
       <span class="card-index">E</span>
       <h3>Open source runtime</h3>
-      <p>We have not found another open source MCP product that combines discovery with the deployable control plane, broker, registry workflow, and Kubernetes operator.</p>
+      <p>As of April 2026, we have not found another open-source MCP product that combines a deployable control plane, brokered request path, access/session model, audit pipeline, registry workflow, and Kubernetes operator.</p>
     </article>
     <article>
       <span class="card-index">F</span>
-      <h3>Private by design</h3>
-      <p>Companies can run the same platform experience internally so teams discover approved servers without depending on a third-party control plane.</p>
+      <h3>Governed by design</h3>
+      <p>Companies can manage MCP access for agents, IDEs, and humans with grants, sessions, policy decisions, and audit evidence.</p>
     </article>
   </section>
 
@@ -208,12 +209,12 @@ spec:
         <p>Expose internal tools to agents with controlled access, request inspection, and audit trails.</p>
       </article>
       <article class="use-case">
-        <h3>Internal MCP catalog</h3>
-        <p>Give teams a shared place to publish, discover, and operate MCP servers instead of one-off sidecars.</p>
+        <h3>Internal MCP operations</h3>
+        <p>Give teams a shared control surface to publish, operate, govern, and inspect MCP servers instead of one-off sidecars.</p>
       </article>
       <article class="use-case">
         <h3>Private platform preview</h3>
-        <p>Use the public platform to understand the deployed product, then run the same control surface inside a company cluster for approved internal servers.</p>
+        <p>Use the public platform to understand the deployed product, then run the same control surface inside a company cluster for owned MCP servers.</p>
       </article>
       <article class="use-case">
         <h3>Cross-team governance</h3>


### PR DESCRIPTION
## Summary

- Reframes the public platform as a preview of the deployable MCP Runtime control surface, not a listing site or sales catalog.
- Adds comparison language against public MCP directories/catalogs while preserving MCP Runtime's positioning as a deployable Kubernetes runtime platform.
- Updates website and docs copy to emphasize internal server catalog, brokered request path, access/session governance, and audit.

## Validation

- `git diff --check`
- Commit hooks during `git commit` passed: go fmt skipped, staticcheck passed, go vet passed, go doc package reference drift skipped.
- `python3 -m mkdocs build --config-file docs/mkdocs.yml --strict` could not run locally because `mkdocs` is not installed.

## Notes

The branch was pushed from local git because SSH auth worked. Local `gh auth status` reports an invalid GitHub CLI token, so PR creation used the GitHub connector instead of `gh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP Runtime positioning as an internal deployable platform rather than a marketplace
  * Added comprehensive comparison with public MCP directories highlighting governance, audit, and control-plane capabilities
  * Repositioned platform.mcpruntime.org as a live preview for internal deployment evaluation
  * Updated messaging across website and documentation to emphasize governed access and observability features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->