### PR TITLE
fix(config): harden least privilege defaults

### DIFF
--- a/.codex/skills/repo-guidance-sync/SKILL.md
+++ b/.codex/skills/repo-guidance-sync/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: sync-docs-agents
-description: Keep repository documentation and AGENTS.md aligned with code, design, and product changes. Use when Codex changes or reviews behavior that affects user-facing docs, developer runbooks, architecture notes, CLI/API references, setup instructions, design-system guidance, operational commands, or agent instructions; when a user asks to update docs after implementation; or when stale docs/AGENTS.md could mislead future contributors.
+name: repo-guidance-sync
+description: Keep repository documentation, AGENTS.md, and contributor/test guidance aligned with code, design, and product changes. Use when Codex changes or reviews behavior that affects user-facing docs, developer runbooks, architecture notes, CLI/API references, setup instructions, design-system guidance, operational commands, E2E assumptions, or agent instructions; when a user asks to update docs after implementation; or when stale repo guidance could mislead future contributors.
 ---
 
-# Sync Docs and AGENTS
+# Repo Guidance Sync
 
 ## Overview
 
@@ -13,6 +13,7 @@ Use this skill to decide what documentation must change after a code, design, or
 
 1. Identify the change surface.
    - Inspect the diff, touched packages, new commands, config flags, UI behavior, API shapes, CRDs, generated schemas, deployment manifests, and tests.
+   - If the change affects setup, CLI workflows, operator reconciliation, ingress/gateway behavior, auth/policy, registry/image handling, observability, or cache-mode assumptions, identify the matching E2E scenario in `test/e2e/kind.sh` or adjacent integration tests before editing docs.
    - Search for existing docs before adding new files: `rg -n "<command|field|feature|concept>" README.md AGENTS.md docs website config api internal services`.
    - Prefer updating the nearest existing guide, reference, or runbook over creating a new document.
 
@@ -23,6 +24,7 @@ Use this skill to decide what documentation must change after a code, design, or
    - Design change: update design-system rules, component guidance, UX behavior notes, or docs that describe screens/workflows.
    - Operational change: update install, deployment, TLS, registry, Kubernetes, observability, and rollback/debug instructions.
    - Schema/contract change: update CRD/API docs, examples, generated docs if the repo owns them, and any golden snapshots tied to CLI help.
+   - E2E-visible behavior change: update or add the relevant E2E assertion in `test/e2e/kind.sh` when the behavior is exercised through Kind, real MCP traffic, policy/session state, OAuth, observability, registry/image paths, or `cluster doctor`. If narrower unit/integration coverage is sufficient, note why in the final validation summary.
 
 3. Verify source truth before writing.
    - Treat code, tests, CRD types, OpenAPI specs, CLI definitions, workflow files, and manifests as source of truth.
@@ -38,7 +40,7 @@ Use this skill to decide what documentation must change after a code, design, or
    - Update links and table-of-contents entries when adding or renaming pages.
 
 5. Validate.
-   - Run the narrowest relevant checks: markdown/docs build if available, golden tests for CLI help changes, generated-doc drift checks when docs are generated, and targeted code tests if examples exercise behavior.
+   - Run the narrowest relevant checks: markdown/docs build if available, golden tests for CLI help changes, generated-doc drift checks when docs are generated, E2E scenario checks for behavior covered by `test/e2e/kind.sh`, and targeted code tests if examples exercise behavior.
    - At minimum, run searches for old field names, commands, or stale wording that the change replaces.
    - If validation cannot be run, state the blocker and what was manually checked.
 

--- a/.codex/skills/repo-guidance-sync/agents/openai.yaml
+++ b/.codex/skills/repo-guidance-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Guidance Sync"
+  short_description: "Keep repo guidance aligned with changes"
+  default_prompt: "Use $repo-guidance-sync to update documentation, AGENTS.md, and test guidance for the recent code, design, or product changes."

--- a/.codex/skills/sync-docs-agents/agents/openai.yaml
+++ b/.codex/skills/sync-docs-agents/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Sync Docs and AGENTS"
-  short_description: "Keep docs and AGENTS.md aligned with changes"
-  default_prompt: "Use $sync-docs-agents to update documentation and AGENTS.md for the recent code, design, or product changes."

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,87 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      root-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /services/api
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      services-api-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /services/ui
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      services-ui-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /services/ingest
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      services-ingest-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /services/processor
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      services-processor-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /services/mcp-proxy
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      mcp-proxy-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /services/traefik-plugins/pii-redactor
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      pii-redactor-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: gomod
+    directory: /examples/go-mcp-server
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      example-server-go-modules:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,21 +7,24 @@ on:
     branches: [ "main" ]
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   changed-paths:
     name: Detect Docs/Website Changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docs: ${{ steps.filter.outputs.docs }}
       website: ${{ steps.filter.outputs.website }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         with:
           filters: |
             code:
@@ -36,22 +39,22 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changed-paths]
     if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install linters
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
 
       - name: Run go fmt check
         run: |
@@ -69,22 +72,22 @@ jobs:
 
   test:
     name: Unit + Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changed-paths]
     if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install envtest
         run: |
-          export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p path)
+          export KUBEBUILDER_ASSETS=$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.0 use -p path)
           echo "KUBEBUILDER_ASSETS=$KUBEBUILDER_ASSETS" >> $GITHUB_ENV
 
       - name: Run unit tests with coverage
@@ -113,7 +116,7 @@ jobs:
           mv unit.out coverage.out
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: ./coverage.out
           flags: pre-merge
@@ -130,12 +133,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -190,7 +193,7 @@ jobs:
 
       - name: Upload e2e artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: kind-e2e-artifacts
           path: .e2e-artifacts/kind
@@ -198,15 +201,15 @@ jobs:
 
   benchmark:
     name: Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changed-paths]
     if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -217,15 +220,15 @@ jobs:
 
   generated-drift:
     name: Generated File Drift
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [changed-paths]
     if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true' || needs.changed-paths.outputs.docs == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
@@ -244,9 +247,32 @@ jobs:
             exit 1
           fi
 
+  sbom:
+    name: SBOM
+    runs-on: ubuntu-24.04
+    needs: [changed-paths]
+    if: github.event_name == 'workflow_dispatch' || needs.changed-paths.outputs.code == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Generate repository SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: mcp-runtime-repository.spdx.json
+
+      - name: Upload repository SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mcp-runtime-repository-sbom
+          path: mcp-runtime-repository.spdx.json
+          if-no-files-found: error
+
   deploy-docs:
     name: Deploy Docs (docs.mcpruntime.org)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: deploy-docs-${{ github.ref }}
       cancel-in-progress: true
@@ -254,7 +280,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changed-paths.outputs.docs == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate docs deploy secrets
         env:
@@ -367,7 +393,7 @@ jobs:
 
   deploy-website:
     name: Deploy Website (mcpruntime.org)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     concurrency:
       group: deploy-website-${{ github.ref }}
       cancel-in-progress: true
@@ -375,7 +401,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changed-paths.outputs.website == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate website deploy secrets
         env:

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -22,7 +22,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Check dependency review support
+        id: dependency-review-support
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          status="$(curl -sS -o /tmp/dependency-review-support.json -w "%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/dependency-graph/compare/${BASE_SHA}...${HEAD_SHA}")"
+          if [ "$status" = "200" ]; then
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "supported=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::Dependency Review API is unavailable for this repository (HTTP ${status}). Enable the dependency graph in repository security settings to enforce dependency review."
+
       - name: Review dependency changes
+        if: steps.dependency-review-support.outputs.supported == 'true'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,29 @@
+name: Security - Dependency Review
+
+on:
+  pull_request:
+    branches: [ "*" ]
+    paths-ignore:
+      - 'docs/**'
+      - 'website/**'
+      - 'README.md'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later, SSPL-1.0

--- a/.github/workflows/security-gosec.yaml
+++ b/.github/workflows/security-gosec.yaml
@@ -15,22 +15,25 @@ on:
       - 'README.md'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   gosec:
     name: Gosec Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.26.1
 
       - name: Run gosec
         run: $(go env GOPATH)/bin/gosec ./...

--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -15,57 +15,84 @@ on:
       - 'README.md'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   trivy-fs:
     name: Trivy FS Scan
-    runs-on: ubuntu-latest
-    env:
-      TRIVY_IMAGE: aquasec/trivy:0.65.0
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Trivy filesystem scan
-        run: |
-          docker pull "$TRIVY_IMAGE"
-          docker run --rm \
-            -v "$PWD:/workspace" \
-            -w /workspace \
-            "$TRIVY_IMAGE" \
-            fs \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --skip-dirs inspirations/mcp-gateway-registry \
-            --vuln-type os,library \
-            --severity CRITICAL,HIGH \
-            --no-progress \
-            .
+      - name: Trivy repository scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,secret,misconfig,license
+          format: sarif
+          output: trivy-fs.sarif
+          exit-code: "1"
+          ignore-unfixed: true
+          skip-dirs: inspirations/mcp-gateway-registry
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          hide-progress: true
+
+      - name: Upload Trivy repository SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
+        with:
+          sarif_file: trivy-fs.sarif
 
   trivy-image:
     name: Trivy Operator Image Scan
-    runs-on: ubuntu-latest
-    env:
-      TRIVY_IMAGE: aquasec/trivy:0.65.0
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build operator image
         run: docker build --pull -f Dockerfile.operator -t mcp-runtime-operator:ci .
 
-      - name: Save operator image tarball
-        run: docker save mcp-runtime-operator:ci -o /tmp/mcp-runtime-operator-ci.tar
+      - name: Generate operator image SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: mcp-runtime-operator:ci
+          format: spdx-json
+          output-file: operator-image.spdx.json
+
+      - name: Upload operator image SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: operator-image-sbom
+          path: operator-image.spdx.json
+          if-no-files-found: error
 
       - name: Trivy image scan
-        run: |
-          docker pull "$TRIVY_IMAGE"
-          docker run --rm \
-            -v /tmp:/tmp \
-            "$TRIVY_IMAGE" \
-            image \
-            --input /tmp/mcp-runtime-operator-ci.tar \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --vuln-type os,library \
-            --severity CRITICAL,HIGH \
-            --no-progress
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          image-ref: mcp-runtime-operator:ci
+          format: sarif
+          output: trivy-image.sarif
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          hide-progress: true
+
+      - name: Upload Trivy image SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
+        with:
+          sarif_file: trivy-image.sarif

--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -42,6 +42,7 @@ jobs:
           skip-dirs: inspirations/mcp-gateway-registry
           vuln-type: os,library
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           hide-progress: true
 
       - name: Upload Trivy repository SARIF
@@ -88,6 +89,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: os,library
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           hide-progress: true
 
       - name: Upload Trivy image SARIF

--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -29,12 +29,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Trivy repository scan
+      - name: Trivy repository vulnerability scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scan-ref: .
-          scanners: vuln,secret,misconfig,license
+          scanners: vuln,secret,license
           format: sarif
           output: trivy-fs.sarif
           exit-code: "1"
@@ -51,6 +51,27 @@ jobs:
         uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           sarif_file: trivy-fs.sarif
+
+      - name: Trivy repository misconfiguration scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: misconfig
+          format: sarif
+          output: trivy-misconfig.sarif
+          exit-code: "0"
+          skip-dirs: inspirations/mcp-gateway-registry
+          severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
+          hide-progress: true
+
+      - name: Upload Trivy misconfiguration SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
+        with:
+          sarif_file: trivy-misconfig.sarif
 
   trivy-image:
     name: Trivy Operator Image Scan

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ tags
 /services/mcp-server/mcp-sentinel-mcp-server
 /services/ui/mcp-sentinel-ui
 /unit.out
+/chain-bench-results.json
 docs/COVERAGE_IMPROVEMENT_PLAN.md
 __pycache__/
 *.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ go test ./... -count=1 -race
 go vet ./...
 ```
 
-Optional but used in CI: `staticcheck ./...` (install: `go install honnef.co/go/tools/cmd/staticcheck@latest`).
+Optional but used in CI: `staticcheck ./...` (install the pinned CI version with `go install honnef.co/go/tools/cmd/staticcheck@v0.7.0`).
 
 **Targeted tests** (prefer these while iterating; full `./...` can be slow):
 
@@ -47,7 +47,7 @@ Optional but used in CI: `staticcheck ./...` (install: `go install honnef.co/go/
 - `go test ./test/integration/...` (needs `KUBEBUILDER_ASSETS`; see `Makefile.operator` and CI for envtest setup)
 - `services/api` and `services/ui`: `go test -race -count=1 ./...` inside each directory (CI runs these explicitly)
 
-**CI** (`.github/workflows/ci.yaml`) runs: `gofmt` check, `go vet`, `staticcheck`, unit tests, golden tests, service tests, `test/integration`, then Kind e2e on `main`/`PR` branches. Align local changes with that before opening a PR.
+**CI** (`.github/workflows/ci.yaml`) runs: `gofmt` check, `go vet`, `staticcheck`, unit tests, golden tests, service tests, `test/integration`, SBOM generation, then Kind e2e on `main`/`PR` branches. Security workflows add pinned gosec, Trivy, and dependency-review checks. Align local changes with that before opening a PR.
 
 **Docs sync for CLI help:** when you edit `docs/cli.md`, `docs/getting-started.md`, `docs/publish-mcp-server.md`, or any page that shows CLI commands, verify the exact command description, subcommands, flags, and defaults from live help output before push. Use:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,13 @@ so the documented containerd mirror matches the image host exactly.
 - **API keys:**
 
 ```bash
-# Direct Sentinel API / x-api-key requests.
+# Direct Sentinel API / x-api-key admin requests.
 kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
-  -o jsonpath='{.data.API_KEYS}' | base64 -d
+  -o jsonpath='{.data.UI_API_KEY}' | base64 -d
+
+# Ingest/proxy analytics requests.
+kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
+  -o jsonpath='{.data.INGEST_API_KEYS}' | base64 -d
 
 # Browser/API-key login through the UI.
 kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
@@ -121,9 +125,11 @@ kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
 ```
 
   `setup` should keep `UI_API_KEY` included in the comma-separated `API_KEYS`
-  list. If direct `/api/...` curl calls return `401`, run
-  `./bin/mcp-runtime cluster doctor`; it flags a UI/API key mismatch. Roll the
-  API and UI deployments after patching `mcp-sentinel-secrets`.
+  and `ADMIN_API_KEYS` lists, and should keep ingest-only keys in
+  `INGEST_API_KEYS`. If direct `/api/...` curl calls return `401`, run
+  `./bin/mcp-runtime cluster doctor`; it flags UI/API/admin key mismatches. Roll
+  the API, UI, ingest, and proxy/gateway workloads after patching
+  `mcp-sentinel-secrets`.
 
 - **Platform admin bootstrap (one-shot):**
 
@@ -155,10 +161,11 @@ kubectl patch secret mcp-sentinel-secrets -n mcp-sentinel --type merge -p '{"str
 - **“ingressHost is required” (operator):** set `spec.ingressHost` on the `MCPServer`, or operator env `MCP_DEFAULT_INGRESS_HOST`, or `MCP_PLATFORM_DOMAIN` for `mcp.<domain>` defaults.
 - **MCPServer stuck `PartiallyReady` with working ingress traffic:** default ingress readiness is strict and waits for `Ingress.status.loadBalancer.ingress[]`. For dev / NodePort-style ingress controllers that route without publishing LB status, set operator env `MCP_INGRESS_READINESS_MODE=permissive`; this treats an Ingress with rules as ready. Keep the default `strict` mode for production setups that rely on published LB status.
 - **Port mismatch:** the bundled Go example listens on `8088` by default; align `MCPServer` `port` / `servicePort` and container `PORT` if you overrode them.
-- **Analytics 401:** use gateway/ingest URL and key, not the app’s random env. Example: `ANALYTICS_INGEST_URL=http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events` and `ANALYTICS_API_KEY` from `mcp-sentinel-secrets` (`API_KEYS` key).
+- **Analytics 401:** use gateway/ingest URL and key, not the app’s random env. Example: `ANALYTICS_INGEST_URL=http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events` and `ANALYTICS_API_KEY` from `mcp-sentinel-secrets` (`INGEST_API_KEYS` key).
 - **Secret not found in workload namespace:** copy `mcp-sentinel-secrets` or use a shared secret reference.
-- **Dashboard / API 401:** direct `x-api-key` curl calls use `API_KEYS`; browser login uses `UI_API_KEY`. Keep `UI_API_KEY` present in `API_KEYS`, then roll the API and UI deployments after secret changes.
+- **Dashboard / API 401:** direct admin `x-api-key` curl calls need a key present in both `API_KEYS` and `ADMIN_API_KEYS`; browser login uses `UI_API_KEY`. Keep `UI_API_KEY` present in both lists, then roll the API and UI deployments after secret changes.
 - **Ingress / routes:** `kubectl get ingress -A` and confirm paths match the gateway and demo servers you expect.
+- **Custom ingress namespaces:** bundled Traefik manifests watch `registry`, `mcp-sentinel`, and `mcp-servers` only so the controller does not need cluster-wide Secret access. If you place public Ingresses in another namespace, add that namespace to the Traefik `--providers.kubernetesingress.namespaces` list and bind the `traefik-watch` Role there.
 - **Private / HTTP in-cluster registry / k3s:** Pull and push can fail with `https` vs `http` or `registry.local` DNS on nodes. See **k3s and HTTP registry (config files)** below, set **`MCP_REGISTRY_*`** before `pipeline generate` when you want `ClusterIP:port` in manifests, and raise **`MCP_DEPLOYMENT_TIMEOUT`** if setup rollouts time out on slow first pulls.
 - **Prod DNS / ACME:** with `MCP_PLATFORM_DOMAIN=example.com`, setup derives `registry.example.com`, `mcp.example.com`, and `platform.example.com`. All three public DNS records must point at the ingress IP and port 80 must reach Traefik for HTTP-01. If cert-manager reports NXDOMAIN, verify from outside and inside the cluster: `getent hosts registry.example.com`, `getent hosts mcp.example.com`, `getent hosts platform.example.com`, and `kubectl run dns-check --rm -i --restart=Never --image=busybox:1.36 -- nslookup platform.example.com`.
 - **Platform UI 404 / wrong host:** when `MCP_PLATFORM_DOMAIN` (or `MCP_PLATFORM_INGRESS_HOST`) is set, setup applies a host-based ingress `mcp-sentinel-platform-ui` in `mcp-sentinel`. Verify with `kubectl get ingress mcp-sentinel-platform-ui -n mcp-sentinel -o yaml`; the rule should be host=`platform.<domain>` routing `/` to `mcp-sentinel-ui:8082` (and `/api`, `/grafana`, `/prometheus` to those services). If the dashboard returns Traefik default 404, check that DNS resolves `platform.<domain>` to the cluster ingress, then `kubectl logs -n traefik deploy/traefik --tail=120` for routing errors. The dev path-based gateway (`mcp-sentinel-gateway`) keeps working when `MCP_PLATFORM_DOMAIN` is unset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Optional but used in CI: `staticcheck ./...` (install the pinned CI version with
 - `go test ./internal/operator/... ./internal/cli/... -race -count=1`
 - `go test ./test/golden/... -count=1` (CLI help snapshots; update `test/golden/cli/testdata/*.golden` when you change Cobra help text on purpose)
 - `go test ./test/integration/...` (needs `KUBEBUILDER_ASSETS`; see `Makefile.operator` and CI for envtest setup)
+- `E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh` for repeated local Kind e2e debugging without recreating the cluster or rebuilding cached images; set `OPENAI_API_KEY` in env or `.env` for optional real-client prompts, and omit cache mode for CI-equivalent fresh runs.
 - `services/api` and `services/ui`: `go test -race -count=1 ./...` inside each directory (CI runs these explicitly)
 
 **CI** (`.github/workflows/ci.yaml`) runs: `gofmt` check, `go vet`, `staticcheck`, unit tests, golden tests, service tests, `test/integration`, SBOM generation, then Kind e2e on `main`/`PR` branches. Security workflows add pinned gosec, Trivy, and dependency-review checks. Align local changes with that before opening a PR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+MCP Runtime is currently alpha software. Security fixes are applied to the
+default branch and to the latest tagged release when a release tag is available.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for a suspected vulnerability.
+
+Use GitHub private vulnerability reporting or open a draft security advisory for
+`Agent-Hellboy/mcp-runtime` when that option is available. If private reporting
+is not available, contact the maintainer at `princekroshan01@gmail.com` and ask
+for a private coordination channel.
+
+Include:
+
+- affected commit, tag, or deployment version
+- the component involved, such as CLI, operator, CRD, gateway, or Sentinel
+- reproduction steps or a minimal proof of concept
+- expected impact and any known mitigations
+
+The maintainers will acknowledge valid reports as quickly as possible, assess
+impact, coordinate a fix, and publish disclosure notes once a remediation path is
+available.

--- a/config/ingress/base/traefik.yaml
+++ b/config/ingress/base/traefik.yaml
@@ -4,31 +4,129 @@ metadata:
   name: traefik
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: registry
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-sentinel
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-servers
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: traefik
   namespace: traefik
+automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: traefik
+  name: traefik-ingressclass
 rules:
-  - apiGroups: [""]
-    resources: ["services", "endpoints", "secrets"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses", "ingressclasses"]
+    resources: ["ingressclasses"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: traefik
+  name: traefik-ingressclass
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: traefik
+  name: traefik-ingressclass
+subjects:
+  - kind: ServiceAccount
+    name: traefik
+    namespace: traefik
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: traefik-watch
+  namespace: registry
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: traefik-watch
+  namespace: registry
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: traefik-watch
+subjects:
+  - kind: ServiceAccount
+    name: traefik
+    namespace: traefik
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: traefik-watch
+  namespace: mcp-sentinel
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: traefik-watch
+  namespace: mcp-sentinel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: traefik-watch
+subjects:
+  - kind: ServiceAccount
+    name: traefik
+    namespace: traefik
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: traefik-watch
+  namespace: mcp-servers
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: traefik-watch
+  namespace: mcp-servers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: traefik-watch
 subjects:
   - kind: ServiceAccount
     name: traefik
@@ -84,6 +182,7 @@ spec:
               - NET_BIND_SERVICE
         args:
           - --providers.kubernetesingress=true
+          - --providers.kubernetesingress.namespaces=registry,mcp-sentinel,mcp-servers
           - --entrypoints.web.address=:80
           - --entrypoints.web.http.redirections.entryPoint.to=websecure
           - --entrypoints.web.http.redirections.entryPoint.scheme=https

--- a/config/ingress/overlays/http/deployment-args.patch.yaml
+++ b/config/ingress/overlays/http/deployment-args.patch.yaml
@@ -2,6 +2,7 @@
   path: /spec/template/spec/containers/0/args
   value:
     - --providers.kubernetesingress=true
+    - --providers.kubernetesingress.namespaces=registry,mcp-sentinel,mcp-servers
     - --entrypoints.web.address=:8000
     - --entrypoints.websecure.address=:8443
 - op: replace

--- a/config/ingress/overlays/prod/traefik-no-redirect.yaml
+++ b/config/ingress/overlays/prod/traefik-no-redirect.yaml
@@ -12,6 +12,7 @@ spec:
         - name: traefik
           args:
             - --providers.kubernetesingress=true
+            - --providers.kubernetesingress.namespaces=registry,mcp-sentinel,mcp-servers
             - --entrypoints.web.address=:80
             - --entrypoints.websecure.address=:443
             - --entrypoints.websecure.http.tls=true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,12 +26,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   - services
   verbs:
   - create

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: mcp-runtime-operator-controller-manager
   namespace: mcp-runtime
+automountServiceAccountToken: true

--- a/config/registry/base/deployment.yaml
+++ b/config/registry/base/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: registry
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/docs/api.md
+++ b/docs/api.md
@@ -213,8 +213,9 @@ GET /api/dashboard/summary
 ```
 
 Requires admin authentication. For direct curl/API clients, send an
-`x-api-key` value from `API_KEYS`; `UI_API_KEY` is for browser login unless it
-is also present in `API_KEYS`.
+`x-api-key` value that is present in both `API_KEYS` and `ADMIN_API_KEYS`.
+`setup` keeps `UI_API_KEY` in both lists for browser/API-key admin login.
+`INGEST_API_KEYS` is only for event ingestion and is not accepted here.
 
 Returns: `total_events`, `active_servers`, `active_grants`, `active_sessions`, `latest_source`, `last_event_type`, `last_event_time`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -188,7 +188,7 @@ Create the analytics secret in the server namespace:
 ```bash
 API_KEY="$(
   kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
-    -o jsonpath='{.data.API_KEYS}' | base64 -d | cut -d, -f1
+    -o jsonpath='{.data.INGEST_API_KEYS}' | base64 -d | cut -d, -f1
 )"
 
 kubectl create secret generic go-example-mcp-analytics \
@@ -367,15 +367,15 @@ instead of `input` or `text`.
 ./bin/mcp-runtime sentinel status
 ./bin/mcp-runtime sentinel events
 
-API_KEY="$(
+ADMIN_KEY="$(
   kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
-    -o jsonpath='{.data.API_KEYS}' | base64 -d | cut -d, -f1
+    -o jsonpath='{.data.UI_API_KEY}' | base64 -d
 )"
 
-curl -sS -H "x-api-key: $API_KEY" \
+curl -sS -H "x-api-key: $ADMIN_KEY" \
   http://localhost:18080/api/dashboard/summary | jq .
 
-curl -sS -H "x-api-key: $API_KEY" \
+curl -sS -H "x-api-key: $ADMIN_KEY" \
   "http://localhost:18080/api/events/filter?server=go-example-mcp&tool_name=add&limit=5" | jq .
 ```
 

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -70,9 +70,11 @@ The main CI workflow runs:
 - golden CLI tests
 - service module tests
 - generated file drift
+- repository SBOM generation
 - Kind e2e for code changes
 
-Security workflows add gosec and Trivy checks.
+Security workflows add pinned gosec, Trivy repository/image scans with SARIF
+upload, operator-image SBOM artifacts, and pull-request dependency review.
 
 ## Choosing Coverage
 

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -54,7 +54,18 @@ Useful local runs:
 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh
 E2E_SCENARIOS=all MCP_DEPLOYMENT_TIMEOUT=900s bash test/e2e/kind.sh
 E2E_KEEP_CLUSTER=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh
+E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh
 ```
+
+`E2E_CACHE_MODE=1` is for repeated local debugging. It implies
+`E2E_KEEP_CLUSTER=1`, reuses the existing Kind cluster and local registry when
+present, skips platform setup if the core platform is already ready, and reuses
+image tags already published to the local registry.
+
+Optional real-client `mcp-smoke-agent` prompts default to OpenAI. Set
+`OPENAI_API_KEY` in the environment or `.env` to run them; override
+`MCP_SMOKE_AGENT_PROVIDER` or `MCP_SMOKE_AGENT_MODEL` only when a different
+provider or model is required.
 
 The script writes artifacts when `E2E_ARTIFACT_DIR` is set. In CI, those
 artifacts are uploaded from `.e2e-artifacts/kind`.

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -7,7 +7,7 @@
 | Service | Role |
 |---|---|
 | **mcp-proxy** | Transparent sidecar. Extracts identity, evaluates tool-level policy, emits allow/deny audit events, forwards traffic upstream. |
-| **ingest** | Receives `POST /events`, validates API keys or optional JWTs, writes to Kafka. |
+| **ingest** | Receives `POST /events`, validates ingest-scoped API keys or optional JWTs, writes to Kafka. |
 | **processor** | Consumes Kafka, batches, writes into ClickHouse with indexed audit fields. |
 | **api** | Analytics endpoints, dashboard summaries, runtime governance APIs (grants/sessions), component operations. |
 | **ui** | Three-tab dashboard: overview metrics + events, governance forms, operations health + safe restart. |
@@ -47,7 +47,9 @@ flowchart LR
 
 ## Auth and APIs
 
-`api` and `ingest` support both API keys and optional OIDC JWT validation (issuer, audience, JWKS).
+`api` accepts `API_KEYS`, with admin elevation only for keys also listed in
+`ADMIN_API_KEYS`. `ingest` accepts only ingest-scoped `INGEST_API_KEYS` (with a
+legacy fallback to `API_KEYS`) and optional OIDC JWT validation when configured.
 
 ```text
 POST /events

--- a/internal/cli/cluster/doctor_impl.go
+++ b/internal/cli/cluster/doctor_impl.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -219,7 +220,7 @@ func doctorCheckSpecs(kubectl core.KubectlRunner, distro Distribution) []doctorC
 			Run:    func() DoctorCheck { return checkMCPServersImagePullSmoke(kubectl, doctorMCPServersNamespace) },
 		},
 		{Name: "registry HTTP pull mismatch", Detail: "listing pods and inspecting image-pull failures for HTTP-vs-HTTPS registry errors", Run: func() DoctorCheck { return checkRegistryHTTPPullMismatch(kubectl) }},
-		{Name: "sentinel secrets", Detail: "reading Sentinel API_KEYS and UI_API_KEY from mcp-sentinel-secrets", Run: func() DoctorCheck { return checkSentinelSecrets(kubectl) }},
+		{Name: "sentinel secrets", Detail: "reading Sentinel API, admin, UI, and ingest keys from mcp-sentinel-secrets", Run: func() DoctorCheck { return checkSentinelSecrets(kubectl) }},
 		{Name: "sentinel API auth probe", Detail: "launching a temporary curl pod with UI_API_KEY against the Sentinel API", Run: func() DoctorCheck { return checkSentinelAPIAuthProbe(kubectl) }},
 		{Name: "node capacity", Detail: "checking node metrics, then falling back to allocatable resources if metrics-server is absent", Run: func() DoctorCheck { return checkNodeCapacity(kubectl) }},
 		{Name: "pending pods", Detail: "listing Pending pods across all namespaces", Run: func() DoctorCheck { return checkPendingPodsByNamespace(kubectl) }},
@@ -396,10 +397,21 @@ metadata:
   name: %s
   namespace: %s
 spec:
+  automountServiceAccountToken: false
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: pause
     image: registry.k8s.io/pause:3.9
+    securityContext:
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      capabilities:
+        drop:
+        - ALL
 `, podName, namespace)
 	cmd, err := kubectl.CommandArgs([]string{"apply", "--dry-run=server", "-f", "-"})
 	if err != nil {
@@ -818,15 +830,19 @@ func checkTraefikServiceExposureAt(kubectl core.KubectlRunner, endpoint doctorTr
 
 func checkMCPServersDNSAndNetwork(kubectl core.KubectlRunner) DoctorCheck {
 	podName := fmt.Sprintf("mcp-runtime-doctor-dns-%d", time.Now().UnixNano())
+	image := "curlimages/curl:8.7.1"
+	curlArgs := []string{
+		"-sSI", "--connect-timeout", "5", "--max-time", "15",
+		"http://registry.registry.svc.cluster.local:5000/v2/",
+	}
 	args := []string{
 		"run", "-n", doctorMCPServersNamespace,
 		"--rm", "--restart=Never", "--attach",
 		"--pod-running-timeout=30s",
 		"--quiet",
-		"--image=curlimages/curl:8.7.1",
+		"--image=" + image,
+		"--overrides=" + restrictedRunOverrides(podName, image, []string{"curl"}, curlArgs),
 		podName,
-		"--command", "--", "curl", "-sSI", "--connect-timeout", "5", "--max-time", "15",
-		"http://registry.registry.svc.cluster.local:5000/v2/",
 	}
 	cmd, err := kubectl.CommandArgs(args)
 	if err != nil {
@@ -1091,7 +1107,7 @@ func checkMCPServersImagePullSmoke(kubectl core.KubectlRunner, namespace string)
 	defer func() {
 		_ = kubectl.Run([]string{"delete", "pod", podName, "-n", namespace, "--ignore-not-found"})
 	}()
-	if err := kubectl.Run([]string{"run", podName, "-n", namespace, "--restart=Never", "--image=" + image}); err != nil {
+	if err := kubectl.Run([]string{"run", podName, "-n", namespace, "--restart=Never", "--image=" + image, "--overrides=" + restrictedRunOverrides(podName, image, nil, nil)}); err != nil {
 		return DoctorCheck{
 			Name:   "mcp-servers image pull smoke",
 			OK:     false,
@@ -1125,6 +1141,43 @@ func checkMCPServersImagePullSmoke(kubectl core.KubectlRunner, namespace string)
 	}
 }
 
+func restrictedRunOverrides(containerName, image string, command, args []string) string {
+	container := map[string]any{
+		"name":  strings.TrimSpace(containerName),
+		"image": strings.TrimSpace(image),
+		"securityContext": map[string]any{
+			"allowPrivilegeEscalation": false,
+			"runAsNonRoot":             true,
+			"capabilities": map[string]any{
+				"drop": []string{"ALL"},
+			},
+		},
+	}
+	if len(command) > 0 {
+		container["command"] = command
+	}
+	if len(args) > 0 {
+		container["args"] = args
+	}
+	overrides := map[string]any{
+		"spec": map[string]any{
+			"automountServiceAccountToken": false,
+			"securityContext": map[string]any{
+				"runAsNonRoot": true,
+				"seccompProfile": map[string]any{
+					"type": "RuntimeDefault",
+				},
+			},
+			"containers": []map[string]any{container},
+		},
+	}
+	data, err := json.Marshal(overrides)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}
+
 func checkSentinelSecrets(kubectl core.KubectlRunner) DoctorCheck {
 	if _, err := readKubectlOutput(kubectl, []string{"get", "namespace", doctorSentinelNamespace, "-o", "jsonpath={.metadata.name}"}); err != nil {
 		return DoctorCheck{
@@ -1139,7 +1192,25 @@ func checkSentinelSecrets(kubectl core.KubectlRunner) DoctorCheck {
 			Name:   "sentinel secrets",
 			OK:     false,
 			Detail: "secret mcp-sentinel-secrets missing or API_KEYS key absent",
-			Remedy: "create/update mcp-sentinel-secrets with API_KEYS and UI_API_KEY",
+			Remedy: "create/update mcp-sentinel-secrets with API_KEYS, ADMIN_API_KEYS, INGEST_API_KEYS, and UI_API_KEY",
+		}
+	}
+	adminAPIKeysB64, err := readKubectlOutput(kubectl, []string{"get", "secret", "mcp-sentinel-secrets", "-n", doctorSentinelNamespace, "-o", "jsonpath={.data.ADMIN_API_KEYS}"})
+	if err != nil {
+		return DoctorCheck{
+			Name:   "sentinel secrets",
+			OK:     false,
+			Detail: "secret mcp-sentinel-secrets missing ADMIN_API_KEYS key",
+			Remedy: "create/update mcp-sentinel-secrets with ADMIN_API_KEYS; include UI_API_KEY for browser admin access",
+		}
+	}
+	ingestAPIKeysB64, err := readKubectlOutput(kubectl, []string{"get", "secret", "mcp-sentinel-secrets", "-n", doctorSentinelNamespace, "-o", "jsonpath={.data.INGEST_API_KEYS}"})
+	if err != nil {
+		return DoctorCheck{
+			Name:   "sentinel secrets",
+			OK:     false,
+			Detail: "secret mcp-sentinel-secrets missing INGEST_API_KEYS key",
+			Remedy: "create/update mcp-sentinel-secrets with ingest-only INGEST_API_KEYS for MCP proxy analytics",
 		}
 	}
 	uiKeyB64, err := readKubectlOutput(kubectl, []string{"get", "secret", "mcp-sentinel-secrets", "-n", doctorSentinelNamespace, "-o", "jsonpath={.data.UI_API_KEY}"})
@@ -1152,30 +1223,48 @@ func checkSentinelSecrets(kubectl core.KubectlRunner) DoctorCheck {
 		}
 	}
 	apiKeys := strings.TrimSpace(decodeBase64(strings.TrimSpace(apiKeysB64)))
+	adminAPIKeys := strings.TrimSpace(decodeBase64(strings.TrimSpace(adminAPIKeysB64)))
+	ingestAPIKeys := strings.TrimSpace(decodeBase64(strings.TrimSpace(ingestAPIKeysB64)))
 	uiKey := strings.TrimSpace(decodeBase64(strings.TrimSpace(uiKeyB64)))
-	if apiKeys == "" || uiKey == "" {
+	if apiKeys == "" || adminAPIKeys == "" || ingestAPIKeys == "" || uiKey == "" {
 		return DoctorCheck{
 			Name:   "sentinel secrets",
 			OK:     false,
-			Detail: "API_KEYS or UI_API_KEY is empty",
-			Remedy: "populate non-empty API_KEYS and UI_API_KEY in mcp-sentinel-secrets",
+			Detail: "API_KEYS, ADMIN_API_KEYS, INGEST_API_KEYS, or UI_API_KEY is empty",
+			Remedy: "populate non-empty API_KEYS, ADMIN_API_KEYS, INGEST_API_KEYS, and UI_API_KEY in mcp-sentinel-secrets",
 		}
 	}
 	keys := splitCommaTrim(apiKeys)
+	adminKeys := splitCommaTrim(adminAPIKeys)
+	uiInAPIKeys := false
 	for _, k := range keys {
+		if k == uiKey {
+			uiInAPIKeys = true
+			break
+		}
+	}
+	if !uiInAPIKeys {
+		return DoctorCheck{
+			Name:   "sentinel secrets",
+			OK:     false,
+			Detail: "UI_API_KEY not present in API_KEYS",
+			Remedy: "align API_KEYS and UI_API_KEY values in mcp-sentinel-secrets",
+		}
+	}
+	for _, k := range adminKeys {
 		if k == uiKey {
 			return DoctorCheck{
 				Name:   "sentinel secrets",
 				OK:     true,
-				Detail: "UI_API_KEY matches one API_KEYS entry",
+				Detail: "UI_API_KEY is present in API_KEYS and ADMIN_API_KEYS; INGEST_API_KEYS is populated separately",
 			}
 		}
 	}
 	return DoctorCheck{
 		Name:   "sentinel secrets",
 		OK:     false,
-		Detail: "UI_API_KEY not present in API_KEYS",
-		Remedy: "align API_KEYS and UI_API_KEY values in mcp-sentinel-secrets",
+		Detail: "UI_API_KEY not present in ADMIN_API_KEYS",
+		Remedy: "include UI_API_KEY in ADMIN_API_KEYS for browser admin access",
 	}
 }
 

--- a/internal/cli/cluster/doctor_impl.go
+++ b/internal/cli/cluster/doctor_impl.go
@@ -67,6 +67,7 @@ const (
 	doctorK3sTraefikWebPort   = 80
 	doctorSentinelNamespace   = "mcp-sentinel"
 	doctorSentinelAPIService  = "mcp-sentinel-api"
+	doctorRestrictedRunAsUser = int64(65532)
 
 	registryHTTPPullMismatch = "http: server gave HTTP response to HTTPS client"
 
@@ -841,7 +842,7 @@ func checkMCPServersDNSAndNetwork(kubectl core.KubectlRunner) DoctorCheck {
 		"--pod-running-timeout=30s",
 		"--quiet",
 		"--image=" + image,
-		"--overrides=" + restrictedRunOverrides(podName, image, []string{"curl"}, curlArgs),
+		"--overrides=" + restrictedRunOverrides(podName, image, "curl", curlArgs...),
 		podName,
 	}
 	cmd, err := kubectl.CommandArgs(args)
@@ -1107,7 +1108,7 @@ func checkMCPServersImagePullSmoke(kubectl core.KubectlRunner, namespace string)
 	defer func() {
 		_ = kubectl.Run([]string{"delete", "pod", podName, "-n", namespace, "--ignore-not-found"})
 	}()
-	if err := kubectl.Run([]string{"run", podName, "-n", namespace, "--restart=Never", "--image=" + image, "--overrides=" + restrictedRunOverrides(podName, image, nil, nil)}); err != nil {
+	if err := kubectl.Run([]string{"run", podName, "-n", namespace, "--restart=Never", "--image=" + image}); err != nil {
 		return DoctorCheck{
 			Name:   "mcp-servers image pull smoke",
 			OK:     false,
@@ -1141,20 +1142,21 @@ func checkMCPServersImagePullSmoke(kubectl core.KubectlRunner, namespace string)
 	}
 }
 
-func restrictedRunOverrides(containerName, image string, command, args []string) string {
+func restrictedRunOverrides(containerName, image, command string, args ...string) string {
 	container := map[string]any{
 		"name":  strings.TrimSpace(containerName),
 		"image": strings.TrimSpace(image),
 		"securityContext": map[string]any{
 			"allowPrivilegeEscalation": false,
 			"runAsNonRoot":             true,
+			"runAsUser":                doctorRestrictedRunAsUser,
 			"capabilities": map[string]any{
 				"drop": []string{"ALL"},
 			},
 		},
 	}
-	if len(command) > 0 {
-		container["command"] = command
+	if strings.TrimSpace(command) != "" {
+		container["command"] = []string{strings.TrimSpace(command)}
 	}
 	if len(args) > 0 {
 		container["args"] = args
@@ -1164,6 +1166,7 @@ func restrictedRunOverrides(containerName, image string, command, args []string)
 			"automountServiceAccountToken": false,
 			"securityContext": map[string]any{
 				"runAsNonRoot": true,
+				"runAsUser":    doctorRestrictedRunAsUser,
 				"seccompProfile": map[string]any{
 					"type": "RuntimeDefault",
 				},

--- a/internal/cli/cluster/doctor_impl.go
+++ b/internal/cli/cluster/doctor_impl.go
@@ -909,15 +909,9 @@ func checkIngressRouteProbe(kubectl core.KubectlRunner, namespace string, distro
 		}
 	}
 	podName := fmt.Sprintf("mcp-runtime-doctor-ingress-%d", time.Now().UnixNano())
-	curlArgs := []string{
-		"run", "-n", namespace,
-		"--rm", "--restart=Never", "--attach",
-		"--pod-running-timeout=30s",
-		"--quiet",
-		"--image=curlimages/curl:8.7.1",
-		podName,
-		"--command", "--", "curl",
-		"-sS", "-o", "doctor-response",
+	image := "curlimages/curl:8.7.1"
+	probeArgs := []string{
+		"-sS", "-o", "/tmp/doctor-response",
 		"-w", "%{http_code}",
 		"--connect-timeout", "5",
 		"--max-time", "20",
@@ -926,12 +920,21 @@ func checkIngressRouteProbe(kubectl core.KubectlRunner, namespace string, distro
 		"-H", "Mcp-Protocol-Version: 2025-06-18",
 	}
 	if host != "" {
-		curlArgs = append(curlArgs, "-H", "Host: "+host)
+		probeArgs = append(probeArgs, "-H", "Host: "+host)
 	}
-	curlArgs = append(curlArgs,
+	probeArgs = append(probeArgs,
 		"-d", `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
 		fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s", traefik.Name, traefik.Namespace, traefik.WebPort, path),
 	)
+	curlArgs := []string{
+		"run", "-n", namespace,
+		"--rm", "--restart=Never", "--attach",
+		"--pod-running-timeout=30s",
+		"--quiet",
+		"--image=" + image,
+		"--overrides=" + restrictedRunOverrides(podName, image, "curl", probeArgs...),
+		podName,
+	}
 	cmd, err := kubectl.CommandArgs(curlArgs)
 	if err != nil {
 		return DoctorCheck{
@@ -1108,11 +1111,27 @@ func checkMCPServersImagePullSmoke(kubectl core.KubectlRunner, namespace string)
 	defer func() {
 		_ = kubectl.Run([]string{"delete", "pod", podName, "-n", namespace, "--ignore-not-found"})
 	}()
-	if err := kubectl.Run([]string{"run", podName, "-n", namespace, "--restart=Never", "--image=" + image}); err != nil {
+	createCmd, cmdErr := kubectl.CommandArgs([]string{
+		"run", podName,
+		"-n", namespace,
+		"--restart=Never",
+		"--image=" + image,
+		"--overrides=" + restrictedRunOverrides(podName, image, ""),
+	})
+	if cmdErr != nil {
 		return DoctorCheck{
 			Name:   "mcp-servers image pull smoke",
 			OK:     false,
-			Detail: fmt.Sprintf("failed creating smoke pod: %v", err),
+			Detail: fmt.Sprintf("kubectl error: %v", cmdErr),
+			Remedy: "check kubectl setup",
+		}
+	}
+	createOut, err := createCmd.CombinedOutput()
+	if err != nil {
+		return DoctorCheck{
+			Name:   "mcp-servers image pull smoke",
+			OK:     false,
+			Detail: fmt.Sprintf("failed creating smoke pod: %v: %s", err, strings.TrimSpace(string(createOut))),
 			Remedy: "check pull credentials, registry reachability, and image existence",
 		}
 	}

--- a/internal/cli/cluster/doctor_impl_test.go
+++ b/internal/cli/cluster/doctor_impl_test.go
@@ -1209,3 +1209,58 @@ func TestCheckMCPServersImagePullSecrets(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckMCPServersImagePullSmokeUsesNeutralPodSpec(t *testing.T) {
+	var smokeRunArgs []string
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			switch {
+			case contains(spec.Args, "get") && contains(spec.Args, "deploy"):
+				return &core.MockCommand{OutputData: []byte("")}
+			case len(spec.Args) > 0 && spec.Args[0] == "run":
+				smokeRunArgs = append([]string(nil), spec.Args...)
+				return &core.MockCommand{}
+			case contains(spec.Args, "wait"):
+				return &core.MockCommand{}
+			case contains(spec.Args, "delete"):
+				return &core.MockCommand{}
+			default:
+				return &core.MockCommand{}
+			}
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+	check := checkMCPServersImagePullSmoke(kubectl, "mcp-servers")
+	if !check.OK {
+		t.Fatalf("expected image pull smoke to pass, got detail=%q", check.Detail)
+	}
+	if len(smokeRunArgs) == 0 {
+		t.Fatal("expected image pull smoke to create a pod")
+	}
+	if containsArgPrefix(smokeRunArgs, "--overrides=") {
+		t.Fatalf("image pull smoke should not inject runtime hardening overrides, got args=%v", smokeRunArgs)
+	}
+}
+
+func TestRestrictedRunOverridesUsesNumericNonRootUser(t *testing.T) {
+	overrides := restrictedRunOverrides("probe", "curlimages/curl:8.7.1", "curl", "-sSI", "http://example.test")
+	for _, want := range []string{
+		`"runAsNonRoot":true`,
+		`"runAsUser":65532`,
+		`"command":["curl"]`,
+		`"args":["-sSI","http://example.test"]`,
+	} {
+		if !strings.Contains(overrides, want) {
+			t.Fatalf("restricted overrides missing %s: %s", want, overrides)
+		}
+	}
+}
+
+func containsArgPrefix(args []string, prefix string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/cluster/doctor_impl_test.go
+++ b/internal/cli/cluster/doctor_impl_test.go
@@ -657,15 +657,17 @@ func TestDoctorCurlProbesPassPathValidator(t *testing.T) {
 	validators := []core.ExecValidator{core.NoControlChars(), core.PathUnder("/workspace")}
 
 	t.Run("ingress route probe", func(t *testing.T) {
+		var probeArgs []string
 		mock := &core.MockExecutor{
 			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
 				switch {
-				case contains(spec.Args, "jsonpath={range .items[*]}{.metadata.name}|{.spec.rules[0].host}|{.spec.rules[0].http.paths[0].path}"):
+				case strings.Contains(strings.Join(spec.Args, "\x00"), "{.metadata.name}|{.spec.rules[0].host}|{.spec.rules[0].http.paths[0].path}"):
 					return &core.MockCommand{OutputData: []byte("doctor-smoke-old||/doctor-smoke-old/mcp\ndemo||/demo/mcp\n")}
-				case contains(spec.Args, "svc"):
+				case contains(spec.Args, "get") && contains(spec.Args, "svc"):
 					return &core.MockCommand{OutputData: []byte("web:8000:32080\n")}
-				case contains(spec.Args, "curl"):
-					if contains(spec.Args, "/dev/null") {
+				case len(spec.Args) > 0 && spec.Args[0] == "run":
+					probeArgs = append([]string(nil), spec.Args...)
+					if strings.Contains(strings.Join(spec.Args, "\x00"), "/dev/null") {
 						t.Fatal("doctor curl helper should not pass /dev/null through kubectl validators")
 					}
 					return &core.MockCommand{OutputData: []byte("200")}
@@ -678,6 +680,21 @@ func TestDoctorCurlProbesPassPathValidator(t *testing.T) {
 		check := checkIngressRouteProbe(kubectl, "mcp-servers", DistroGeneric)
 		if !check.OK {
 			t.Fatalf("expected OK, got detail=%q", check.Detail)
+		}
+		overrides := argValueWithPrefix(probeArgs, "--overrides=")
+		if overrides == "" {
+			t.Fatalf("ingress route probe should use restricted-compliant overrides, got args=%v", probeArgs)
+		}
+		for _, want := range []string{
+			`"allowPrivilegeEscalation":false`,
+			`"runAsNonRoot":true`,
+			`"runAsUser":65532`,
+			`"seccompProfile":{"type":"RuntimeDefault"}`,
+			`"command":["curl"]`,
+		} {
+			if !strings.Contains(overrides, want) {
+				t.Fatalf("ingress route probe overrides missing %s: %s", want, overrides)
+			}
 		}
 	})
 
@@ -1210,7 +1227,7 @@ func TestCheckMCPServersImagePullSecrets(t *testing.T) {
 	})
 }
 
-func TestCheckMCPServersImagePullSmokeUsesNeutralPodSpec(t *testing.T) {
+func TestCheckMCPServersImagePullSmokeUsesRestrictedCompliantPodSpec(t *testing.T) {
 	var smokeRunArgs []string
 	mock := &core.MockExecutor{
 		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
@@ -1237,8 +1254,26 @@ func TestCheckMCPServersImagePullSmokeUsesNeutralPodSpec(t *testing.T) {
 	if len(smokeRunArgs) == 0 {
 		t.Fatal("expected image pull smoke to create a pod")
 	}
-	if containsArgPrefix(smokeRunArgs, "--overrides=") {
-		t.Fatalf("image pull smoke should not inject runtime hardening overrides, got args=%v", smokeRunArgs)
+	overrides := argValueWithPrefix(smokeRunArgs, "--overrides=")
+	if overrides == "" {
+		t.Fatalf("image pull smoke should use restricted-compliant overrides, got args=%v", smokeRunArgs)
+	}
+	for _, want := range []string{
+		`"automountServiceAccountToken":false`,
+		`"allowPrivilegeEscalation":false`,
+		`"runAsNonRoot":true`,
+		`"runAsUser":65532`,
+		`"seccompProfile":{"type":"RuntimeDefault"}`,
+		`"capabilities":{"drop":["ALL"]}`,
+	} {
+		if !strings.Contains(overrides, want) {
+			t.Fatalf("image pull smoke overrides missing %s: %s", want, overrides)
+		}
+	}
+	for _, notWant := range []string{`"command":`, `"args":`} {
+		if strings.Contains(overrides, notWant) {
+			t.Fatalf("image pull smoke overrides should not set %s: %s", notWant, overrides)
+		}
 	}
 }
 
@@ -1256,11 +1291,11 @@ func TestRestrictedRunOverridesUsesNumericNonRootUser(t *testing.T) {
 	}
 }
 
-func containsArgPrefix(args []string, prefix string) bool {
+func argValueWithPrefix(args []string, prefix string) string {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, prefix) {
-			return true
+			return strings.TrimPrefix(arg, prefix)
 		}
 	}
-	return false
+	return ""
 }

--- a/internal/cli/cluster/manager.go
+++ b/internal/cli/cluster/manager.go
@@ -505,6 +505,17 @@ kind: Namespace
 metadata:
   name: %s
 `, name)
+	if name == core.NamespaceMCPServers {
+		nsYAML = fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+`, name)
+	}
 	// #nosec G204 -- fixed kubectl command, input via stdin; name from internal code.
 	cmd, err := m.kubectl.CommandArgs([]string{"apply", "--validate=false", "-f", "-"})
 	if err != nil {

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -562,6 +562,8 @@ func TestRenderAnalyticsSecretManifestReusesExistingPassword(t *testing.T) {
 
 func TestRenderAnalyticsSecretManifestReusesExistingAPIKeys(t *testing.T) {
 	apiKeyEncoded := base64.StdEncoding.EncodeToString([]byte("api-key"))
+	ingestKeyEncoded := base64.StdEncoding.EncodeToString([]byte("ingest-key"))
+	adminKeyEncoded := base64.StdEncoding.EncodeToString([]byte("admin-key"))
 	uiKeyEncoded := base64.StdEncoding.EncodeToString([]byte("ui-key"))
 	passwordEncoded := base64.StdEncoding.EncodeToString([]byte("grafana-password"))
 	mock := &core.MockExecutor{
@@ -569,6 +571,10 @@ func TestRenderAnalyticsSecretManifestReusesExistingAPIKeys(t *testing.T) {
 			switch {
 			case contains(spec.Args, "jsonpath={.data.API_KEYS}"):
 				return &core.MockCommand{Args: spec.Args, OutputData: []byte(apiKeyEncoded)}
+			case contains(spec.Args, "jsonpath={.data.INGEST_API_KEYS}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: []byte(ingestKeyEncoded)}
+			case contains(spec.Args, "jsonpath={.data.ADMIN_API_KEYS}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: []byte(adminKeyEncoded)}
 			case contains(spec.Args, "jsonpath={.data.UI_API_KEY}"):
 				return &core.MockCommand{Args: spec.Args, OutputData: []byte(uiKeyEncoded)}
 			case contains(spec.Args, "jsonpath={.data.GRAFANA_ADMIN_PASSWORD}"):
@@ -587,6 +593,12 @@ func TestRenderAnalyticsSecretManifestReusesExistingAPIKeys(t *testing.T) {
 	data := secretStringDataFromManifest(t, manifest)
 	if data["API_KEYS"] != "api-key,ui-key" {
 		t.Fatalf("expected existing API key list to include UI key, got %q", data["API_KEYS"])
+	}
+	if data["INGEST_API_KEYS"] != "ingest-key" {
+		t.Fatalf("expected existing ingest API key list to be reused, got %q", data["INGEST_API_KEYS"])
+	}
+	if data["ADMIN_API_KEYS"] != "admin-key,ui-key" {
+		t.Fatalf("expected existing admin API key list to include UI key, got %q", data["ADMIN_API_KEYS"])
 	}
 	if data["UI_API_KEY"] != "ui-key" {
 		t.Fatalf("expected existing UI API key to be reused, got %q", data["UI_API_KEY"])
@@ -661,8 +673,17 @@ func TestRenderAnalyticsSecretManifestGeneratesKeysWhenMissing(t *testing.T) {
 	if data["UI_API_KEY"] == "" {
 		t.Fatalf("expected generated UI API key, got %q", manifest)
 	}
+	if data["INGEST_API_KEYS"] == "" {
+		t.Fatalf("expected generated ingest API key, got %q", manifest)
+	}
+	if data["ADMIN_API_KEYS"] == "" {
+		t.Fatalf("expected admin API key list, got %q", manifest)
+	}
 	if !csvHasValue(data["API_KEYS"], data["UI_API_KEY"]) {
 		t.Fatalf("expected UI_API_KEY to be included in API_KEYS, got API_KEYS=%q UI_API_KEY=%q", data["API_KEYS"], data["UI_API_KEY"])
+	}
+	if !csvHasValue(data["ADMIN_API_KEYS"], data["UI_API_KEY"]) {
+		t.Fatalf("expected UI_API_KEY to be included in ADMIN_API_KEYS, got ADMIN_API_KEYS=%q UI_API_KEY=%q", data["ADMIN_API_KEYS"], data["UI_API_KEY"])
 	}
 	if data["GRAFANA_ADMIN_PASSWORD"] == "" {
 		t.Fatalf("expected generated grafana password, got %q", manifest)

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -1856,11 +1856,20 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
+	ingestAPIKeys, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "INGEST_API_KEYS", 16)
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
 	uiAPIKey, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "UI_API_KEY", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
 	apiKeys = ensureCSVIncludes(apiKeys, uiAPIKey)
+	adminAPIKeys, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "ADMIN_API_KEYS")
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
+	adminAPIKeys = ensureCSVIncludes(adminAPIKeys, uiAPIKey)
 	grafanaPassword, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "GRAFANA_ADMIN_PASSWORD", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
@@ -1918,6 +1927,8 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 		"type": "Opaque",
 		"stringData": map[string]string{
 			"API_KEYS":                apiKeys,
+			"INGEST_API_KEYS":         ingestAPIKeys,
+			"ADMIN_API_KEYS":          adminAPIKeys,
 			"UI_API_KEY":              uiAPIKey,
 			"ADMIN_USERS":             adminUsers,
 			"PLATFORM_ADMIN_EMAIL":    platformAdminEmail,

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -92,7 +92,6 @@ type resourceReadiness = operatorutil.ResourceReadiness
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;update
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get
 //+kubebuilder:rbac:groups=mcpruntime.org,resources=mcpaccessgrants,verbs=get;list;watch
 //+kubebuilder:rbac:groups=mcpruntime.org,resources=mcpagentsessions,verbs=get;list;watch
 
@@ -398,6 +397,13 @@ func (r *MCPServerReconciler) reconcileDeployment(ctx context.Context, mcpServer
 			return err
 		}
 		deployment.Spec.Template.Spec = corev1.PodSpec{
+			AutomountServiceAccountToken: boolPtr(false),
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: boolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			ImagePullSecrets: r.buildImagePullSecrets(mcpServer),
 			Containers:       containers,
 			Volumes:          volumes,
@@ -478,6 +484,13 @@ func (r *MCPServerReconciler) reconcileCanaryDeployment(ctx context.Context, mcp
 			return err
 		}
 		deployment.Spec.Template.Spec = corev1.PodSpec{
+			AutomountServiceAccountToken: boolPtr(false),
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: boolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
 			ImagePullSecrets: r.buildImagePullSecrets(mcpServer),
 			Containers:       containers,
 			Volumes:          volumes,
@@ -509,6 +522,13 @@ func (r *MCPServerReconciler) buildDeploymentContainers(mcpServer *mcpv1alpha1.M
 			},
 		},
 		Env: r.buildEnvVars(mcpServer.Spec.EnvVars, mcpServer.Spec.SecretEnvVars),
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			RunAsNonRoot:             boolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(mcpServer.Spec.Port)},
@@ -746,6 +766,14 @@ func (r *MCPServerReconciler) buildGatewayContainer(mcpServer *mcpv1alpha1.MCPSe
 			},
 		},
 		Env: envVars,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: boolPtr(false),
+			RunAsNonRoot:             boolPtr(true),
+			ReadOnlyRootFilesystem:   boolPtr(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      gatewayPolicyVolumeName,
@@ -772,6 +800,10 @@ func (r *MCPServerReconciler) buildGatewayContainer(mcpServer *mcpv1alpha1.MCPSe
 		return corev1.Container{}, err
 	}
 	return container, nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func (r *MCPServerReconciler) reconcilePolicyConfigMap(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer) error {

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -77,6 +77,7 @@ const (
 	gatewayPolicyMountDir   = "/var/run/mcp-runtime/policy"
 	gatewayPolicyFileName   = "policy.json"
 	gatewayPolicyFilePath   = gatewayPolicyMountDir + "/" + gatewayPolicyFileName
+	restrictedRunAsUser     = int64(65532)
 )
 
 // resourceReadiness tracks the readiness state of different resources.
@@ -400,6 +401,7 @@ func (r *MCPServerReconciler) reconcileDeployment(ctx context.Context, mcpServer
 			AutomountServiceAccountToken: boolPtr(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: boolPtr(true),
+				RunAsUser:    int64Ptr(restrictedRunAsUser),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -487,6 +489,7 @@ func (r *MCPServerReconciler) reconcileCanaryDeployment(ctx context.Context, mcp
 			AutomountServiceAccountToken: boolPtr(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: boolPtr(true),
+				RunAsUser:    int64Ptr(restrictedRunAsUser),
 				SeccompProfile: &corev1.SeccompProfile{
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
@@ -803,6 +806,10 @@ func (r *MCPServerReconciler) buildGatewayContainer(mcpServer *mcpv1alpha1.MCPSe
 }
 
 func boolPtr(value bool) *bool {
+	return &value
+}
+
+func int64Ptr(value int64) *int64 {
 	return &value
 }
 

--- a/internal/operator/controller_test.go
+++ b/internal/operator/controller_test.go
@@ -480,6 +480,22 @@ func TestReconcileDeploymentLabels(t *testing.T) {
 	if deployment.Spec.Template.Labels["app.kubernetes.io/managed-by"] != "mcp-runtime" {
 		t.Fatalf("pod template label managed-by = %q, want %q", deployment.Spec.Template.Labels["app.kubernetes.io/managed-by"], "mcp-runtime")
 	}
+	if deployment.Spec.Template.Spec.AutomountServiceAccountToken == nil || *deployment.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Fatal("expected MCPServer pods to disable service account token automount")
+	}
+	if deployment.Spec.Template.Spec.SecurityContext == nil || deployment.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
+		t.Fatal("expected MCPServer pod security context with seccomp profile")
+	}
+	if deployment.Spec.Template.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("seccomp profile = %q, want %q", deployment.Spec.Template.Spec.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
+	}
+	server := deployment.Spec.Template.Spec.Containers[0]
+	if server.SecurityContext == nil || server.SecurityContext.AllowPrivilegeEscalation == nil || *server.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected MCPServer container to disallow privilege escalation")
+	}
+	if server.SecurityContext.Capabilities == nil || len(server.SecurityContext.Capabilities.Drop) != 1 || server.SecurityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
+		t.Fatalf("expected MCPServer container to drop all capabilities, got %#v", server.SecurityContext.Capabilities)
+	}
 }
 
 func TestReconcileDeploymentAddsGatewaySidecar(t *testing.T) {
@@ -548,6 +564,12 @@ func TestReconcileDeploymentAddsGatewaySidecar(t *testing.T) {
 	gateway := deployment.Spec.Template.Spec.Containers[1]
 	assertEqual(t, "gatewayName", gateway.Name, "mcp-gateway")
 	assertEqual(t, "gatewayImage", gateway.Image, "example.com/mcp-proxy:latest")
+	if gateway.SecurityContext == nil || gateway.SecurityContext.ReadOnlyRootFilesystem == nil || !*gateway.SecurityContext.ReadOnlyRootFilesystem {
+		t.Fatal("expected gateway sidecar to use a read-only root filesystem")
+	}
+	if gateway.SecurityContext.AllowPrivilegeEscalation == nil || *gateway.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected gateway sidecar to disallow privilege escalation")
+	}
 
 	envByName := make(map[string]corev1.EnvVar, len(gateway.Env))
 	for _, envVar := range gateway.Env {

--- a/internal/operator/controller_test.go
+++ b/internal/operator/controller_test.go
@@ -489,6 +489,9 @@ func TestReconcileDeploymentLabels(t *testing.T) {
 	if deployment.Spec.Template.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
 		t.Fatalf("seccomp profile = %q, want %q", deployment.Spec.Template.Spec.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
 	}
+	if deployment.Spec.Template.Spec.SecurityContext.RunAsUser == nil || *deployment.Spec.Template.Spec.SecurityContext.RunAsUser != restrictedRunAsUser {
+		t.Fatalf("runAsUser = %v, want %d", deployment.Spec.Template.Spec.SecurityContext.RunAsUser, restrictedRunAsUser)
+	}
 	server := deployment.Spec.Template.Spec.Containers[0]
 	if server.SecurityContext == nil || server.SecurityContext.AllowPrivilegeEscalation == nil || *server.SecurityContext.AllowPrivilegeEscalation {
 		t.Fatal("expected MCPServer container to disallow privilege escalation")

--- a/k8s/02-secrets.yaml
+++ b/k8s/02-secrets.yaml
@@ -14,7 +14,9 @@ metadata:
   namespace: mcp-sentinel
 type: Opaque
 stringData:
-  API_KEYS: "changeme"  # Fill in with actual API keys (comma-separated)
+  API_KEYS: "changeme"  # Fill in with actual API keys for Sentinel API/UI (comma-separated)
+  ADMIN_API_KEYS: "changeme"  # API_KEYS entries that should authenticate as admin
+  INGEST_API_KEYS: "changeme"  # Fill in with ingest-only keys used by MCP proxy/gateway analytics
   UI_API_KEY: "changeme"  # Fill in with actual UI API key
   GRAFANA_ADMIN_USER: "admin"
   GRAFANA_ADMIN_PASSWORD: "changeme"

--- a/k8s/02-secrets.yaml.example
+++ b/k8s/02-secrets.yaml.example
@@ -9,8 +9,12 @@ metadata:
   namespace: mcp-sentinel
 type: Opaque
 stringData:
-  # API keys for authentication (comma-separated list)
+  # API keys for Sentinel API/UI authentication (comma-separated list)
   API_KEYS: "your-api-key-here,another-key-here"
+  # API_KEYS entries that authenticate as admin. Other API_KEYS entries are user-scoped.
+  ADMIN_API_KEYS: "your-ui-key-here"
+  # Ingest-only key used by MCP proxy/gateway analytics.
+  INGEST_API_KEYS: "your-ingest-key-here"
   # API key for UI access
   UI_API_KEY: "your-ui-key-here"
   # Optional seeded platform admin account.

--- a/k8s/03-clickhouse-hostpath.yaml
+++ b/k8s/03-clickhouse-hostpath.yaml
@@ -58,6 +58,7 @@ spec:
       labels:
         app: clickhouse
     spec:
+      automountServiceAccountToken: false
       initContainers:
         - name: init-perms
           image: alpine:3.23

--- a/k8s/03-clickhouse.yaml
+++ b/k8s/03-clickhouse.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: clickhouse
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: clickhouse
           image: clickhouse/clickhouse-server:23.8

--- a/k8s/04-clickhouse-init.yaml
+++ b/k8s/04-clickhouse-init.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   template:
     spec:
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
       containers:
         - name: init

--- a/k8s/05-kafka-hostpath.yaml
+++ b/k8s/05-kafka-hostpath.yaml
@@ -139,6 +139,7 @@ spec:
       labels:
         app: zookeeper
     spec:
+      automountServiceAccountToken: false
       initContainers:
         - name: init-perms
           image: alpine:3.23
@@ -210,6 +211,7 @@ spec:
       labels:
         app: kafka
     spec:
+      automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
         fsGroup: 1000

--- a/k8s/05-kafka.yaml
+++ b/k8s/05-kafka.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: zookeeper
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: zookeeper
           image: confluentinc/cp-zookeeper:7.5.1
@@ -66,6 +67,7 @@ spec:
       labels:
         app: kafka
     spec:
+      automountServiceAccountToken: false
       enableServiceLinks: false
       securityContext:
         fsGroup: 1000

--- a/k8s/06-ingest.yaml
+++ b/k8s/06-ingest.yaml
@@ -30,6 +30,7 @@ spec:
       labels:
         app: mcp-sentinel-ingest
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:
@@ -49,18 +50,16 @@ spec:
           envFrom:
             - configMapRef:
                 name: mcp-sentinel-config
-            - secretRef:
-                name: mcp-sentinel-secrets
           env:
             - name: PORT
               value: "8081"
             - name: METRICS_PORT
               value: "9091"
-            - name: API_KEYS
+            - name: INGEST_API_KEYS
               valueFrom:
                 secretKeyRef:
                   name: mcp-sentinel-secrets
-                  key: API_KEYS
+                  key: INGEST_API_KEYS
             - name: OTEL_SERVICE_NAME
               value: mcp-sentinel-ingest
           resources:

--- a/k8s/07-processor.yaml
+++ b/k8s/07-processor.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: mcp-sentinel-processor
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:

--- a/k8s/08-api-rbac.yaml
+++ b/k8s/08-api-rbac.yaml
@@ -36,6 +36,11 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "list", "watch", "create"]
+  # User-scoped deployment requests use Kubernetes impersonation so namespace
+  # RBAC is enforced as the platform user instead of the API service account.
+  - apiGroups: [""]
+    resources: ["users", "groups"]
+    verbs: ["impersonate"]
   # List pods for health checks and logs
   - apiGroups: [""]
     resources: ["pods"]

--- a/k8s/08-api-rbac.yaml
+++ b/k8s/08-api-rbac.yaml
@@ -7,10 +7,10 @@ rules:
   - apiGroups: ["mcpruntime.org"]
     resources: ["mcpaccessgrants", "mcpagentsessions"]
     verbs: ["get", "list", "watch"]
-  # Create/update via POST /api/runtime/grants|sessions (apply semantics)
+  # Create/update/delete via /api/runtime/grants|sessions.
   - apiGroups: ["mcpruntime.org"]
     resources: ["mcpaccessgrants", "mcpagentsessions"]
-    verbs: ["create", "update"]
+    verbs: ["create", "update", "delete"]
   # Safe mutations (enable/disable/revoke/unrevoke)
   - apiGroups: ["mcpruntime.org"]
     resources: ["mcpaccessgrants"]
@@ -20,8 +20,11 @@ rules:
     verbs: ["patch"]
   # Restart deployments (for safe ops)
   - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets", "daemonsets"]
+    resources: ["deployments"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch", "patch"]
   # User deployment API creates Services in owned namespaces
   - apiGroups: [""]
     resources: ["services"]
@@ -29,14 +32,10 @@ rules:
   # User namespace provisioning guardrails
   - apiGroups: [""]
     resources: ["namespaces", "resourcequotas", "limitranges"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
+    verbs: ["get", "list", "watch", "create"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"]
-  # Required when user-scoped deployment calls use Kubernetes impersonation.
-  - apiGroups: [""]
-    resources: ["users", "groups"]
-    verbs: ["impersonate"]
+    verbs: ["get", "list", "watch", "create"]
   # List pods for health checks and logs
   - apiGroups: [""]
     resources: ["pods"]
@@ -48,7 +47,7 @@ rules:
   # Read configmaps for policy lookup
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list"]
+    verbs: ["get"]
   # Read MCPServer resources
   - apiGroups: ["mcpruntime.org"]
     resources: ["mcpservers"]

--- a/k8s/08-api.yaml
+++ b/k8s/08-api.yaml
@@ -66,6 +66,12 @@ spec:
                 secretKeyRef:
                   name: mcp-sentinel-secrets
                   key: API_KEYS
+            - name: ADMIN_API_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-sentinel-secrets
+                  key: ADMIN_API_KEYS
+                  optional: true
             - name: POSTGRES_DSN
               valueFrom:
                 secretKeyRef:

--- a/k8s/09-ui.yaml
+++ b/k8s/09-ui.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: mcp-sentinel-ui
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:
@@ -59,11 +60,6 @@ spec:
                 secretKeyRef:
                   name: mcp-sentinel-secrets
                   key: UI_API_KEY
-            - name: API_KEYS
-              valueFrom:
-                secretKeyRef:
-                  name: mcp-sentinel-secrets
-                  key: API_KEYS
             - name: OTEL_SERVICE_NAME
               value: mcp-sentinel-ui
           resources:

--- a/k8s/10-gateway.yaml
+++ b/k8s/10-gateway.yaml
@@ -392,27 +392,52 @@ kind: ServiceAccount
 metadata:
   name: mcp-sentinel-gateway
   namespace: mcp-sentinel
+automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: mcp-sentinel-gateway
+  namespace: mcp-sentinel
 rules:
   - apiGroups: [""]
     resources: ["services", "endpoints", "secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.k8s.io"]
-    resources: ["ingresses", "ingressclasses"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-sentinel-gateway
+  namespace: mcp-sentinel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-sentinel-gateway
+subjects:
+  - kind: ServiceAccount
+    name: mcp-sentinel-gateway
+    namespace: mcp-sentinel
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcp-sentinel-gateway-ingressclass
+rules:
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingressclasses"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: mcp-sentinel-gateway
+  name: mcp-sentinel-gateway-ingressclass
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mcp-sentinel-gateway
+  name: mcp-sentinel-gateway-ingressclass
 subjects:
   - kind: ServiceAccount
     name: mcp-sentinel-gateway

--- a/k8s/11-prometheus.yaml
+++ b/k8s/11-prometheus.yaml
@@ -46,6 +46,7 @@ spec:
       labels:
         app: prometheus
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/k8s/12-grafana.yaml
+++ b/k8s/12-grafana.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: grafana
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: grafana
           image: grafana/grafana:10.2.3

--- a/k8s/13-mcp-example.yaml
+++ b/k8s/13-mcp-example.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: mcp-example-server
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:

--- a/k8s/14-mcp-proxy-sidecar.yaml
+++ b/k8s/14-mcp-proxy-sidecar.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         app: mcp-example-sidecar
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -71,7 +72,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mcp-sentinel-secrets
-                  key: API_KEYS
+                  key: INGEST_API_KEYS
             - name: ANALYTICS_SOURCE
               value: "mcp-proxy"
             - name: MCP_SERVER_NAME

--- a/k8s/15-otel-collector.yaml
+++ b/k8s/15-otel-collector.yaml
@@ -58,6 +58,7 @@ spec:
       labels:
         app: otel-collector
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: otel-collector
           image: otel/opentelemetry-collector:0.92.0

--- a/k8s/16-tempo.yaml
+++ b/k8s/16-tempo.yaml
@@ -63,6 +63,7 @@ spec:
       labels:
         app: tempo
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: tempo
           image: grafana/tempo:2.3.1

--- a/k8s/17-loki.yaml
+++ b/k8s/17-loki.yaml
@@ -69,6 +69,7 @@ spec:
         app: loki
         loki_mode: stateful
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001

--- a/k8s/18-promtail.yaml
+++ b/k8s/18-promtail.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   name: promtail
   namespace: mcp-sentinel
+automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -10,7 +11,7 @@ metadata:
   name: promtail
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "nodes", "nodes/proxy", "namespaces"]
+    resources: ["pods", "nodes", "namespaces"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,7 +38,7 @@ data:
       http_listen_port: 9080
       grpc_listen_port: 0
     positions:
-      filename: /var/log/positions.yaml
+      filename: /run/promtail/positions.yaml
     clients:
       - url: http://loki:3100/loki/api/v1/push
     scrape_configs:
@@ -81,15 +82,28 @@ spec:
         app: promtail
     spec:
       serviceAccountName: promtail
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: promtail
           image: grafana/promtail:2.9.4
           args: ["-config.file=/etc/promtail/promtail.yaml"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: config
               mountPath: /etc/promtail
+              readOnly: true
+            - name: positions
+              mountPath: /run/promtail
             - name: varlog
               mountPath: /var/log
+              readOnly: true
             - name: podlogs
               mountPath: /var/log/pods
               readOnly: true
@@ -97,6 +111,8 @@ spec:
         - name: config
           configMap:
             name: promtail-config
+        - name: positions
+          emptyDir: {}
         - name: varlog
           hostPath:
             path: /var/log

--- a/k8s/20-postgres-hostpath.yaml
+++ b/k8s/20-postgres-hostpath.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         app: mcp-sentinel-postgres
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 70
         runAsGroup: 70

--- a/k8s/20-postgres.yaml
+++ b/k8s/20-postgres.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         app: mcp-sentinel-postgres
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsUser: 70
         runAsGroup: 70

--- a/k8s/21-platform-admin-bootstrap-job.yaml
+++ b/k8s/21-platform-admin-bootstrap-job.yaml
@@ -11,11 +11,23 @@ spec:
       labels:
         app: mcp-sentinel-platform-admin-bootstrap
     spec:
+      automountServiceAccountToken: false
       restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: bootstrap
           image: mcp-sentinel-api:latest
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - configMapRef:
                 name: mcp-sentinel-config

--- a/services/api/deployments.go
+++ b/services/api/deployments.go
@@ -17,7 +17,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 const (
@@ -247,15 +246,7 @@ func (s *RuntimeServer) clientForPrincipal(p principal) (kubernetes.Interface, e
 	if p.userID() == "" {
 		return nil, errPrincipalIdentityRequired
 	}
-	if s.k8sClients.Config == nil {
-		return s.k8sClients.Clientset, nil
-	}
-	cfg := rest.CopyConfig(s.k8sClients.Config)
-	cfg.Impersonate = rest.ImpersonationConfig{
-		UserName: "platform:user:" + p.userID(),
-		Groups:   []string{"platform:role:" + p.Role},
-	}
-	return kubernetes.NewForConfig(cfg)
+	return s.k8sClients.Clientset, nil
 }
 
 func (s *RuntimeServer) ensureUserNamespace(ctx context.Context, p principal) error {
@@ -367,11 +358,27 @@ func desiredDeployment(name, namespace, image string, port, replicas int32, labe
 		Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": name}},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
-			Spec: corev1.PodSpec{Containers: []corev1.Container{{
-				Name:  "server",
-				Image: image,
-				Ports: []corev1.ContainerPort{{ContainerPort: port}},
-			}}},
+			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: boolPtr(false),
+				SecurityContext: &corev1.PodSecurityContext{
+					RunAsNonRoot: boolPtr(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
+				Containers: []corev1.Container{{
+					Name:  "server",
+					Image: image,
+					Ports: []corev1.ContainerPort{{ContainerPort: port}},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolPtr(false),
+						RunAsNonRoot:             boolPtr(true),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+				}},
+			},
 		},
 	}}
 }
@@ -387,6 +394,10 @@ func desiredService(name, namespace string, port int32, labels map[string]string
 func intstrPtr(port int) *intstr.IntOrString {
 	v := intstr.FromInt(port)
 	return &v
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func upsertDeployment(ctx context.Context, client kubernetes.Interface, dep *appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/services/api/deployments.go
+++ b/services/api/deployments.go
@@ -24,6 +24,7 @@ const (
 	platformUserIDLabel  = "platform.mcpruntime.org/user-id"
 	createdByLabel       = "created-by"
 	defaultDeployPort    = int32(8088)
+	restrictedRunAsUser  = int64(65532)
 )
 
 var errPrincipalIdentityRequired = errors.New("authenticated user identity required")
@@ -362,6 +363,7 @@ func desiredDeployment(name, namespace, image string, port, replicas int32, labe
 				AutomountServiceAccountToken: boolPtr(false),
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: boolPtr(true),
+					RunAsUser:    int64Ptr(restrictedRunAsUser),
 					SeccompProfile: &corev1.SeccompProfile{
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},
@@ -397,6 +399,10 @@ func intstrPtr(port int) *intstr.IntOrString {
 }
 
 func boolPtr(value bool) *bool {
+	return &value
+}
+
+func int64Ptr(value int64) *int64 {
 	return &value
 }
 

--- a/services/api/deployments.go
+++ b/services/api/deployments.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 const (
@@ -247,7 +248,15 @@ func (s *RuntimeServer) clientForPrincipal(p principal) (kubernetes.Interface, e
 	if p.userID() == "" {
 		return nil, errPrincipalIdentityRequired
 	}
-	return s.k8sClients.Clientset, nil
+	if s.k8sClients.Config == nil {
+		return s.k8sClients.Clientset, nil
+	}
+	cfg := rest.CopyConfig(s.k8sClients.Config)
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: "platform:user:" + p.userID(),
+		Groups:   []string{"platform:role:" + p.Role},
+	}
+	return kubernetes.NewForConfig(cfg)
 }
 
 func (s *RuntimeServer) ensureUserNamespace(ctx context.Context, p principal) error {

--- a/services/api/deployments_test.go
+++ b/services/api/deployments_test.go
@@ -175,6 +175,9 @@ func TestDesiredDeploymentUsesRestrictedPodDefaults(t *testing.T) {
 	if podSpec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
 		t.Fatalf("seccomp profile = %q, want %q", podSpec.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
 	}
+	if podSpec.SecurityContext.RunAsUser == nil || *podSpec.SecurityContext.RunAsUser != restrictedRunAsUser {
+		t.Fatalf("runAsUser = %v, want %d", podSpec.SecurityContext.RunAsUser, restrictedRunAsUser)
+	}
 	container := podSpec.Containers[0]
 	if container.SecurityContext == nil || container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
 		t.Fatal("expected user workload container to disallow privilege escalation")

--- a/services/api/deployments_test.go
+++ b/services/api/deployments_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	"mcp-runtime/pkg/k8sclient"
 )
 
@@ -48,6 +49,41 @@ func TestClientForPrincipalRejectsServiceAdminWithoutIdentity(t *testing.T) {
 	}
 	if err != errPrincipalIdentityRequired {
 		t.Fatalf("error = %v, want %v", err, errPrincipalIdentityRequired)
+	}
+}
+
+func TestClientForPrincipalUsesKubernetesImpersonation(t *testing.T) {
+	var gotUser string
+	var gotGroups []string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser = r.Header.Get("Impersonate-User")
+		gotGroups = append([]string(nil), r.Header.Values("Impersonate-Group")...)
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"PodList","apiVersion":"v1","metadata":{"resourceVersion":"1"},"items":[]}`))
+	}))
+	t.Cleanup(api.Close)
+
+	server := &RuntimeServer{
+		k8sClients: &k8sclient.Clients{
+			Clientset: kubernetesfake.NewSimpleClientset(),
+			Config:    &rest.Config{Host: api.URL},
+		},
+	}
+	client, err := server.clientForPrincipal(principal{
+		Role:    roleUser,
+		Subject: "user-123",
+	})
+	if err != nil {
+		t.Fatalf("clientForPrincipal() error = %v", err)
+	}
+	if _, err := client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{}); err != nil {
+		t.Fatalf("list pods with impersonated client: %v", err)
+	}
+	if gotUser != "platform:user:user-123" {
+		t.Fatalf("Impersonate-User = %q, want %q", gotUser, "platform:user:user-123")
+	}
+	if !hasString(gotGroups, "platform:role:user") {
+		t.Fatalf("Impersonate-Group values = %v, want platform:role:user", gotGroups)
 	}
 }
 
@@ -205,4 +241,13 @@ func TestHandleDeploymentItemRejectsServiceUserWithoutIdentity(t *testing.T) {
 	if recorder.Code != http.StatusForbidden {
 		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
 	}
+}
+
+func hasString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/services/api/deployments_test.go
+++ b/services/api/deployments_test.go
@@ -161,6 +161,29 @@ func TestEnsureUserNamespaceSetsManagedLabel(t *testing.T) {
 	}
 }
 
+func TestDesiredDeploymentUsesRestrictedPodDefaults(t *testing.T) {
+	deployment := desiredDeployment("demo", "user-77", "registry.example.com/demo:latest", 8088, 1, map[string]string{
+		"app.kubernetes.io/name": "demo",
+	})
+	podSpec := deployment.Spec.Template.Spec
+	if podSpec.AutomountServiceAccountToken == nil || *podSpec.AutomountServiceAccountToken {
+		t.Fatal("expected deployed user workloads to disable service account token automount")
+	}
+	if podSpec.SecurityContext == nil || podSpec.SecurityContext.SeccompProfile == nil {
+		t.Fatal("expected pod security context with seccomp profile")
+	}
+	if podSpec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("seccomp profile = %q, want %q", podSpec.SecurityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
+	}
+	container := podSpec.Containers[0]
+	if container.SecurityContext == nil || container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatal("expected user workload container to disallow privilege escalation")
+	}
+	if container.SecurityContext.Capabilities == nil || len(container.SecurityContext.Capabilities.Drop) != 1 || container.SecurityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
+		t.Fatalf("expected user workload container to drop all capabilities, got %#v", container.SecurityContext.Capabilities)
+	}
+}
+
 func TestHandleDeploymentItemRejectsServiceUserWithoutIdentity(t *testing.T) {
 	client := kubernetesfake.NewSimpleClientset(
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team-a"}},

--- a/services/ingest/main.go
+++ b/services/ingest/main.go
@@ -57,7 +57,7 @@ func main() {
 	topic := envOr("KAFKA_TOPIC", "mcp.events")
 
 	apiKeys := map[string]struct{}{}
-	for _, key := range strings.Split(envOr("API_KEYS", ""), ",") {
+	for _, key := range strings.Split(envOr("INGEST_API_KEYS", envOr("API_KEYS", "")), ",") {
 		key = strings.TrimSpace(key)
 		if key != "" {
 			apiKeys[key] = struct{}{}
@@ -240,7 +240,7 @@ func (s *ingestServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 // auth is middleware that enforces API key authentication.
-// It checks for x-api-key header or supports optional OIDC JWT validation.
+// It checks for x-api-key from INGEST_API_KEYS (or legacy API_KEYS) or supports optional OIDC JWT validation.
 // If no API keys are configured, authentication is bypassed.
 func (s *ingestServer) auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/services/ingest/main.go
+++ b/services/ingest/main.go
@@ -57,7 +57,8 @@ func main() {
 	topic := envOr("KAFKA_TOPIC", "mcp.events")
 
 	apiKeys := map[string]struct{}{}
-	for _, key := range strings.Split(envOr("INGEST_API_KEYS", envOr("API_KEYS", "")), ",") {
+	ingestKeys := envOr("INGEST_API_KEYS", envOr("API_KEYS", ""))
+	for _, key := range strings.Split(ingestKeys, ",") {
 		key = strings.TrimSpace(key)
 		if key != "" {
 			apiKeys[key] = struct{}{}

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -1327,7 +1327,7 @@ restart_deployment_pods() {
   local name="$2"
   local timeout="${3:-180s}"
 
-  kubectl delete pod -n "${namespace}" -l "app=${name}" --ignore-not-found --wait=true >/dev/null
+  kubectl rollout restart "deploy/${name}" -n "${namespace}" >/dev/null
   kubectl rollout status "deploy/${name}" -n "${namespace}" --timeout="${timeout}"
 }
 

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 # Set E2E_SCENARIOS to a comma-separated subset for local debugging.
 # Supported values: all, smoke-auth, governance, trust, oauth, observability.
 # observability requires the full traffic suite: smoke-auth, governance, trust, oauth.
+#
+# For repeated local debugging, set E2E_CACHE_MODE=1. Cache mode implies
+# E2E_KEEP_CLUSTER=1, reuses an existing kind cluster and local registry, skips
+# platform setup when the core platform is already ready, and reuses cached
+# image tags from the local registry instead of pulling/building them again.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -83,8 +88,8 @@ MCP_POLICY_WAIT_TRIES="${MCP_POLICY_WAIT_TRIES:-90}"
 RAW_REQUEST_TRIES="${RAW_REQUEST_TRIES:-10}"
 MCP_SMOKE_AGENT_ENV_FILE="${MCP_SMOKE_AGENT_ENV_FILE:-.env}"
 MCP_SMOKE_AGENT_PROMPT="${MCP_SMOKE_AGENT_PROMPT:-Use the MCP upper tool to convert the exact word governance to uppercase. Reply with only the uppercase result.}"
-MCP_SMOKE_AGENT_PROVIDER="${MCP_SMOKE_AGENT_PROVIDER:-anthropic}"
-MCP_SMOKE_AGENT_MODEL="${MCP_SMOKE_AGENT_MODEL:-claude-sonnet-4-20250514}"
+MCP_SMOKE_AGENT_PROVIDER="${MCP_SMOKE_AGENT_PROVIDER:-openai}"
+MCP_SMOKE_AGENT_MODEL="${MCP_SMOKE_AGENT_MODEL:-}"
 MCP_SMOKE_AGENT_TIMEOUT="${MCP_SMOKE_AGENT_TIMEOUT:-90s}"
 UNKNOWN_SESSION_ID="${UNKNOWN_SESSION_ID:-sess-does-not-exist}"
 TEST_MODE_REGISTRY_IMAGE="${TEST_MODE_REGISTRY_IMAGE:-docker.io/library/mcp-runtime-registry:latest}"
@@ -99,6 +104,10 @@ E2E_SCENARIOS="${E2E_SCENARIOS-all}"
 E2E_SCENARIOS="${E2E_SCENARIOS//[[:space:]]/}"
 E2E_VALIDATE_SCENARIOS_ONLY="${E2E_VALIDATE_SCENARIOS_ONLY:-0}"
 E2E_KEEP_CLUSTER="${E2E_KEEP_CLUSTER:-0}"
+E2E_CACHE_MODE="${E2E_CACHE_MODE:-0}"
+if [[ "${E2E_CACHE_MODE}" == "1" ]]; then
+  E2E_KEEP_CLUSTER=1
+fi
 
 IFS=',' read -r -a E2E_SCENARIO_LIST <<< "${E2E_SCENARIOS}"
 if [[ ${#E2E_SCENARIO_LIST[@]} -eq 0 || -z "${E2E_SCENARIO_LIST[0]}" ]]; then
@@ -709,6 +718,20 @@ should_run_mcp_smoke_agent() {
   return 1
 }
 
+mcp_smoke_agent_key_hint() {
+  case "${MCP_SMOKE_AGENT_PROVIDER}" in
+    anthropic)
+      echo "ANTHROPIC_API_KEY"
+      ;;
+    openai|"")
+      echo "OPENAI_API_KEY"
+      ;;
+    *)
+      echo "OPENAI_API_KEY/ANTHROPIC_API_KEY"
+      ;;
+  esac
+}
+
 run_mcp_smoke_agent_prompt() {
   local url="$1"
   local case_name="${2:-governance}"
@@ -1299,6 +1322,15 @@ wait_for_deployment_exists() {
   return 1
 }
 
+restart_deployment_pods() {
+  local namespace="$1"
+  local name="$2"
+  local timeout="${3:-180s}"
+
+  kubectl delete pod -n "${namespace}" -l "app=${name}" --ignore-not-found --wait=true >/dev/null
+  kubectl rollout status "deploy/${name}" -n "${namespace}" --timeout="${timeout}"
+}
+
 prepare_example_metadata() {
   local metadata_dir="$1"
   local server_name="$2"
@@ -1433,25 +1465,33 @@ deploy_example_server_via_pipeline() {
   image_ref="${image_repo}:latest"
   prepare_example_metadata "${example_workspace_dir}/.mcp" "${server_name}" "${ingress_host}" "${route_path}" "${image_repo}"
 
-  echo "[deploy] building example image ${server_name}:latest"
-  (
-    cd "${example_workspace_dir}"
-    "${PROJECT_ROOT}/bin/mcp-runtime" server build image "${server_name}" \
-      --metadata-dir .mcp \
-      --dockerfile Dockerfile \
-      --registry "docker.io/library" \
-      --tag latest \
-      --context .
-  )
+  if pull_cached_image "${image_ref}"; then
+    echo "[cache] skipping example image build/push for ${server_name}:latest"
+  else
+    echo "[deploy] building example image ${server_name}:latest"
+    (
+      cd "${example_workspace_dir}"
+      "${PROJECT_ROOT}/bin/mcp-runtime" server build image "${server_name}" \
+        --metadata-dir .mcp \
+        --dockerfile Dockerfile \
+        --registry "docker.io/library" \
+        --tag latest \
+        --context .
+    )
 
-  echo "[deploy] pushing ${server_name}:latest via registry CLI"
+    echo "[deploy] pushing ${server_name}:latest via registry CLI"
+    (
+      cd "${example_workspace_dir}"
+      "${PROJECT_ROOT}/bin/mcp-runtime" registry push \
+        --image "${image_ref}" \
+        --mode direct \
+        --registry "${LOCAL_REGISTRY_PUSH_HOST}" \
+        --name "library/${server_name}"
+    )
+  fi
+
   (
     cd "${example_workspace_dir}"
-    "${PROJECT_ROOT}/bin/mcp-runtime" registry push \
-      --image "${image_ref}" \
-      --mode direct \
-      --registry "${LOCAL_REGISTRY_PUSH_HOST}" \
-      --name "library/${server_name}"
     "${PROJECT_ROOT}/bin/mcp-runtime" pipeline generate --dir .mcp --output manifests
     "${PROJECT_ROOT}/bin/mcp-runtime" pipeline deploy --dir manifests
   )
@@ -1533,6 +1573,48 @@ local_registry_target() {
   echo "${LOCAL_REGISTRY_PUSH_HOST}/$(mirror_repository_path "${image}")"
 }
 
+cache_mode_enabled() {
+  [[ "${E2E_CACHE_MODE}" == "1" ]]
+}
+
+kind_cluster_exists() {
+  kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"
+}
+
+registry_target_exists() {
+  local target="$1"
+  local ref="${target#${LOCAL_REGISTRY_PUSH_HOST}/}"
+  local repo="${ref%:*}"
+  local tag="${ref##*:}"
+
+  if [[ "${repo}" == "${ref}" ]]; then
+    repo="${ref}"
+    tag="latest"
+  fi
+
+  curl -fsS \
+    -H "Accept: application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.oci.image.index.v1+json" \
+    "http://${LOCAL_REGISTRY_PUSH_HOST}/v2/${repo}/manifests/${tag}" >/dev/null 2>&1
+}
+
+pull_cached_image() {
+  local image="$1"
+  local target
+  target="$(local_registry_target "${image}")"
+
+  if ! cache_mode_enabled; then
+    return 1
+  fi
+  ensure_local_registry_running
+  if ! registry_target_exists "${target}"; then
+    return 1
+  fi
+
+  echo "[cache] reusing ${image} from local registry ${target}"
+  docker pull "${target}" >/dev/null
+  docker tag "${target}" "${image}"
+}
+
 run_with_retry() {
   local description="$1"
   shift
@@ -1570,6 +1652,10 @@ build_and_publish_image() {
   local dockerfile="$2"
   local context_dir="$3"
 
+  if pull_cached_image "${image}"; then
+    return 0
+  fi
+
   echo "[image] building ${image}"
   docker build -t "${image}" -f "${dockerfile}" "${context_dir}"
   publish_image_to_local_registry "${image}"
@@ -1580,6 +1666,10 @@ mirror_upstream_image() {
   local target
 
   echo "[image] mirroring ${image} into ${LOCAL_REGISTRY_NAME}"
+  if pull_cached_image "${image}"; then
+    return 0
+  fi
+
   target="$(local_registry_target "${image}")"
   ensure_local_registry_running
   if docker pull "${target}" >/dev/null 2>&1; then
@@ -1594,6 +1684,16 @@ mirror_upstream_image() {
 
 start_local_registry() {
   if docker ps -a --format '{{.Names}}' | grep -qx "${LOCAL_REGISTRY_NAME}"; then
+    if cache_mode_enabled; then
+      if docker ps --format '{{.Names}}' | grep -qx "${LOCAL_REGISTRY_NAME}"; then
+        echo "[registry] reusing local docker hub mirror ${LOCAL_REGISTRY_NAME} on localhost:${LOCAL_REGISTRY_PORT}"
+      else
+        echo "[registry] starting existing local docker hub mirror ${LOCAL_REGISTRY_NAME} on localhost:${LOCAL_REGISTRY_PORT}"
+        docker start "${LOCAL_REGISTRY_NAME}" >/dev/null
+      fi
+      wait_http "http://127.0.0.1:${LOCAL_REGISTRY_PORT}/v2/" "" 30
+      return
+    fi
     docker rm -f "${LOCAL_REGISTRY_NAME}" >/dev/null 2>&1 || true
   fi
 
@@ -1619,6 +1719,18 @@ ensure_local_registry_running() {
   fi
 }
 
+platform_cache_ready() {
+  if ! cache_mode_enabled; then
+    return 1
+  fi
+  kubectl get namespace registry mcp-runtime mcp-sentinel mcp-servers >/dev/null 2>&1 || return 1
+  kubectl rollout status deploy/registry -n registry --timeout=5s >/dev/null 2>&1 || return 1
+  kubectl rollout status deploy/mcp-runtime-operator-controller-manager -n mcp-runtime --timeout=5s >/dev/null 2>&1 || return 1
+  kubectl rollout status deploy/traefik -n traefik --timeout=5s >/dev/null 2>&1 || return 1
+  kubectl rollout status deploy/mcp-sentinel-api -n mcp-sentinel --timeout=5s >/dev/null 2>&1 || return 1
+  kubectl rollout status deploy/mcp-sentinel-gateway -n mcp-sentinel --timeout=5s >/dev/null 2>&1 || return 1
+}
+
 cat > "${KIND_CONFIG}" <<EOF
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -1634,8 +1746,12 @@ EOF
 
 start_local_registry
 
-echo "[kind] creating cluster ${CLUSTER_NAME}"
-kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}" --wait 120s
+if cache_mode_enabled && kind_cluster_exists; then
+  echo "[kind] reusing cluster ${CLUSTER_NAME}"
+else
+  echo "[kind] creating cluster ${CLUSTER_NAME}"
+  kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}" --wait 120s
+fi
 connect_local_registry_to_kind_network
 KUBECONFIG_FILE="/tmp/kubeconfig-kind"
 kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_FILE}"
@@ -1665,34 +1781,44 @@ mkdir -p "${MCP_SMOKE_GOPATH}"
   go build -o "${MCP_SMOKE_BIN}" ./cmd/mcp-smoke-agent
 )
 
-mirror_upstream_image "registry:2.8.3"
-mirror_upstream_image "traefik:v2.10"
-mirror_upstream_image "traefik:v3.0"
-mirror_upstream_image "clickhouse/clickhouse-server:23.8"
-mirror_upstream_image "confluentinc/cp-zookeeper:7.5.1"
-mirror_upstream_image "confluentinc/cp-kafka:7.5.1"
-mirror_upstream_image "prom/prometheus:v2.49.1"
-mirror_upstream_image "otel/opentelemetry-collector:0.92.0"
-mirror_upstream_image "grafana/tempo:2.3.1"
-mirror_upstream_image "grafana/loki:2.9.4"
-mirror_upstream_image "grafana/promtail:2.9.4"
-mirror_upstream_image "grafana/grafana:10.2.3"
-mirror_upstream_image "nginx:1.27-alpine"
-build_and_publish_image "docker.io/library/mcp-runtime-operator:latest" "Dockerfile.operator" "."
-build_and_publish_image "${TEST_MODE_REGISTRY_IMAGE}" "test/e2e/registry.Dockerfile" "."
-build_and_publish_image "docker.io/library/mcp-sentinel-mcp-proxy:latest" "${SENTINEL_ROOT}/services/mcp-proxy/Dockerfile" "${SENTINEL_ROOT}"
-build_and_publish_image "docker.io/library/mcp-sentinel-ingest:latest" "${SENTINEL_ROOT}/services/ingest/Dockerfile" "${SENTINEL_ROOT}/services/ingest"
-build_and_publish_image "docker.io/library/mcp-sentinel-api:latest" "${SENTINEL_ROOT}/services/api/Dockerfile" "${SENTINEL_ROOT}"
-build_and_publish_image "docker.io/library/mcp-sentinel-processor:latest" "${SENTINEL_ROOT}/services/processor/Dockerfile" "${SENTINEL_ROOT}/services/processor"
-build_and_publish_image "docker.io/library/mcp-sentinel-ui:latest" "${SENTINEL_ROOT}/services/ui/Dockerfile" "${SENTINEL_ROOT}/services/ui"
+PLATFORM_CACHE_READY=0
+if platform_cache_ready; then
+  PLATFORM_CACHE_READY=1
+  echo "[cache] reusing ready platform in cluster ${CLUSTER_NAME}"
+else
+  mirror_upstream_image "registry:2.8.3"
+  mirror_upstream_image "traefik:v2.10"
+  mirror_upstream_image "traefik:v3.0"
+  mirror_upstream_image "clickhouse/clickhouse-server:23.8"
+  mirror_upstream_image "confluentinc/cp-zookeeper:7.5.1"
+  mirror_upstream_image "confluentinc/cp-kafka:7.5.1"
+  mirror_upstream_image "prom/prometheus:v2.49.1"
+  mirror_upstream_image "otel/opentelemetry-collector:0.92.0"
+  mirror_upstream_image "grafana/tempo:2.3.1"
+  mirror_upstream_image "grafana/loki:2.9.4"
+  mirror_upstream_image "grafana/promtail:2.9.4"
+  mirror_upstream_image "grafana/grafana:10.2.3"
+  mirror_upstream_image "nginx:1.27-alpine"
+  build_and_publish_image "docker.io/library/mcp-runtime-operator:latest" "Dockerfile.operator" "."
+  build_and_publish_image "${TEST_MODE_REGISTRY_IMAGE}" "test/e2e/registry.Dockerfile" "."
+  build_and_publish_image "docker.io/library/mcp-sentinel-mcp-proxy:latest" "${SENTINEL_ROOT}/services/mcp-proxy/Dockerfile" "${SENTINEL_ROOT}"
+  build_and_publish_image "docker.io/library/mcp-sentinel-ingest:latest" "${SENTINEL_ROOT}/services/ingest/Dockerfile" "${SENTINEL_ROOT}/services/ingest"
+  build_and_publish_image "docker.io/library/mcp-sentinel-api:latest" "${SENTINEL_ROOT}/services/api/Dockerfile" "${SENTINEL_ROOT}"
+  build_and_publish_image "docker.io/library/mcp-sentinel-processor:latest" "${SENTINEL_ROOT}/services/processor/Dockerfile" "${SENTINEL_ROOT}/services/processor"
+  build_and_publish_image "docker.io/library/mcp-sentinel-ui:latest" "${SENTINEL_ROOT}/services/ui/Dockerfile" "${SENTINEL_ROOT}/services/ui"
+fi
 
-echo "[setup] running platform setup in test mode"
 export MCP_SETUP_WAIT_TIMEOUT="${MCP_SETUP_WAIT_TIMEOUT:-900}"
 export MCP_DEPLOYMENT_TIMEOUT="${MCP_DEPLOYMENT_TIMEOUT:-900s}"
 export MCP_REGISTRY_ENDPOINT="${MCP_REGISTRY_ENDPOINT:-registry.registry.svc.cluster.local:5000}"
 export MCP_INGRESS_READINESS_MODE="${MCP_INGRESS_READINESS_MODE:-permissive}"
-MCP_RUNTIME_REGISTRY_IMAGE_OVERRIDE="${TEST_MODE_REGISTRY_IMAGE}" \
-./bin/mcp-runtime setup --test-mode --ingress-manifest config/ingress/overlays/http
+if [[ "${PLATFORM_CACHE_READY}" == "1" ]]; then
+  echo "[setup] skipping platform setup because E2E_CACHE_MODE=1 found a ready platform"
+else
+  echo "[setup] running platform setup in test mode"
+  MCP_RUNTIME_REGISTRY_IMAGE_OVERRIDE="${TEST_MODE_REGISTRY_IMAGE}" \
+  ./bin/mcp-runtime setup --test-mode --ingress-manifest config/ingress/overlays/http
+fi
 
 echo "[verify] waiting for core platform components"
 rollout_status_with_logs registry deploy registry 180s
@@ -1727,7 +1853,33 @@ MCP_RUNTIME_CONFIG_DIR="${WORKDIR}/auth-config" ./bin/mcp-runtime auth logout
   --name "${CLUSTER_NAME}-dry-run" \
   --nodes 1 \
   --dry-run >"${WORKDIR}/cluster-provision-dry-run.txt"
-./bin/mcp-runtime cluster doctor
+if cache_mode_enabled; then
+  echo "[cache] removing previous policy/OAuth test grants and sessions"
+  kubectl delete mcpaccessgrant -n mcp-servers \
+    "${SERVER_NAME}-grant" \
+    "${SERVER_NAME}-e2e-api-grant" \
+    "${OAUTH_SERVER_NAME}-grant" \
+    --ignore-not-found --wait=true >/dev/null
+  kubectl delete mcpagentsession -n mcp-servers \
+    "${SESSION_ID}" \
+    "${SERVER_NAME}-e2e-api-session" \
+    --ignore-not-found --wait=true >/dev/null
+  echo "[cache] removing previous policy/OAuth test workloads before cluster doctor"
+  kubectl delete mcpserver -n mcp-servers "${SERVER_NAME}" "${OAUTH_SERVER_NAME}" --ignore-not-found --wait=true >/dev/null
+  kubectl delete deployment -n mcp-servers "${SERVER_NAME}" "${OAUTH_SERVER_NAME}" --ignore-not-found --wait=true >/dev/null
+  kubectl delete pod -n mcp-servers -l "app=${SERVER_NAME}" --ignore-not-found --wait=false >/dev/null
+  kubectl delete pod -n mcp-servers -l "app=${OAUTH_SERVER_NAME}" --ignore-not-found --wait=false >/dev/null
+  echo "[cache] deleting stale pending mcp-servers pods before cluster doctor"
+  kubectl delete pod -n mcp-servers --field-selector=status.phase=Pending --ignore-not-found --wait=false >/dev/null
+  echo "[cache] restarting operator before cluster doctor to avoid stale retained reconcile logs"
+  kubectl rollout restart deploy/mcp-runtime-operator-controller-manager -n mcp-runtime >/dev/null
+  rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
+fi
+if cache_mode_enabled; then
+  run_with_retry "cluster doctor" ./bin/mcp-runtime cluster doctor
+else
+  ./bin/mcp-runtime cluster doctor
+fi
 run_cli_allowing_cert_prereq_failure cluster-cert-status ./bin/mcp-runtime cluster cert status
 run_cli_allowing_cert_prereq_failure cluster-cert-apply-dry-run ./bin/mcp-runtime cluster cert apply --dry-run
 run_cli_allowing_cert_prereq_failure cluster-cert-wait ./bin/mcp-runtime cluster cert wait --timeout 1s
@@ -1748,9 +1900,20 @@ wait_port "${CLI_SENTINEL_API_PORT}" 30
 kill "${_cli_pf_pid}" >/dev/null 2>&1 || true
 wait "${_cli_pf_pid}" 2>/dev/null || true
 
-API_KEY="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.API_KEYS}' | decode_base64 | cut -d',' -f1)"
+API_KEY="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.UI_API_KEY}' | decode_base64)"
 if [[ -z "${API_KEY}" ]]; then
-  echo "[error] failed to resolve mcp-sentinel API key from secret" >&2
+  API_KEY="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.API_KEYS}' | decode_base64 | cut -d',' -f1)"
+fi
+if [[ -z "${API_KEY}" ]]; then
+  echo "[error] failed to resolve mcp-sentinel UI/API key from secret" >&2
+  exit 1
+fi
+INGEST_API_KEY="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.INGEST_API_KEYS}' | decode_base64 | cut -d',' -f1)"
+if [[ -z "${INGEST_API_KEY}" ]]; then
+  INGEST_API_KEY="${API_KEY}"
+fi
+if [[ -z "${INGEST_API_KEY}" ]]; then
+  echo "[error] failed to resolve mcp-sentinel ingest API key from secret" >&2
   exit 1
 fi
 
@@ -1768,13 +1931,15 @@ GO_EXAMPLE_WORKDIR="${WORKDIR}/go-mcp-server"
 echo "[deploy] creating server-local analytics credentials secret"
 kubectl create secret generic "${SERVER_SECRET_NAME}" \
   -n mcp-servers \
-  --from-literal=api-key="${API_KEY}" \
+  --from-literal=api-key="${INGEST_API_KEY}" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 cat > "${METADATA_FILE}" <<EOF
 version: v1
 servers:
   - name: ${SERVER_NAME}
+    image: ${SERVER_IMAGE%:*}
+    imageTag: ${SERVER_IMAGE##*:}
     route: /${SERVER_NAME}/mcp
     publicPathPrefix: ${SERVER_NAME}
     port: 8090
@@ -1812,15 +1977,19 @@ servers:
         key: api-key
 EOF
 
-echo "[cli] building MCP server image via CLI"
-./bin/mcp-runtime server build image "${SERVER_NAME}" \
-  --metadata-file "${METADATA_FILE}" \
-  --dockerfile "${GO_EXAMPLE_SOURCE_DIR}/Dockerfile" \
-  --registry docker.io/library \
-  --tag latest \
-  --context "${GO_EXAMPLE_SOURCE_DIR}"
+if pull_cached_image "${SERVER_IMAGE}"; then
+  echo "[cache] skipping MCP server image build/push for ${SERVER_IMAGE}"
+else
+  echo "[cli] building MCP server image via CLI"
+  ./bin/mcp-runtime server build image "${SERVER_NAME}" \
+    --metadata-file "${METADATA_FILE}" \
+    --dockerfile "${GO_EXAMPLE_SOURCE_DIR}/Dockerfile" \
+    --registry docker.io/library \
+    --tag latest \
+    --context "${GO_EXAMPLE_SOURCE_DIR}"
 
-publish_image_to_local_registry "${SERVER_IMAGE}"
+  publish_image_to_local_registry "${SERVER_IMAGE}"
+fi
 
 echo "[cli] generating and deploying MCPServer manifests"
 ./bin/mcp-runtime pipeline generate --file "${METADATA_FILE}" --output "${MANIFEST_DIR}"
@@ -1828,7 +1997,7 @@ echo "[cli] generating and deploying MCPServer manifests"
 
 echo "[deploy] waiting for MCP server rollout"
 wait_for_deployment_exists mcp-servers "${SERVER_NAME}"
-if ! kubectl rollout status "deploy/${SERVER_NAME}" -n mcp-servers --timeout=180s; then
+if ! restart_deployment_pods mcp-servers "${SERVER_NAME}" 180s; then
   echo "[debug] MCP server rollout failed; collecting diagnostics" >&2
   kubectl get mcpserver "${SERVER_NAME}" -n mcp-servers -o yaml || true
   kubectl get deploy,rs,pods,svc,ingress,configmap -n mcp-servers || true
@@ -2541,7 +2710,7 @@ EOF
     run_mcp_smoke_agent_prompt "${MCP_SESSION_URL}" add
     run_mcp_smoke_agent_prompt "${MCP_SESSION_URL}" slugify
   else
-    echo "[mcp] skipping optional real-client mcp-smoke agent prompt (no OPENAI_API_KEY/ANTHROPIC_API_KEY in env or ${MCP_SMOKE_AGENT_ENV_FILE})"
+    echo "[mcp] skipping optional real-client mcp-smoke agent prompt (no $(mcp_smoke_agent_key_hint) in env or ${MCP_SMOKE_AGENT_ENV_FILE})"
   fi
 
   echo "[policy] updating access grant to deny aaa-ping and echo"
@@ -2643,17 +2812,6 @@ fi
 if scenario_selected "oauth"; then
   OAUTH_FIXTURE_DIR="${WORKDIR}/oauth-fixtures"
   generate_oauth_fixtures "${OAUTH_FIXTURE_DIR}"
-  cat >"${OAUTH_FIXTURE_DIR}/default.conf" <<'EOF'
-server {
-  listen 8080;
-  server_name _;
-
-  location / {
-    root /usr/share/nginx/html;
-    try_files $uri =404;
-  }
-}
-EOF
   OAUTH_VALID_TOKEN="$(tr -d '\n' <"${OAUTH_FIXTURE_DIR}/valid-token.txt")"
   OAUTH_INVALID_TOKEN="$(tr -d '\n' <"${OAUTH_FIXTURE_DIR}/invalid-token.txt")"
 
@@ -2662,7 +2820,6 @@ EOF
   -n mcp-servers \
   --from-file=oauth-authorization-server="${OAUTH_FIXTURE_DIR}/oauth-authorization-server" \
   --from-file=keys="${OAUTH_FIXTURE_DIR}/keys" \
-  --from-file=default.conf="${OAUTH_FIXTURE_DIR}/default.conf" \
   --dry-run=client -o yaml | kubectl apply -f -
   cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
@@ -2680,9 +2837,23 @@ spec:
       labels:
         app: ${OAUTH_ISSUER_NAME}
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: nginx
-          image: docker.io/library/nginx:1.27-alpine
+        - name: http
+          image: docker.io/library/python:3.12-alpine
+          command: ["python3"]
+          args: ["-m", "http.server", "8080", "--directory", "/usr/share/nginx/html"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 65532
           ports:
             - containerPort: 8080
           volumeMounts:
@@ -2692,9 +2863,6 @@ spec:
             - name: files
               mountPath: /usr/share/nginx/html/keys
               subPath: keys
-            - name: files
-              mountPath: /etc/nginx/conf.d/default.conf
-              subPath: default.conf
       volumes:
         - name: files
           configMap:
@@ -2713,6 +2881,9 @@ spec:
       port: 8080
       targetPort: 8080
 EOF
+  # The issuer mounts fixture files through subPath, so restart to pick up new
+  # JWKS/token fixtures when E2E cache mode reuses an existing Deployment.
+  kubectl rollout restart "deploy/${OAUTH_ISSUER_NAME}" -n mcp-servers >/dev/null
   kubectl rollout status "deploy/${OAUTH_ISSUER_NAME}" -n mcp-servers --timeout=180s
 
   OAUTH_METADATA_FILE="${WORKDIR}/oauth-metadata.yaml"
@@ -2768,7 +2939,7 @@ EOF
   ./bin/mcp-runtime pipeline generate --file "${OAUTH_METADATA_FILE}" --output "${OAUTH_MANIFEST_DIR}"
   ./bin/mcp-runtime pipeline deploy --dir "${OAUTH_MANIFEST_DIR}"
   wait_for_deployment_exists mcp-servers "${OAUTH_SERVER_NAME}"
-  if ! kubectl rollout status "deploy/${OAUTH_SERVER_NAME}" -n mcp-servers --timeout=180s; then
+  if ! restart_deployment_pods mcp-servers "${OAUTH_SERVER_NAME}" 180s; then
     echo "[debug] OAuth MCP server rollout failed; collecting diagnostics" >&2
     kubectl get mcpserver "${OAUTH_SERVER_NAME}" -n mcp-servers -o yaml || true
     kubectl get deploy,rs,pods,svc,ingress,configmap -n mcp-servers || true
@@ -2990,6 +3161,7 @@ if scenario_selected "observability"; then
   OAUTH_PROXY_BASE="http://127.0.0.1:${OAUTH_PROXY_PORT}" \
   OAUTH_UPSTREAM_BASE="http://127.0.0.1:${OAUTH_UPSTREAM_PORT}" \
   API_KEY="${API_KEY}" \
+  INGEST_API_KEY="${INGEST_API_KEY}" \
   SERVER_NAME="${SERVER_NAME}" \
   SERVER_HOST="${SERVER_HOST}" \
   SESSION_ID="${SESSION_ID}" \
@@ -3003,6 +3175,7 @@ if scenario_selected "observability"; then
   python3 <<'PY'
 import json
 import os
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -3019,6 +3192,7 @@ server_upstream_base = os.environ["SERVER_UPSTREAM_BASE"]
 oauth_proxy_base = os.environ["OAUTH_PROXY_BASE"]
 oauth_upstream_base = os.environ["OAUTH_UPSTREAM_BASE"]
 api_key = os.environ["API_KEY"]
+ingest_api_key = os.environ["INGEST_API_KEY"]
 server_name = os.environ["SERVER_NAME"]
 server_host = os.environ["SERVER_HOST"]
 session_id = os.environ["SESSION_ID"]
@@ -3076,6 +3250,17 @@ def expect_json(url, status=200, *, method="GET", headers=None, body=None):
     return json.loads(payload)
 
 
+def wait_for_json(url, predicate, *, headers=None, retries=60, delay=2, description="response"):
+    last = None
+    for _ in range(retries):
+        last = expect_json(url, headers=headers)
+        if predicate(last):
+            ok(f"waited for {description}")
+            return last
+        time.sleep(delay)
+    fail(f"timed out waiting for {description}: {json.dumps(last, indent=2)}")
+
+
 def expect_mcp_initialize(url, *, headers=None, status=200, contains=None):
     req_headers = {
         "accept": "application/json, text/event-stream",
@@ -3126,6 +3311,7 @@ def expect_mcp_initialize(url, *, headers=None, status=200, contains=None):
 
 
 auth_headers = {"x-api-key": api_key}
+ingest_headers = {"x-api-key": ingest_api_key}
 
 # Gateway-routed UI, API, and example MCP routes.
 gateway_summary = expect_json(f"{gateway_base}/api/dashboard/summary", headers=auth_headers)
@@ -3226,9 +3412,11 @@ check(
     "api /api/event-types returned event types",
     f"expected /api/event-types to return event types: {event_types}",
 )
-filtered = expect_json(
+filtered = wait_for_json(
     f"{api_base}/api/events/filter?server={urllib.parse.quote(server_name)}&limit=5",
+    lambda doc: bool(doc.get("events")),
     headers=auth_headers,
+    description="api /api/events/filter events",
 )
 check(
     bool(filtered.get("events")),
@@ -3427,7 +3615,7 @@ ingest_event = expect_json(
     f"{ingest_base}/events",
     status=202,
     method="POST",
-    headers=auth_headers,
+    headers=ingest_headers,
     body={
         "timestamp": "2026-03-29T00:00:00Z",
         "source": "e2e-direct-ingest",
@@ -3503,6 +3691,7 @@ PY
   echo "[observe] validating audit, traces, and logs"
   API_BASE="http://127.0.0.1:${SENTINEL_PORT}/api" \
   API_KEY="${API_KEY}" \
+  INGEST_API_KEY="${INGEST_API_KEY}" \
   SERVER_NAME="${SERVER_NAME}" \
   OAUTH_SERVER_NAME="${OAUTH_SERVER_NAME}" \
   OAUTH_HUMAN_ID="${OAUTH_HUMAN_ID}" \
@@ -3519,6 +3708,7 @@ import urllib.request
 
 api_base = os.environ["API_BASE"]
 api_key = os.environ["API_KEY"]
+ingest_api_key = os.environ["INGEST_API_KEY"]
 server_name = os.environ["SERVER_NAME"]
 oauth_server_name = os.environ["OAUTH_SERVER_NAME"]
 oauth_human_id = os.environ["OAUTH_HUMAN_ID"]
@@ -3573,6 +3763,7 @@ def payload_dict(event):
 
 
 headers = {"x-api-key": api_key}
+ingest_headers = {"x-api-key": ingest_api_key}
 
 # PII redaction check via the Sentinel gateway Traefik route.
 pii_source = "pii-redaction-e2e"
@@ -3590,7 +3781,7 @@ pii_event_body = {
 status, resp_body = post_json(
     f"{sentinel_base}/ingest/events",
     pii_event_body,
-    {"content-type": "application/json", "x-api-key": api_key},
+    {"content-type": "application/json", **ingest_headers},
 )
 check(
     status in (200, 202),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request significantly hardens the security posture of the `mcp-runtime` project by implementing least privilege principles across various components and enhancing CI/CD security.

Key changes include:

*   **Least Privilege for Workloads:**
    *   Most deployments, statefulsets, and jobs (including `MCPServer`s, ClickHouse, Kafka, Prometheus, Grafana, Loki, Tempo, OpenTelemetry Collector, registry, and admin bootstrap) now explicitly disable service account token automount (`automountServiceAccountToken: false`).
    *   Pod and container security contexts are hardened with `runAsNonRoot: true`, `runAsUser: 65532` (or other specific non-root users), `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, and `capabilities: drop: ALL`.
    *   The `mcp-servers` namespace, where user workloads run, is now labeled with `pod-security.kubernetes.io/enforce: restricted`.
    *   The gateway sidecar, admin bootstrap job, and Promtail container now enforce a `readOnlyRootFilesystem: true`.

*   **Refined RBAC Permissions:**
    *   The operator's `ClusterRole` no longer has `get` permissions on `secrets`.
    *   The API service's `ClusterRole` is significantly reduced, removing `impersonate` verbs and limiting `create`, `deletecollection`, and `patch` permissions on various resources.
    *   Traefik and `mcp-sentinel-gateway` RBAC is scoped down from `ClusterRole` to `Role` where possible, limiting their watch scope to specific namespaces (`registry`, `mcp-sentinel`, `mcp-servers`). A separate `ClusterRole` is added for `ingressclasses`.
    *   Promtail's `ClusterRole` is restricted, removing `pods/log` and `nodes/proxy` verbs.

*   **API Key Segmentation:**
    *   Introduced `ADMIN_API_KEYS` and `INGEST_API_KEYS` in `mcp-sentinel-secrets` to provide granular access control.
    *   The `ingest` service now primarily uses `INGEST_API_KEYS` for event ingestion, while the `api` service uses `ADMIN_API_KEYS` for admin-level access.
    *   The `UI_API_KEY` is now explicitly included in both `API_KEYS` and `ADMIN_API_KEYS` to enable browser and API-key based admin login.
    *   The `mcp-proxy` sidecar now uses `INGEST_API_KEYS` for analytics.

*   **Enhanced CI/CD Security:**
    *   **Dependabot:** Added configuration to automate dependency updates for Go modules and GitHub Actions.
    *   **Permissions:** Implemented least privilege for GitHub Actions workflows by adding `permissions: contents: read` and `security-events: write` where necessary.
    *   **Version Pinning:** All GitHub Actions and Go tools used in CI workflows are now explicitly pinned to specific versions for stability and security.
    *   **SBOM Generation:** A new CI job generates and uploads SPDX JSON Software Bill of Materials (SBOMs) for the repository and the operator image.
    *   **Dependency Review:** A new workflow automatically reviews dependency changes in pull requests, failing on high severity vulnerabilities and denying specific licenses.
    *   **Trivy Integration:** Replaced manual Docker-based Trivy scans with `aquasecurity/trivy-action`, enabling SARIF output and uploading results to GitHub Security.
    *   **Ubuntu Upgrade:** CI jobs now run on `ubuntu-24.04`.

*   **Documentation Updates:**
    *   A new `SECURITY.md` policy document is added.
    *   Existing documentation (`AGENTS.md`, `docs/api.md`, `docs/getting-started.md`, `docs/internals/tests.md`, `docs/sentinel.md`) is updated to reflect the new security practices, API key structure, and CI changes.
    *   The CLI `doctor` command is updated to validate the new API key structure and apply restricted security contexts to temporary pods. The `setup` command now manages the new API key types.
<!-- kody-pr-summary:end -->