### PR TITLE
doc: document sentinel debugging and APIs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -189,8 +189,8 @@ GET  /api/auth/me
 | Route | Body / response |
 |---|---|
 | `POST /api/auth/signup` | Body: `email`, `password`, optional `role`. Returns `201` with `access_token`, `token_type`, `expires_in`, and `user`. Admin signup requires an admin principal. |
-| `POST /api/auth/login` | Body: `email`, `password`. Returns `access_token`, `token_type`, `expires_in`, and `user`. |
-| `POST /api/auth/oidc` | Body: `id_token`. Requires configured issuer, audience, and JWKS. Returns a platform bearer token and user. |
+| `POST /api/auth/login` | Body: `email`, `password`. Returns `200` with `access_token`, `token_type`, `expires_in`, and `user`. |
+| `POST /api/auth/oidc` | Body: `id_token`. Requires configured issuer, audience, and JWKS. Returns `200` with `access_token`, `token_type`, `expires_in`, and `user`. |
 | `GET /api/auth/me` | Requires auth. Returns `authenticated=true` and the current principal. |
 
 ## Gateway flow and headers
@@ -247,13 +247,13 @@ For `POST /api/runtime/grants` and `POST /api/runtime/sessions`, the API resolve
 ```text
 GET  /api/runtime/servers              # List MCP server deployments
 GET  /api/runtime/grants               # List MCPAccessGrant resources
-GET  /api/runtime/grants/{ns}/{name}   # Get one MCPAccessGrant
+GET  /api/runtime/grants/{namespace}/{name}   # Get one MCPAccessGrant
 POST /api/runtime/grants               # Create or update an MCPAccessGrant (x-api-key)
-DELETE /api/runtime/grants/{ns}/{name} # Delete one MCPAccessGrant
+DELETE /api/runtime/grants/{namespace}/{name} # Delete one MCPAccessGrant
 GET  /api/runtime/sessions             # List MCPAgentSession resources
-GET  /api/runtime/sessions/{ns}/{name} # Get one MCPAgentSession
+GET  /api/runtime/sessions/{namespace}/{name} # Get one MCPAgentSession
 POST /api/runtime/sessions             # Create or update an MCPAgentSession (x-api-key)
-DELETE /api/runtime/sessions/{ns}/{name} # Delete one MCPAgentSession
+DELETE /api/runtime/sessions/{namespace}/{name} # Delete one MCPAgentSession
 GET  /api/runtime/components           # Sentinel component health status
 GET  /api/runtime/policy?namespace=&server=   # Get rendered policy for a server
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -173,6 +173,26 @@ No `/authorize`, `/token`, `/.well-known/oauth-authorization-server`, PKCE, or D
 - Use **MCPAccessGrant + MCPAgentSession** for trust and revocation.
 - Use **OIDC-issued bearer tokens** only where Sentinel services validate them.
 
+## Authentication API
+
+These routes are served by `services/api`. Platform identity routes require the
+Postgres-backed platform store (`POSTGRES_DSN` or `DATABASE_URL`) and
+`PLATFORM_JWT_SECRET`.
+
+```text
+POST /api/auth/signup
+POST /api/auth/login
+POST /api/auth/oidc
+GET  /api/auth/me
+```
+
+| Route | Body / response |
+|---|---|
+| `POST /api/auth/signup` | Body: `email`, `password`, optional `role`. Returns `201` with `access_token`, `token_type`, `expires_in`, and `user`. Admin signup requires an admin principal. |
+| `POST /api/auth/login` | Body: `email`, `password`. Returns `access_token`, `token_type`, `expires_in`, and `user`. |
+| `POST /api/auth/oidc` | Body: `id_token`. Requires configured issuer, audience, and JWKS. Returns a platform bearer token and user. |
+| `GET /api/auth/me` | Requires auth. Returns `authenticated=true` and the current principal. |
+
 ## Gateway flow and headers
 
 ```mermaid
@@ -229,9 +249,11 @@ GET  /api/runtime/servers              # List MCP server deployments
 GET  /api/runtime/grants               # List MCPAccessGrant resources
 GET  /api/runtime/grants/{ns}/{name}   # Get one MCPAccessGrant
 POST /api/runtime/grants               # Create or update an MCPAccessGrant (x-api-key)
+DELETE /api/runtime/grants/{ns}/{name} # Delete one MCPAccessGrant
 GET  /api/runtime/sessions             # List MCPAgentSession resources
 GET  /api/runtime/sessions/{ns}/{name} # Get one MCPAgentSession
 POST /api/runtime/sessions             # Create or update an MCPAgentSession (x-api-key)
+DELETE /api/runtime/sessions/{ns}/{name} # Delete one MCPAgentSession
 GET  /api/runtime/components           # Sentinel component health status
 GET  /api/runtime/policy?namespace=&server=   # Get rendered policy for a server
 ```
@@ -291,13 +313,33 @@ Additional authenticated routes exposed by the API service:
 
 ```text
 GET  /api/deployments                  # User-scoped deployment list
-GET  /api/deployments/{namespace}/{name}
+POST /api/deployments                  # Apply a platform-managed Deployment + Service
+DELETE /api/deployments/{namespace}/{name}
 GET  /api/admin/namespaces             # Admin-only namespace inventory
 GET  /api/admin/deployments            # Admin-only deployment inventory
 GET  /api/user/api-keys                # List caller-owned API keys
 POST /api/user/api-keys                # Create caller-owned API key
 POST /api/user/api-keys/{id}/revoke    # Revoke caller-owned API key
+GET  /api/user/registry-credentials    # List caller-owned registry credentials
+POST /api/user/registry-credentials    # Create a registry credential
+POST /api/user/registry-credentials/{id}/revoke
 ```
+
+Deployment apply body:
+
+```json
+{
+  "name": "payments",
+  "image": "registry.example.com/payments-mcp",
+  "version": "v1.0.0",
+  "port": 8088,
+  "replicas": 1,
+  "namespace": "team-a"
+}
+```
+
+For non-admin users, deployment operations are scoped to the caller's namespace.
+Admins may pass `namespace`; if omitted, admin list calls can span namespaces.
 
 ## Analytics API
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -224,23 +224,35 @@ kubectl rollout status deploy/go-example-mcp -n mcp-servers --timeout=180s
 ./bin/mcp-runtime server status --namespace mcp-servers
 ```
 
-Useful checks while iterating:
+Useful server and policy checks while iterating:
 
 ```bash
-kubectl get mcpservers -n mcp-servers
-kubectl get pods -n mcp-servers -o wide
-kubectl get pods -n mcp-servers \
+SERVER=go-example-mcp
+NAMESPACE=mcp-servers
+CONTAINER=go-example-mcp
+
+kubectl get mcpservers -n "$NAMESPACE"
+kubectl get deploy/"$SERVER" svc/"$SERVER" ingress/"$SERVER" -n "$NAMESPACE" -o wide
+kubectl get cm -n "$NAMESPACE" "${SERVER}-gateway-policy" -o yaml
+kubectl get mcpaccessgrant,mcpagentsession -n "$NAMESPACE" -o wide
+kubectl get pods -n "$NAMESPACE" -o wide
+kubectl get pods -n "$NAMESPACE" \
   -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .spec.containers[*]}{.name}{","}{end}{"\n"}{end}'
 
 POD="$(
-  kubectl get pods -n mcp-servers -l app=go-example-mcp \
+  kubectl get pods -n "$NAMESPACE" -l app="$SERVER" \
     -o jsonpath='{.items[0].metadata.name}'
 )"
 
-kubectl describe pod -n mcp-servers "$POD"
-kubectl logs -n mcp-servers "$POD" -c go-example-mcp
-kubectl logs -n mcp-servers "$POD" -c mcp-gateway
-./bin/mcp-runtime server policy inspect go-example-mcp --namespace mcp-servers
+kubectl describe mcpserver -n "$NAMESPACE" "$SERVER"
+kubectl describe pod -n "$NAMESPACE" "$POD"
+kubectl logs -n "$NAMESPACE" "$POD" -c "$CONTAINER"
+kubectl logs -n "$NAMESPACE" "$POD" -c mcp-gateway
+./bin/mcp-runtime server logs "$SERVER" --namespace "$NAMESPACE"
+./bin/mcp-runtime server policy inspect "$SERVER" --namespace "$NAMESPACE"
+kubectl get cm -n "$NAMESPACE" "${SERVER}-gateway-policy" \
+  -o 'go-template={{index .data "policy.json"}}'
+kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp
 ```
 
 The governed sidecar container is named `mcp-gateway`; it runs the
@@ -250,9 +262,51 @@ Go example image is distroless, so `kubectl exec ... -- /bin/sh` and
 container when you need a shell in the pod namespace:
 
 ```bash
-kubectl debug -it -n mcp-servers "pod/$POD" \
-  --target=go-example-mcp \
+kubectl debug -it -n "$NAMESPACE" "pod/$POD" \
+  --target="$CONTAINER" \
   --image=busybox:1.36 -- sh
+```
+
+`server policy inspect` prints the rendered `policy.json` from the
+`${SERVER}-gateway-policy` ConfigMap. If a grant or session exists in
+Kubernetes but is missing from that output, check the operator logs in the
+platform block below. If it appears in the rendered policy but calls still fail,
+check the `mcp-gateway` sidecar logs and allow a few seconds for the sidecar to
+reload the mounted file.
+
+Start from the symptom instead of running every command every time:
+
+| Symptom | First checks |
+|---------|--------------|
+| Pod is not ready or image pulls fail | `kubectl describe pod`, namespace events, `cluster doctor` |
+| Grant or session does not affect traffic | `kubectl get mcpaccessgrant,mcpagentsession`, `server policy inspect`, raw policy ConfigMap |
+| Policy renders but tool calls are denied | `kubectl logs ... -c mcp-gateway`, request headers, `Mcp-Session-Id` / `X-MCP-Agent-Session` values |
+| Requests work but analytics are missing | `sentinel logs ingest`, `sentinel logs processor`, analytics secret and ingest URL |
+| Dashboard, API, or MCP route returns 404 | `kubectl get ingress -A`, Sentinel ingress YAML, Traefik logs |
+
+Useful local platform checks:
+
+```bash
+./bin/mcp-runtime cluster doctor
+./bin/mcp-runtime sentinel status
+./bin/mcp-runtime sentinel events
+./bin/mcp-runtime sentinel logs api --since 10m
+./bin/mcp-runtime sentinel logs ui --since 10m
+./bin/mcp-runtime sentinel logs gateway --since 10m
+./bin/mcp-runtime sentinel logs ingest --since 10m
+./bin/mcp-runtime sentinel logs processor --since 10m
+
+kubectl get pods -n mcp-runtime -o wide
+kubectl get pods -n mcp-sentinel -o wide
+kubectl rollout status deploy/mcp-sentinel-api -n mcp-sentinel --timeout=90s
+kubectl rollout status deploy/mcp-sentinel-ingest -n mcp-sentinel --timeout=90s
+kubectl rollout status deploy/mcp-sentinel-processor -n mcp-sentinel --timeout=90s
+kubectl rollout status deploy/mcp-sentinel-ui -n mcp-sentinel --timeout=90s
+kubectl rollout status deploy/mcp-sentinel-gateway -n mcp-sentinel --timeout=90s
+kubectl logs -n mcp-runtime deploy/mcp-runtime-operator-controller-manager --since=10m
+kubectl logs -n traefik deploy/traefik --tail=120
+kubectl get ingress -A
+kubectl get ingress -n mcp-sentinel -o yaml
 ```
 
 Apply an access grant and session for the local request:
@@ -299,7 +353,8 @@ until ./bin/mcp-runtime server policy inspect go-example-mcp --namespace mcp-ser
   sleep 2
 done
 
-# The proxy sidecar reloads the rendered policy file on a short polling loop.
+# The proxy sidecar reloads rendered policy on a short polling loop, so give the
+# gateway a few seconds to observe the new access session before the first tool call.
 sleep 6
 ```
 
@@ -357,6 +412,10 @@ curl -sS \
 
 You should see successful `tools/call` responses containing `5` and
 `HELLO WORLD`. Then verify Sentinel health and query the analytics API:
+
+The bundled Go example server also exposes `upper`, `lower`, `echo`, and
+`slugify`, and each of those tools expects a `message` field in `arguments`
+instead of `input` or `text`.
 
 ```bash
 ./bin/mcp-runtime sentinel status

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -79,9 +79,9 @@ metrics on `METRICS_PORT` (default `9090`).
 |---|---|---|
 | `GET` | `/health` | API health and runtime initialization status. |
 | `GET` | `/metrics` | Prometheus metrics on the metrics server. |
-| `POST` | `/api/auth/signup` | Create a platform user when platform identity storage is configured. Admin signup requires an admin principal. |
-| `POST` | `/api/auth/login` | Exchange platform email/password for a bearer token. |
-| `POST` | `/api/auth/oidc` | Exchange a configured OIDC ID token for a platform bearer token. |
+| `POST` | `/api/auth/signup` | Create a platform user when platform identity storage is configured. Returns `201` with `access_token`, `token_type`, `expires_in`, and `user`. Admin signup requires an admin principal. |
+| `POST` | `/api/auth/login` | Exchange platform email/password for a bearer token. Returns `200` with `access_token`, `token_type`, `expires_in`, and `user`. |
+| `POST` | `/api/auth/oidc` | Exchange a configured OIDC ID token for a platform bearer token. Returns `200` with `access_token`, `token_type`, `expires_in`, and `user`. |
 | `GET` | `/api/auth/me` | Return the authenticated principal. |
 | `GET` | `/api/dashboard/summary` | Dashboard cards: event totals, active grants/sessions, latest event metadata. Admin role required. |
 | `GET` | `/api/events` | Recent ClickHouse-backed audit events, newest first. Query: `limit` (1-1000, default 100). Admin role required. |

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -45,22 +45,157 @@ flowchart LR
 | **OTel Collector + Tempo** | Distributed tracing pipeline. |
 | **Loki + Promtail** | Log shipping and storage. |
 
-## Auth and APIs
+## Service HTTP reference
 
-`api` and `ingest` support both API keys and optional OIDC JWT validation (issuer, audience, JWKS).
+The Sentinel stack has multiple HTTP services. In local test mode, Traefik
+usually exposes them through `http://localhost:18080/`; inside the cluster,
+call the service DNS names directly.
 
-```text
-POST /events
-GET  /api/events?limit=100
-GET  /api/stats
-GET  /api/sources
-GET  /api/event-types
-GET  /api/events/filter?server=payments&decision=deny&agent_id=ops-agent&limit=50
-GET  /health
-GET  /metrics
+| Surface | Public path in dev | In-cluster service | Notes |
+|---|---|---|---|
+| **UI** | `/` | `mcp-sentinel-ui:8082` | Browser app, browser login/session routes, and `/api` reverse proxy. |
+| **API** | `/api/*` through UI | `mcp-sentinel-api:8080` | Auth, analytics queries, runtime governance, deployments, admin/user APIs. |
+| **Ingest** | `/ingest/events` | `mcp-sentinel-ingest:8081/events` | Event intake used by `mcp-proxy`; the public ingress strips `/ingest`. |
+| **Grafana** | `/grafana` | `grafana:3000` | Observability UI. |
+| **Prometheus** | `/prometheus` | `prometheus:9090` | Metrics query UI. |
+| **MCP proxy sidecar** | per-server route, for example `/demo-one/mcp` | pod-local sidecar port | Enforces policy and forwards to the MCP server container. |
+
+### Auth model
+
+| Service | Auth behavior |
+|---|---|
+| **api** | `/health` is open. Authenticated `/api/*` routes accept `x-api-key` from `API_KEYS`, user-generated API keys, platform JWT bearer tokens, or OIDC JWT bearer tokens when OIDC is configured. If `ADMIN_API_KEYS` is set, only those keys get admin role; other `API_KEYS` values are user role. |
+| **ui** | `/auth/login` creates an HttpOnly UI session from `api_key`, `id_token`, or `email`/`password`. The UI then proxies `/api/*` with an upstream API key or bearer token. |
+| **ingest** | `/live`, `/ready`, and `/health` are open. `/events` accepts `x-api-key` from `API_KEYS` or a configured OIDC bearer token. If no API keys and no JWKS are configured, intake auth is bypassed. |
+| **processor** | No data API. It exposes metrics and a simple health check on the metrics port. |
+| **mcp-proxy** | No admin API. It authenticates MCP requests according to the rendered server policy: header identity or OAuth bearer tokens, depending on `spec.auth`. |
+
+### API service
+
+`services/api` runs the main API on `PORT` (default `8080`) and Prometheus
+metrics on `METRICS_PORT` (default `9090`).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | API health and runtime initialization status. |
+| `GET` | `/metrics` | Prometheus metrics on the metrics server. |
+| `POST` | `/api/auth/signup` | Create a platform user when platform identity storage is configured. Admin signup requires an admin principal. |
+| `POST` | `/api/auth/login` | Exchange platform email/password for a bearer token. |
+| `POST` | `/api/auth/oidc` | Exchange a configured OIDC ID token for a platform bearer token. |
+| `GET` | `/api/auth/me` | Return the authenticated principal. |
+| `GET` | `/api/dashboard/summary` | Dashboard cards: event totals, active grants/sessions, latest event metadata. Admin role required. |
+| `GET` | `/api/events` | Recent ClickHouse-backed audit events, newest first. Query: `limit` (1-1000, default 100). Admin role required. |
+| `GET` | `/api/events/filter` | Filtered audit events. Query: `source`, `event_type`, `server`, `namespace`, `cluster`, `human_id`, `agent_id`, `session_id`, `decision`, `tool_name`, `limit`. Admin role required. |
+| `GET` | `/api/stats` | Total event count. Admin role required. |
+| `GET` | `/api/sources` | Event counts grouped by source. Admin role required. |
+| `GET` | `/api/event-types` | Event counts grouped by event type. Admin role required. |
+| `GET` | `/api/runtime/servers` | List MCP servers. Non-admin users may read `mcp-servers` and their own namespace. |
+| `GET`, `POST` | `/api/runtime/grants` | List or apply `MCPAccessGrant` resources. |
+| `GET`, `DELETE` | `/api/runtime/grants/{namespace}/{name}` | Read or delete one grant. |
+| `POST` | `/api/runtime/grants/{namespace}/{name}/disable` | Set `spec.disabled=true`. |
+| `POST` | `/api/runtime/grants/{namespace}/{name}/enable` | Set `spec.disabled=false`. |
+| `GET`, `POST` | `/api/runtime/sessions` | List or apply `MCPAgentSession` resources. |
+| `GET`, `DELETE` | `/api/runtime/sessions/{namespace}/{name}` | Read or delete one session. |
+| `POST` | `/api/runtime/sessions/{namespace}/{name}/revoke` | Set `spec.revoked=true`. |
+| `POST` | `/api/runtime/sessions/{namespace}/{name}/unrevoke` | Set `spec.revoked=false`. |
+| `GET` | `/api/runtime/components` | Core Sentinel component health from Kubernetes. |
+| `GET` | `/api/runtime/policy?namespace=&server=` | Rendered gateway policy for one server. |
+| `POST` | `/api/runtime/actions/restart` | Restart one Sentinel component or all components. Admin role required. |
+| `GET`, `POST` | `/api/deployments` | User-scoped platform deployment list/apply. |
+| `DELETE` | `/api/deployments/{namespace}/{name}` | Delete a platform-managed deployment and service. |
+| `GET` | `/api/admin/namespaces` | Platform namespace inventory. Admin role required. |
+| `GET` | `/api/admin/deployments` | Deployment inventory across namespaces, optionally filtered by `namespace`. Admin role required. |
+| `GET`, `POST` | `/api/user/api-keys` | List or create caller-owned API keys. |
+| `POST` | `/api/user/api-keys/{id}/revoke` | Revoke one caller-owned API key. |
+| `GET`, `POST` | `/api/user/registry-credentials` | List or create caller-owned registry credentials. |
+| `POST` | `/api/user/registry-credentials/{id}/revoke` | Revoke one registry credential. |
+
+Restart request body examples:
+
+```json
+{"component": "api"}
 ```
 
-Full HTTP surface is in the [API reference](api.md).
+```json
+{"all": true}
+```
+
+The grant/session apply bodies and CRD field details are in the
+[API reference](api.md#runtime-governance-api).
+
+### UI service
+
+`services/ui` runs on `PORT` (default `8082`). It serves static assets and
+wraps API auth for browser users.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | UI health. |
+| `GET` | `/config.js` | Runtime browser config: API base, default namespace/policy version, Google client ID. |
+| `POST` | `/auth/login` | Create a UI session from `{"api_key": "..."}`, `{"id_token": "..."}`, or `{"email": "...", "password": "..."}`. |
+| `POST` | `/auth/logout` | Clear the UI session cookie. |
+| `GET` | `/auth/status` | Return UI session authentication state and principal. |
+| any | `/api/*` | Reverse proxy to `services/api`. Public `GET`/`HEAD /api/runtime/servers` is allowed for the shared `mcp-servers` catalog; other API calls require a UI session or API key. |
+| `GET` | `/*` | Static dashboard assets. |
+
+### Ingest service
+
+`services/ingest` runs event intake on `PORT` (default `8081`) and Prometheus
+metrics on `METRICS_PORT` (default `9091`).
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/live` | Liveness check. |
+| `GET` | `/ready` | Kafka readiness check. Returns `503` with `kafka_unavailable` when no broker is reachable. |
+| `GET` | `/health` | Simple health check. |
+| `POST` | `/events` | Validate and enqueue one event to Kafka topic `KAFKA_TOPIC` (default `mcp.events`). Max body size is 1 MiB. |
+| `GET` | `/metrics` | Prometheus metrics on the metrics server. |
+
+Event intake body:
+
+```json
+{
+  "timestamp": "2026-05-04T18:00:00Z",
+  "source": "mcp-proxy",
+  "event_type": "mcp.request",
+  "payload": {
+    "server": "payments",
+    "namespace": "mcp-servers",
+    "decision": "deny",
+    "reason": "session_not_found"
+  }
+}
+```
+
+`timestamp` is optional; ingest fills it with the current UTC time when absent.
+`source`, `event_type`, and a non-null `payload` are required. Success returns
+`202 {"ok": true}`.
+
+### Processor service
+
+`services/processor` consumes Kafka and writes ClickHouse. It does not expose a
+query or mutation API.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Simple health check on `METRICS_PORT` (default `9102`). |
+| `GET` | `/metrics` | Prometheus metrics, including processor intake pause gauges/counters. |
+
+### MCP proxy sidecar
+
+`services/mcp-proxy` is injected into gateway-enabled `MCPServer` pods as the
+`mcp-gateway` container. It listens on `PORT` (operator default: the server's
+gateway port), forwards to `UPSTREAM_URL`, reads policy from `POLICY_FILE`, and
+emits audit events to `ANALYTICS_INGEST_URL` when configured.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | Sidecar health. |
+| `GET`, `HEAD` | `/.well-known/oauth-protected-resource...` | OAuth protected-resource metadata when the rendered policy uses OAuth. Returns `404` when OAuth is not enabled for the server. |
+| any | `/*` | Reverse proxy to the MCP server. `POST` JSON-RPC `tools/call` requests are inspected and authorized before forwarding. |
+
+The sidecar emits audit events on allowed and denied tool calls. Denied calls do
+not reach the upstream MCP server.
 
 ## Governance UI walkthrough
 

--- a/services/api/docs/platform-api.md
+++ b/services/api/docs/platform-api.md
@@ -1,4 +1,12 @@
-# Platform Identity and Deployment API
+# Platform Identity, Deployment, and User API
+
+This file documents the platform-specific routes served by `services/api`.
+The public documentation pages are the canonical full references:
+
+- `../../../docs/api.md` for the full API reference.
+- `../../../docs/sentinel.md` for the Sentinel service-by-service HTTP surface.
+
+## Enable platform identity
 
 Enable the platform identity database with:
 
@@ -7,9 +15,50 @@ export POSTGRES_DSN='postgres://user:pass@postgres:5432/mcp_runtime?sslmode=disa
 export PLATFORM_JWT_SECRET='<32+ random bytes>'
 ```
 
-`DATABASE_URL` is also accepted when `POSTGRES_DSN` is not set. The API applies the SQL schema at startup; the same schema is available in `services/api/migrations/001_platform_identity.sql`.
+`DATABASE_URL` is also accepted when `POSTGRES_DSN` is not set. The API applies
+the SQL schema at startup; the same schema is available in
+`services/api/migrations/001_platform_identity.sql`.
+
+Optional bootstrap variables:
+
+```bash
+export PLATFORM_ADMIN_EMAIL='admin@example.com'
+export PLATFORM_ADMIN_PASSWORD='change-me-now'
+```
+
+`PLATFORM_ADMIN_BOOTSTRAP_ONLY=1` runs only the admin bootstrap path and exits.
+`PLATFORM_ADMIN_PASSWORD` should be cleared after bootstrap.
+
+## Route summary
+
+All routes below are served by `services/api` on `PORT` (default `8080`) unless
+noted otherwise. Authenticated routes accept `Authorization: Bearer <token>` or
+`x-api-key: <key>`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/health` | API health and runtime initialization status. |
+| `GET` | `/metrics` | Prometheus metrics on `METRICS_PORT` (default `9090`). |
+| `POST` | `/api/auth/signup` | Create a platform user. |
+| `POST` | `/api/auth/login` | Exchange email/password for a platform bearer token. |
+| `POST` | `/api/auth/oidc` | Exchange a configured OIDC ID token for a platform bearer token. |
+| `GET` | `/api/auth/me` | Return the authenticated principal. |
+| `GET`, `POST` | `/api/user/api-keys` | List or create caller-owned API keys. |
+| `POST` | `/api/user/api-keys/{id}/revoke` | Revoke one caller-owned API key. |
+| `GET`, `POST` | `/api/user/registry-credentials` | List or create registry credentials. |
+| `POST` | `/api/user/registry-credentials/{id}/revoke` | Revoke one registry credential. |
+| `GET`, `POST` | `/api/deployments` | List or apply platform-managed deployments. |
+| `DELETE` | `/api/deployments/{namespace}/{name}` | Delete a platform-managed deployment and service. |
+| `GET` | `/api/admin/namespaces` | Admin namespace inventory. |
+| `GET` | `/api/admin/deployments` | Admin deployment inventory, optionally filtered by `namespace`. |
+
+The same API service also hosts analytics and runtime governance routes such as
+`/api/events`, `/api/runtime/grants`, and `/api/runtime/sessions`; keep those
+details in `../../../docs/api.md`.
 
 ## Signup and Login
+
+Create a normal user:
 
 ```bash
 curl -sS -X POST http://localhost:8080/api/auth/signup \
@@ -17,15 +66,31 @@ curl -sS -X POST http://localhost:8080/api/auth/signup \
   -d '{"email":"prince@example.com","password":"change-me-now"}'
 ```
 
+Log in with email/password:
+
 ```bash
 curl -sS -X POST http://localhost:8080/api/auth/login \
   -H 'content-type: application/json' \
   -d '{"email":"prince@example.com","password":"change-me-now"}'
 ```
 
-Both return a bearer `access_token`. Admin signup requires an existing admin credential on the request.
+Both return a bearer `access_token`:
 
-Example (admin creates another admin user using an admin API key):
+```json
+{
+  "access_token": "...",
+  "token_type": "bearer",
+  "expires_in": 43200,
+  "user": {
+    "id": "...",
+    "email": "prince@example.com",
+    "role": "user",
+    "namespace": "user-..."
+  }
+}
+```
+
+Admin signup requires an existing admin credential on the request:
 
 ```bash
 curl -sS -X POST http://localhost:8080/api/auth/signup \
@@ -34,7 +99,24 @@ curl -sS -X POST http://localhost:8080/api/auth/signup \
   -d '{"email":"admin2@example.com","password":"change-me-now","role":"admin"}'
 ```
 
+OIDC login requires `OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL`:
+
+```bash
+curl -sS -X POST http://localhost:8080/api/auth/oidc \
+  -H 'content-type: application/json' \
+  -d '{"id_token":"'"$ID_TOKEN"'"}'
+```
+
+Inspect the current bearer token or API key:
+
+```bash
+curl -sS -H "authorization: Bearer $TOKEN" \
+  http://localhost:8080/api/auth/me
+```
+
 ## API Keys
+
+Create a caller-owned API key:
 
 ```bash
 curl -sS -X POST http://localhost:8080/api/user/api-keys \
@@ -43,11 +125,27 @@ curl -sS -X POST http://localhost:8080/api/user/api-keys \
   -d '{"name":"laptop"}'
 ```
 
-The cleartext API key is returned once. The database stores only a SHA-256 hash.
+The cleartext `api_key` is returned once. The database stores only a SHA-256
+hash.
+
+List keys:
+
+```bash
+curl -sS -H "authorization: Bearer $TOKEN" \
+  http://localhost:8080/api/user/api-keys
+```
+
+Revoke a key:
+
+```bash
+curl -sS -X POST -H "authorization: Bearer $TOKEN" \
+  http://localhost:8080/api/user/api-keys/"$KEY_ID"/revoke
+```
 
 ## Deployments
 
-Normal users deploy only into their owned namespace. Admins may pass `namespace`.
+Normal users deploy only into their owned namespace. Admins may pass
+`namespace`.
 
 ```bash
 curl -sS -X POST http://localhost:8080/api/deployments \
@@ -55,6 +153,10 @@ curl -sS -X POST http://localhost:8080/api/deployments \
   -H 'content-type: application/json' \
   -d '{"name":"demo","image":"registry.example.com/user-1/demo","version":"v1","port":8088,"replicas":1}'
 ```
+
+The API applies a Kubernetes `Deployment` and `Service` labelled as
+platform-managed. `version` is appended as an image tag when `image` does not
+already include a tag.
 
 ```bash
 curl -sS -H "authorization: Bearer $TOKEN" \
@@ -68,7 +170,8 @@ curl -sS -X DELETE -H "authorization: Bearer $TOKEN" \
 
 ## Registry Credentials
 
-Registry credentials are separate from platform API keys so Docker-cached credentials can be revoked independently.
+Registry credentials are separate from platform API keys so Docker-cached
+credentials can be revoked independently.
 
 ```bash
 curl -sS -X POST http://localhost:8080/api/user/registry-credentials \
@@ -77,9 +180,26 @@ curl -sS -X POST http://localhost:8080/api/user/registry-credentials \
   -d '{"name":"docker laptop"}'
 ```
 
-Use the returned `username` and one-time `password` with the configured registry host.
+Use the returned `username` and one-time `password` with the configured registry
+host.
+
+List registry credentials:
+
+```bash
+curl -sS -H "authorization: Bearer $TOKEN" \
+  http://localhost:8080/api/user/registry-credentials
+```
+
+Revoke one registry credential:
+
+```bash
+curl -sS -X POST -H "authorization: Bearer $TOKEN" \
+  http://localhost:8080/api/user/registry-credentials/"$CREDENTIAL_ID"/revoke
+```
 
 ## Admin
+
+Admin routes require an admin principal.
 
 ```bash
 curl -sS -H "authorization: Bearer $ADMIN_TOKEN" \

--- a/services/api/docs/platform-api.md
+++ b/services/api/docs/platform-api.md
@@ -74,13 +74,13 @@ curl -sS -X POST http://localhost:8080/api/auth/login \
   -d '{"email":"prince@example.com","password":"change-me-now"}'
 ```
 
-Both return a bearer `access_token`:
+Both return a bearer `access_token` with a 15-minute lifetime:
 
 ```json
 {
   "access_token": "...",
   "token_type": "bearer",
-  "expires_in": 43200,
+  "expires_in": 900,
   "user": {
     "id": "...",
     "email": "prince@example.com",

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -252,9 +252,9 @@ func main() {
 		mux.Handle("/api/runtime/components", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeComponents)))
 		mux.Handle("/api/runtime/policy", server.auth(http.HandlerFunc(runtimeServer.handleRuntimePolicy)))
 		mux.Handle("/api/runtime/actions/restart", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.handleActionRestart))))
-		// Grant item (POST /api/runtime/grants/{ns}/{name}/disable|enable, DELETE /api/runtime/grants/{ns}/{name})
+		// Grant item (POST /api/runtime/grants/{namespace}/{name}/disable|enable, DELETE /api/runtime/grants/{namespace}/{name})
 		mux.Handle("/api/runtime/grants/", server.auth(http.HandlerFunc(runtimeServer.handleGrantItemPath)))
-		// Session item (POST /api/runtime/sessions/{ns}/{name}/revoke|unrevoke, DELETE /api/runtime/sessions/{ns}/{name})
+		// Session item (POST /api/runtime/sessions/{namespace}/{name}/revoke|unrevoke, DELETE /api/runtime/sessions/{namespace}/{name})
 		mux.Handle("/api/runtime/sessions/", server.auth(http.HandlerFunc(runtimeServer.handleSessionItemPath)))
 		// User-scoped API key lifecycle.
 		mux.Handle("/api/user/api-keys", server.auth(http.HandlerFunc(server.handleUserAPIKeys)))


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request significantly enhances the documentation for the Sentinel platform, focusing on its APIs, authentication models, and debugging procedures.

Key changes include:

*   **Expanded API Reference:**
    *   Introduced a new "Authentication API" section detailing routes for user signup, login, OIDC authentication, and retrieving user principal information.
    *   Added new API endpoints for deleting `MCPAccessGrant` and `MCPAgentSession` resources.
    *   Documented new API endpoints for managing platform-managed deployments (create, delete) and user-owned registry credentials (list, create, revoke).
    *   Provided a comprehensive "Service HTTP reference" for all Sentinel components (UI, API, Ingest, Processor, MCP proxy sidecar), outlining their specific authentication behaviors, routes, and purpose, including new API routes for dashboard summaries, enabling/disabling grants, revoking/unrevoking sessions, and restarting components.
    *   Updated the platform-specific API documentation with more detailed examples for authentication, API key management, deployment management, and registry credentials.

*   **Enhanced Debugging and Troubleshooting Guides:**
    *   Significantly expanded the debugging section in the getting started guide with more detailed `kubectl` commands for inspecting server deployments, policies, and Kubernetes events.
    *   Introduced a new troubleshooting table that maps common symptoms (e.g., pod not ready, policy not affecting traffic, analytics missing) to specific first-check commands.
    *   Documented new `mcp-runtime` CLI commands for checking cluster health, Sentinel status, events, and logs for various components.
    *   Improved guidance on inspecting rendered policy ConfigMaps and understanding policy propagation delays.
<!-- kody-pr-summary:end -->