### PR TITLE
ci: add pre-commit secret scanning

### DIFF
--- a/.github/workflows/security-gitleaks.yaml
+++ b/.github/workflows/security-gitleaks.yaml
@@ -1,0 +1,30 @@
+name: Security - Gitleaks
+
+on:
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks Scan
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+title = "MCP Runtime Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Go module checksum entries contain expected base64-like hashes."
+paths = ['''go\.sum$''']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
   - repo: local
     hooks:
       - id: gofmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
     rev: v8.30.1
     hooks:
       - id: gitleaks
+        name: gitleaks
+        exclude: go\.sum$
   - repo: local
     hooks:
       - id: gofmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,12 @@ go vet ./...
 
 Optional but used in CI: `staticcheck ./...` (install the pinned CI version with `go install honnef.co/go/tools/cmd/staticcheck@v0.7.0`).
 
+Local pre-commit hooks are configured in `.pre-commit-config.yaml`. Install
+them with `pre-commit install`; they run Go formatting/static checks, targeted
+tests, generated-file drift checks, and a staged secret scan through the pinned
+Gitleaks hook. Use `pre-commit run --all-files` before pushing when you want
+the full local hook suite.
+
 **Targeted tests** (prefer these while iterating; full `./...` can be slow):
 
 - `go test ./internal/operator/... ./internal/cli/... -race -count=1`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ Local pre-commit hooks are configured in `.pre-commit-config.yaml`. Install
 them with `pre-commit install`; they run Go formatting/static checks, targeted
 tests, generated-file drift checks, and a staged secret scan through the pinned
 Gitleaks hook. Use `pre-commit run --all-files` before pushing when you want
-the full local hook suite.
+the full local hook suite; that command also runs integration hooks that install
+envtest assets and set `KUBEBUILDER_ASSETS`.
 
 **Targeted tests** (prefer these while iterating; full `./...` can be slow):
 
@@ -54,7 +55,7 @@ the full local hook suite.
 - `E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh` for repeated local Kind e2e debugging without recreating the cluster or rebuilding cached images; set `OPENAI_API_KEY` in env or `.env` for optional real-client prompts, and omit cache mode for CI-equivalent fresh runs.
 - `services/api` and `services/ui`: `go test -race -count=1 ./...` inside each directory (CI runs these explicitly)
 
-**CI** (`.github/workflows/ci.yaml`) runs: `gofmt` check, `go vet`, `staticcheck`, unit tests, golden tests, service tests, `test/integration`, SBOM generation, then Kind e2e on `main`/`PR` branches. Normal PRs, `main`, and manual runs first validate that `OPENAI_API_KEY` is accepted by OpenAI; if validation fails, Kind e2e is skipped with a warning. Those runs use `E2E_SCENARIOS=all` when the key validates. Dependabot PRs use `E2E_SCENARIOS=smoke-auth,governance` so dependency bumps still cover MCP ingress/auth and grant/session behavior without provider API secrets. Security workflows add pinned gosec, Trivy, and dependency-review checks. Align local changes with that before opening a PR.
+**CI** (`.github/workflows/ci.yaml`) runs: `gofmt` check, `go vet`, `staticcheck`, unit tests, golden tests, service tests, `test/integration`, SBOM generation, then Kind e2e on `main`/`PR` branches. Normal PRs, `main`, and manual runs first validate that `OPENAI_API_KEY` is accepted by OpenAI; if validation fails, Kind e2e is skipped with a warning. Those runs use `E2E_SCENARIOS=all` when the key validates. Dependabot PRs use `E2E_SCENARIOS=smoke-auth,governance` so dependency bumps still cover MCP ingress/auth and grant/session behavior without provider API secrets. Security workflows add pinned gosec, Gitleaks, Trivy, and dependency-review checks. Align local changes with that before opening a PR.
 
 **Docs sync for CLI help:** when you edit `docs/cli.md`, `docs/getting-started.md`, `docs/publish-mcp-server.md`, or any page that shows CLI commands, verify the exact command description, subcommands, flags, and defaults from live help output before push. Use:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/Agent-Hellboy/mcp-runtime/actions/workflows/ci.yaml/badge.svg)](https://github.com/Agent-Hellboy/mcp-runtime/actions/workflows/ci.yaml)
 [![Gosec Scan](https://img.shields.io/github/actions/workflow/status/Agent-Hellboy/mcp-runtime/security-gosec.yaml?branch=main&label=Gosec%20Scan)](https://github.com/Agent-Hellboy/mcp-runtime/actions/workflows/security-gosec.yaml)
+[![Gitleaks Scan](https://img.shields.io/github/actions/workflow/status/Agent-Hellboy/mcp-runtime/security-gitleaks.yaml?branch=main&label=Gitleaks%20Scan)](https://github.com/Agent-Hellboy/mcp-runtime/actions/workflows/security-gitleaks.yaml)
 [![Trivy FS Scan](https://img.shields.io/github/actions/workflow/status/Agent-Hellboy/mcp-runtime/security-trivy.yaml?branch=main&label=Trivy%20FS%20Scan&job=Trivy%20FS%20Scan)](https://github.com/Agent-Hellboy/mcp-runtime/actions/workflows/security-trivy.yaml?query=branch%3Amain+job%3ATrivy%20FS%20Scan)
 [![Trivy Image Scan](https://img.shields.io/github/actions/workflow/status/Agent-Hellboy/mcp-runtime/security-trivy.yaml?branch=main&label=Trivy%20Image%20Scan&job=Trivy%20Operator%20Image%20Scan)](https://github.com/Agent-Hellboy/mcp-runtime/actions/workflows/security-trivy.yaml?query=branch%3Amain+job%3ATrivy%20Operator%20Image%20Scan)
 [![Coverage](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main/graph/badge.svg)](https://codecov.io/gh/Agent-Hellboy/mcp-runtime/branch/main)

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -97,7 +97,8 @@ The main CI workflow runs:
 - Kind e2e for code changes
 
 Security workflows add pinned gosec, Trivy repository/image scans with SARIF
-upload, operator-image SBOM artifacts, and pull-request dependency review.
+upload, pinned Gitleaks secret scanning, operator-image SBOM artifacts, and
+pull-request dependency review.
 
 ## Pre-commit Hooks
 
@@ -105,7 +106,8 @@ upload, operator-image SBOM artifacts, and pull-request dependency review.
 `staticcheck`, `go vet`, targeted Go tests, generated-file drift checks, and a
 pinned Gitleaks hook for staged secret detection. Install with
 `pre-commit install`; run `pre-commit run --all-files` before pushing when you
-want the full local hook suite.
+want the full local hook suite. The full suite includes integration hooks that
+install envtest assets and set `KUBEBUILDER_ASSETS`.
 
 ## Choosing Coverage
 

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -99,6 +99,14 @@ The main CI workflow runs:
 Security workflows add pinned gosec, Trivy repository/image scans with SARIF
 upload, operator-image SBOM artifacts, and pull-request dependency review.
 
+## Pre-commit Hooks
+
+`.pre-commit-config.yaml` mirrors the local contributor gates: Go formatting,
+`staticcheck`, `go vet`, targeted Go tests, generated-file drift checks, and a
+pinned Gitleaks hook for staged secret detection. Install with
+`pre-commit install`; run `pre-commit run --all-files` before pushing when you
+want the full local hook suite.
+
 ## Choosing Coverage
 
 | Change | Minimum local check |


### PR DESCRIPTION

fixes #121 
<!-- kody-pr-summary:start -->
Introduces a pre-commit hook for secret scanning using Gitleaks.

The `.pre-commit-config.yaml` file is updated to include the Gitleaks hook (v8.30.1), which will scan staged changes for secrets before a commit is made.

Documentation in `AGENTS.md` and `docs/internals/tests.md` is updated to inform contributors about the new Gitleaks secret scanning hook and provide instructions on how to install and run pre-commit hooks locally.
<!-- kody-pr-summary:end -->