### PR TITLE
[codex] Add Sentinel dev logins and dashboard analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,11 @@ kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
   `./bin/mcp-runtime cluster doctor`; it flags UI/API/admin key mismatches. Roll
   the API, UI, ingest, and proxy/gateway workloads after patching
   `mcp-sentinel-secrets`.
+- **Test-mode platform logins:** `setup --test-mode` seeds local-only
+  email/password accounts through the platform identity store for UI debugging:
+  user `test@mcpruntime.org` / `test@123`, and admin
+  `admin@mcpruntime.org` / `admin@123`. Disable or override them through the
+  `PLATFORM_DEV_*` keys in `mcp-sentinel-secrets`, then roll the API deployment.
 
 - **Platform admin bootstrap (one-shot):**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -226,10 +226,11 @@ X-MCP-Agent-Session: sess-8f1b9d
 
 ## Dashboard API
 
-Overview statistics for the dashboard cards.
+Overview statistics and usage analytics for the admin dashboard.
 
 ```text
 GET /api/dashboard/summary
+GET /api/analytics/usage?limit=10
 ```
 
 Requires admin authentication. For direct curl/API clients, send an
@@ -237,7 +238,13 @@ Requires admin authentication. For direct curl/API clients, send an
 `setup` keeps `UI_API_KEY` in both lists for browser/API-key admin login.
 `INGEST_API_KEYS` is only for event ingestion and is not accepted here.
 
-Returns: `total_events`, `active_servers`, `active_grants`, `active_sessions`, `latest_source`, `last_event_type`, `last_event_time`.
+`/api/dashboard/summary` returns: `total_events`, `active_servers`,
+`active_grants`, `active_sessions`, `latest_source`, `last_event_type`,
+`last_event_time`.
+
+`/api/analytics/usage` reads the ClickHouse event stream and returns admin
+usage rollups for the dashboard: totals, top MCP servers, top human/agent
+pairs, top tools, and decision counts. Query: `limit` (1-50, default 10).
 
 ## Runtime Governance API
 
@@ -351,6 +358,7 @@ GET /api/events?limit=100
 GET /api/stats
 GET /api/sources
 GET /api/event-types
+GET /api/analytics/usage?limit=10
 GET /api/events/filter?server=payments&decision=deny&agent_id=ops-agent&limit=50
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,6 +117,25 @@ Local URLs:
 - API: `http://localhost:18080/api`
 - Demo MCP routes, after applying demo servers: `http://localhost:18080/<server-name>/mcp`
 
+The MCP Servers tab exposes a copyable connect config. In this local test-mode
+flow, that config should use the same reachable local origin, for example:
+
+```json
+{
+  "mcpServers": {
+    "go-example-mcp": {
+      "type": "http",
+      "url": "http://localhost:18080/go-example-mcp/mcp"
+    }
+  }
+}
+```
+
+When the platform is installed with `MCP_PLATFORM_DOMAIN=mcpruntime.org` or an
+explicit `MCP_MCP_INGRESS_HOST`, production connect configs should use the
+public MCP host instead, for example
+`https://mcp.mcpruntime.org/go-example-mcp/mcp`.
+
 `setup --test-mode` also seeds development-only email/password logins in the
 platform identity store:
 
@@ -135,6 +154,20 @@ API deployment.
 After `setup --test-mode` is complete, you do not need to rerun setup for every
 service change. Edit the service under `services/`, build only that image, push
 it to the bundled registry, and update only that Kubernetes Deployment.
+
+Run the targeted service tests before rebuilding the image:
+
+```bash
+(cd services/api && go test ./... -count=1)
+(cd services/ui && go test ./... -count=1)
+node --check services/ui/static/app.js
+```
+
+For API/UI changes that cross the browser-to-API proxy boundary, rebuild and
+roll both services. A common example is the MCP connect config URL: the UI
+forwards the browser origin to the API, and the API uses that origin to return a
+local URL such as `http://localhost:18080/<server-name>/mcp`; production hosts
+map `platform.<domain>` to `mcp.<domain>`.
 
 For the UI, for example:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,6 +117,72 @@ Local URLs:
 - API: `http://localhost:18080/api`
 - Demo MCP routes, after applying demo servers: `http://localhost:18080/<server-name>/mcp`
 
+`setup --test-mode` also seeds development-only email/password logins in the
+platform identity store:
+
+| Role | Email | Password |
+|---|---|---|
+| User | `test@mcpruntime.org` | `test@123` |
+| Admin | `admin@mcpruntime.org` | `admin@123` |
+
+These credentials are for local Kind/debugging only. They are enabled by the
+managed `mcp-sentinel-secrets` key `PLATFORM_DEV_LOGIN_ENABLED=true` and can be
+disabled or overridden by editing the `PLATFORM_DEV_*` keys before rolling the
+API deployment.
+
+### Iterate on one Sentinel service
+
+After `setup --test-mode` is complete, you do not need to rerun setup for every
+service change. Edit the service under `services/`, build only that image, push
+it to the bundled registry, and update only that Kubernetes Deployment.
+
+For the UI, for example:
+
+```bash
+SERVICE=ui
+IMAGE_REPO=mcp-sentinel-ui
+DOCKERFILE=services/ui/Dockerfile
+BUILD_CONTEXT=services/ui
+DEPLOYMENT=mcp-sentinel-ui
+CONTAINER=ui
+TAG="${SERVICE}-dev-$(date +%s)"
+LOCAL_IMAGE="${IMAGE_REPO}:${TAG}"
+REGISTRY=registry.registry.svc.cluster.local:5000
+
+docker build -t "$LOCAL_IMAGE" -f "$DOCKERFILE" "$BUILD_CONTEXT"
+
+./bin/mcp-runtime registry push \
+  --image "$LOCAL_IMAGE" \
+  --name "$IMAGE_REPO" \
+  --registry "$REGISTRY" \
+  --namespace registry
+
+kubectl -n mcp-sentinel set image \
+  "deployment/$DEPLOYMENT" \
+  "$CONTAINER=$REGISTRY/$IMAGE_REPO:$TAG"
+
+kubectl -n mcp-sentinel rollout status "deployment/$DEPLOYMENT" --timeout=90s
+```
+
+Keep the Traefik port-forward running and refresh the local URL:
+`http://localhost:18080/`. Use a new tag for each build so Kubernetes does not
+reuse an older `IfNotPresent` image from the node cache.
+
+Use the same commands with the variables below for other Sentinel services:
+
+| Service | Edit path | Image repo | Dockerfile | Build context | Deployment | Container |
+|---|---|---|---|---|---|---|
+| UI | `services/ui` | `mcp-sentinel-ui` | `services/ui/Dockerfile` | `services/ui` | `mcp-sentinel-ui` | `ui` |
+| API | `services/api` | `mcp-sentinel-api` | `services/api/Dockerfile` | `.` | `mcp-sentinel-api` | `api` |
+| Ingest | `services/ingest` | `mcp-sentinel-ingest` | `services/ingest/Dockerfile` | `services/ingest` | `mcp-sentinel-ingest` | `ingest` |
+| Processor | `services/processor` | `mcp-sentinel-processor` | `services/processor/Dockerfile` | `services/processor` | `mcp-sentinel-processor` | `processor` |
+
+`services/mcp-proxy` is different: it runs as the `mcp-gateway` sidecar inside
+each MCP server pod. To test proxy changes, build and push
+`mcp-sentinel-mcp-proxy`, update the operator's `MCP_GATEWAY_PROXY_IMAGE`, then
+restart the operator and recreate or restart the affected MCP server pods so
+the sidecar image is injected again.
+
 If pods report `ImagePullBackOff`, run `./bin/mcp-runtime cluster doctor`.
 For Kind test mode, the usual cause is a cluster created without the
 `registry.registry.svc.cluster.local:5000` mirror to `127.0.0.1:32000`. If pod
@@ -223,6 +289,12 @@ rm -rf /tmp/go-example-mcp-manifests
 kubectl rollout status deploy/go-example-mcp -n mcp-servers --timeout=180s
 ./bin/mcp-runtime server status --namespace mcp-servers
 ```
+
+In Kind, `server status` may show `PartiallyReady` while the Deployment is
+ready and traffic works. That usually means Traefik is routing through the local
+port-forward but has not written `Ingress.status.loadBalancer.ingress[]`; see
+[Local development notes](#local-development-notes) when you want permissive
+ingress readiness for this setup.
 
 Useful server and policy checks while iterating:
 
@@ -430,12 +502,17 @@ curl -sS -H "x-api-key: $ADMIN_KEY" \
   http://localhost:18080/api/dashboard/summary | jq .
 
 curl -sS -H "x-api-key: $ADMIN_KEY" \
+  "http://localhost:18080/api/analytics/usage?limit=10" | jq .
+
+curl -sS -H "x-api-key: $ADMIN_KEY" \
   "http://localhost:18080/api/events/filter?server=go-example-mcp&tool_name=add&limit=5" | jq .
 ```
 
 `mcp-runtime sentinel events` shows Kubernetes events for the Sentinel
 namespace. Use `/api/dashboard/summary`, `/api/events`, or
-`/api/events/filter` to verify request analytics.
+`/api/analytics/usage` to verify request analytics. The admin Dashboard tab
+uses `/api/analytics/usage` for its MCP server, human/agent, tool, and decision
+rollups.
 
 ## 4. Install the platform stack
 

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -9,8 +9,8 @@
 | **mcp-proxy** | Transparent sidecar. Extracts identity, evaluates tool-level policy, emits allow/deny audit events, forwards traffic upstream. |
 | **ingest** | Receives `POST /events`, validates ingest-scoped API keys or optional JWTs, writes to Kafka. |
 | **processor** | Consumes Kafka, batches, writes into ClickHouse with indexed audit fields. |
-| **api** | Analytics endpoints, dashboard summaries, runtime governance APIs (grants/sessions), component operations. |
-| **ui** | Three-tab dashboard: overview metrics + events, governance forms, operations health + safe restart. |
+| **api** | Analytics endpoints, dashboard summaries, runtime governance APIs (grants/sessions), platform audit, MCP server catalog, component operations. |
+| **ui** | Control-plane dashboard: MCP server catalog and connect config, user API keys, analytics dashboard, governance, MCP operations, and platform management. |
 | **gateway** | Kubernetes deployment fronting the sentinel API, ingest, and UI surfaces. |
 | **reference mcp-server** | Small example server in `examples/go-mcp-server` for end-to-end smoke tests. |
 
@@ -64,7 +64,7 @@ For local `setup --test-mode` clusters, setup seeds two email/password logins:
 | Surface | Public path in dev | In-cluster service | Notes |
 |---|---|---|---|
 | **UI** | `/` | `mcp-sentinel-ui:8082` | Browser app, browser login/session routes, and `/api` reverse proxy. |
-| **API** | `/api/*` through UI | `mcp-sentinel-api:8080` | Auth, analytics queries, runtime governance, deployments, admin/user APIs. |
+| **API** | `/api/*` through UI | `mcp-sentinel-api:8080` | Auth, analytics queries, runtime governance, deployments, admin/user APIs. The UI proxy forwards browser origin headers so local connect configs can point at `http://localhost:18080/<server-name>/mcp`. |
 | **Ingest** | `/ingest/events` | `mcp-sentinel-ingest:8081/events` | Event intake used by `mcp-proxy`; the public ingress strips `/ingest`. |
 | **Grafana** | `/grafana` | `grafana:3000` | Observability UI. |
 | **Prometheus** | `/prometheus` | `prometheus:9090` | Metrics query UI. |
@@ -100,7 +100,7 @@ metrics on `METRICS_PORT` (default `9090`).
 | `GET` | `/api/stats` | Total event count. Admin role required. |
 | `GET` | `/api/sources` | Event counts grouped by source. Admin role required. |
 | `GET` | `/api/event-types` | Event counts grouped by event type. Admin role required. |
-| `GET` | `/api/runtime/servers` | List MCP servers. Non-admin users may read `mcp-servers` and their own namespace. |
+| `GET` | `/api/runtime/servers` | List MCP servers and connect config JSON. Non-admin users may read `mcp-servers` and their own namespace. Local test-mode configs use the browser origin, for example `http://localhost:18080/go-example-mcp/mcp`; production platform hosts map `platform.<domain>` to `https://mcp.<domain>/<server-name>/mcp`. |
 | `GET`, `POST` | `/api/runtime/grants` | List or apply `MCPAccessGrant` resources. |
 | `GET`, `DELETE` | `/api/runtime/grants/{namespace}/{name}` | Read or delete one grant. |
 | `POST` | `/api/runtime/grants/{namespace}/{name}/disable` | Set `spec.disabled=true`. |
@@ -109,13 +109,14 @@ metrics on `METRICS_PORT` (default `9090`).
 | `GET`, `DELETE` | `/api/runtime/sessions/{namespace}/{name}` | Read or delete one session. |
 | `POST` | `/api/runtime/sessions/{namespace}/{name}/revoke` | Set `spec.revoked=true`. |
 | `POST` | `/api/runtime/sessions/{namespace}/{name}/unrevoke` | Set `spec.revoked=false`. |
-| `GET` | `/api/runtime/components` | Core Sentinel component health from Kubernetes. |
+| `GET` | `/api/runtime/components` | Operator, Sentinel service, and observability component health from Kubernetes. |
 | `GET` | `/api/runtime/policy?namespace=&server=` | Rendered gateway policy for one server. |
 | `POST` | `/api/runtime/actions/restart` | Restart one Sentinel component or all components. Admin role required. |
 | `GET`, `POST` | `/api/deployments` | User-scoped platform deployment list/apply. |
 | `DELETE` | `/api/deployments/{namespace}/{name}` | Delete a platform-managed deployment and service. |
 | `GET` | `/api/admin/namespaces` | Platform namespace inventory. Admin role required. |
 | `GET` | `/api/admin/deployments` | Deployment inventory across namespaces, optionally filtered by `namespace`. Admin role required. |
+| `GET` | `/api/admin/audit` | Recent platform audit logs such as login, signup, namespace, and registry credential activity. Query: `limit` (1-200, default 50). Admin role required. |
 | `GET`, `POST` | `/api/user/api-keys` | List or create caller-owned API keys. |
 | `POST` | `/api/user/api-keys/{id}/revoke` | Revoke one caller-owned API key. |
 | `GET`, `POST` | `/api/user/registry-credentials` | List or create caller-owned registry credentials. |

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -51,9 +51,15 @@ The Sentinel stack has multiple HTTP services. In local test mode, Traefik
 usually exposes them through `http://localhost:18080/`; inside the cluster,
 call the service DNS names directly.
 
+For the local build, push, and rollout loop while editing `services/`, see
+[Iterate on one Sentinel service](getting-started.md#iterate-on-one-sentinel-service).
+
 `api` accepts `API_KEYS`, with admin elevation only for keys also listed in
 `ADMIN_API_KEYS`. `ingest` accepts ingest-scoped `INGEST_API_KEYS`, with legacy
 fallback to `API_KEYS`, and optional OIDC JWT validation when configured.
+For local `setup --test-mode` clusters, setup seeds two email/password logins:
+`test@mcpruntime.org` / `test@123` with role `user`, and
+`admin@mcpruntime.org` / `admin@123` with role `admin`.
 
 | Surface | Public path in dev | In-cluster service | Notes |
 |---|---|---|---|
@@ -88,6 +94,7 @@ metrics on `METRICS_PORT` (default `9090`).
 | `POST` | `/api/auth/oidc` | Exchange a configured OIDC ID token for a platform bearer token. Returns `200` with `access_token`, `token_type`, `expires_in`, and `user`. |
 | `GET` | `/api/auth/me` | Return the authenticated principal. |
 | `GET` | `/api/dashboard/summary` | Dashboard cards: event totals, active grants/sessions, latest event metadata. Admin role required. |
+| `GET` | `/api/analytics/usage` | Dashboard usage analytics from ClickHouse: totals, top MCP servers, human/agent pairs, tools, and decision counts. Query: `limit` (1-50, default 10). Admin role required. |
 | `GET` | `/api/events` | Recent ClickHouse-backed audit events, newest first. Query: `limit` (1-1000, default 100). Admin role required. |
 | `GET` | `/api/events/filter` | Filtered audit events. Query: `source`, `event_type`, `server`, `namespace`, `cluster`, `human_id`, `agent_id`, `session_id`, `decision`, `tool_name`, `limit`. Admin role required. |
 | `GET` | `/api/stats` | Total event count. Admin role required. |

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -699,6 +699,38 @@ func TestRenderAnalyticsSecretManifestGeneratesKeysWhenMissing(t *testing.T) {
 	}
 }
 
+func TestRenderAnalyticsSecretManifestSeedsDevLoginsInTestMode(t *testing.T) {
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "1")
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			if contains(spec.Args, "get") && contains(spec.Args, "secret") {
+				return &core.MockCommand{
+					Args:       spec.Args,
+					OutputData: []byte("Error from server (NotFound): secrets \"mcp-sentinel-secrets\" not found"),
+					OutputErr:  errors.New("not found"),
+				}
+			}
+			return &core.MockCommand{Args: spec.Args}
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	manifest, err := renderAnalyticsSecretManifest(kubectl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := secretStringDataFromManifest(t, manifest)
+	if data["PLATFORM_DEV_LOGIN_ENABLED"] != "true" {
+		t.Fatalf("expected dev login seed to be enabled, got %q", data["PLATFORM_DEV_LOGIN_ENABLED"])
+	}
+	if data["PLATFORM_DEV_USER_EMAIL"] != defaultDevUserEmail || data["PLATFORM_DEV_USER_PASSWORD"] != defaultDevUserPassword {
+		t.Fatalf("unexpected dev user credentials: email=%q password=%q", data["PLATFORM_DEV_USER_EMAIL"], data["PLATFORM_DEV_USER_PASSWORD"])
+	}
+	if data["PLATFORM_DEV_ADMIN_EMAIL"] != defaultDevAdminEmail || data["PLATFORM_DEV_ADMIN_PASSWORD"] != defaultDevAdminPassword {
+		t.Fatalf("unexpected dev admin credentials: email=%q password=%q", data["PLATFORM_DEV_ADMIN_EMAIL"], data["PLATFORM_DEV_ADMIN_PASSWORD"])
+	}
+}
+
 func TestEnsureCSVIncludes(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -731,6 +731,50 @@ func TestRenderAnalyticsSecretManifestSeedsDevLoginsInTestMode(t *testing.T) {
 	}
 }
 
+func TestRenderAnalyticsSecretManifestDisablesExistingDevLoginsOutsideTestMode(t *testing.T) {
+	encoded := func(value string) []byte {
+		return []byte(base64.StdEncoding.EncodeToString([]byte(value)))
+	}
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			switch {
+			case contains(spec.Args, "jsonpath={.data.PLATFORM_DEV_LOGIN_ENABLED}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: encoded("true")}
+			case contains(spec.Args, "jsonpath={.data.PLATFORM_DEV_USER_EMAIL}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: encoded(defaultDevUserEmail)}
+			case contains(spec.Args, "jsonpath={.data.PLATFORM_DEV_USER_PASSWORD}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: encoded(defaultDevUserPassword)}
+			case contains(spec.Args, "jsonpath={.data.PLATFORM_DEV_ADMIN_EMAIL}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: encoded(defaultDevAdminEmail)}
+			case contains(spec.Args, "jsonpath={.data.PLATFORM_DEV_ADMIN_PASSWORD}"):
+				return &core.MockCommand{Args: spec.Args, OutputData: encoded(defaultDevAdminPassword)}
+			default:
+				return &core.MockCommand{Args: spec.Args}
+			}
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	manifest, err := renderAnalyticsSecretManifest(kubectl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := secretStringDataFromManifest(t, manifest)
+	if data["PLATFORM_DEV_LOGIN_ENABLED"] != "false" {
+		t.Fatalf("expected dev login seed to be disabled outside test mode, got %q", data["PLATFORM_DEV_LOGIN_ENABLED"])
+	}
+	for _, key := range []string{
+		"PLATFORM_DEV_USER_EMAIL",
+		"PLATFORM_DEV_USER_PASSWORD",
+		"PLATFORM_DEV_ADMIN_EMAIL",
+		"PLATFORM_DEV_ADMIN_PASSWORD",
+	} {
+		if data[key] != "" {
+			t.Fatalf("expected %s to be cleared outside test mode, got %q", key, data[key])
+		}
+	}
+}
+
 func TestEnsureCSVIncludes(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -1923,10 +1923,7 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 	if adminUsers == "" && platformAdminEmail != "" {
 		adminUsers = platformAdminEmail
 	}
-	platformDevLoginEnabled, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_LOGIN_ENABLED")
-	if err != nil {
-		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
-	}
+	platformDevLoginEnabled := ""
 	platformDevUserEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_EMAIL")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
@@ -1944,9 +1941,7 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
 	if os.Getenv("MCP_RUNTIME_TEST_MODE") == "1" {
-		if platformDevLoginEnabled == "" {
-			platformDevLoginEnabled = "true"
-		}
+		platformDevLoginEnabled = "true"
 		if platformDevUserEmail == "" {
 			platformDevUserEmail = defaultDevUserEmail
 		}
@@ -1959,6 +1954,12 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 		if platformDevAdminPassword == "" {
 			platformDevAdminPassword = defaultDevAdminPassword
 		}
+	} else {
+		platformDevLoginEnabled = "false"
+		platformDevUserEmail = ""
+		platformDevUserPassword = ""
+		platformDevAdminEmail = ""
+		platformDevAdminPassword = ""
 	}
 	stringData := map[string]string{
 		"API_KEYS":                apiKeys,

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -41,6 +41,12 @@ const defaultGatewayProxyRepository = "mcp-sentinel-mcp-proxy"
 const defaultAnalyticsIngestURL = "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events"
 const gatewayProxyDockerfilePath = "services/mcp-proxy/Dockerfile"
 const gatewayProxyBuildContext = "."
+const (
+	defaultDevUserEmail     = "test@mcpruntime.org"
+	defaultDevUserPassword  = "test@123"
+	defaultDevAdminEmail    = "admin@mcpruntime.org"
+	defaultDevAdminPassword = "admin@123"
+)
 
 var setupImageTagResolver = registry.DefaultGitTag
 
@@ -1917,6 +1923,70 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 	if adminUsers == "" && platformAdminEmail != "" {
 		adminUsers = platformAdminEmail
 	}
+	platformDevLoginEnabled, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_LOGIN_ENABLED")
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
+	platformDevUserEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_EMAIL")
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
+	platformDevUserPassword, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_PASSWORD")
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
+	platformDevAdminEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_ADMIN_EMAIL")
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
+	platformDevAdminPassword, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_ADMIN_PASSWORD")
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
+	}
+	if os.Getenv("MCP_RUNTIME_TEST_MODE") == "1" {
+		if platformDevLoginEnabled == "" {
+			platformDevLoginEnabled = "true"
+		}
+		if platformDevUserEmail == "" {
+			platformDevUserEmail = defaultDevUserEmail
+		}
+		if platformDevUserPassword == "" {
+			platformDevUserPassword = defaultDevUserPassword
+		}
+		if platformDevAdminEmail == "" {
+			platformDevAdminEmail = defaultDevAdminEmail
+		}
+		if platformDevAdminPassword == "" {
+			platformDevAdminPassword = defaultDevAdminPassword
+		}
+	}
+	stringData := map[string]string{
+		"API_KEYS":                apiKeys,
+		"INGEST_API_KEYS":         ingestAPIKeys,
+		"ADMIN_API_KEYS":          adminAPIKeys,
+		"UI_API_KEY":              uiAPIKey,
+		"ADMIN_USERS":             adminUsers,
+		"PLATFORM_ADMIN_EMAIL":    platformAdminEmail,
+		"PLATFORM_ADMIN_PASSWORD": platformAdminPassword,
+		"POSTGRES_USER":           postgresUser,
+		"POSTGRES_PASSWORD":       postgresPassword,
+		"POSTGRES_DB":             postgresDB,
+		"POSTGRES_DSN":            postgresDSN,
+		"PLATFORM_JWT_SECRET":     platformJWTSecret,
+		"GRAFANA_ADMIN_USER":      "admin",
+		"GRAFANA_ADMIN_PASSWORD":  grafanaPassword,
+	}
+	if platformDevLoginEnabled != "" ||
+		platformDevUserEmail != "" ||
+		platformDevUserPassword != "" ||
+		platformDevAdminEmail != "" ||
+		platformDevAdminPassword != "" {
+		stringData["PLATFORM_DEV_LOGIN_ENABLED"] = platformDevLoginEnabled
+		stringData["PLATFORM_DEV_USER_EMAIL"] = platformDevUserEmail
+		stringData["PLATFORM_DEV_USER_PASSWORD"] = platformDevUserPassword
+		stringData["PLATFORM_DEV_ADMIN_EMAIL"] = platformDevAdminEmail
+		stringData["PLATFORM_DEV_ADMIN_PASSWORD"] = platformDevAdminPassword
+	}
 	secretManifest := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Secret",
@@ -1924,23 +1994,8 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 			"name":      "mcp-sentinel-secrets",
 			"namespace": core.DefaultAnalyticsNamespace,
 		},
-		"type": "Opaque",
-		"stringData": map[string]string{
-			"API_KEYS":                apiKeys,
-			"INGEST_API_KEYS":         ingestAPIKeys,
-			"ADMIN_API_KEYS":          adminAPIKeys,
-			"UI_API_KEY":              uiAPIKey,
-			"ADMIN_USERS":             adminUsers,
-			"PLATFORM_ADMIN_EMAIL":    platformAdminEmail,
-			"PLATFORM_ADMIN_PASSWORD": platformAdminPassword,
-			"POSTGRES_USER":           postgresUser,
-			"POSTGRES_PASSWORD":       postgresPassword,
-			"POSTGRES_DB":             postgresDB,
-			"POSTGRES_DSN":            postgresDSN,
-			"PLATFORM_JWT_SECRET":     platformJWTSecret,
-			"GRAFANA_ADMIN_USER":      "admin",
-			"GRAFANA_ADMIN_PASSWORD":  grafanaPassword,
-		},
+		"type":       "Opaque",
+		"stringData": stringData,
 	}
 	rendered, err := yaml.Marshal(secretManifest)
 	if err != nil {

--- a/k8s/02-secrets.yaml.example
+++ b/k8s/02-secrets.yaml.example
@@ -22,6 +22,13 @@ stringData:
   PLATFORM_ADMIN_EMAIL: "admin@example.com"
   PLATFORM_ADMIN_PASSWORD: "change-me-now"
   ADMIN_USERS: "admin@example.com"
+  # Optional local-only dev logins. setup --test-mode enables these with the
+  # defaults below; keep disabled for shared or production clusters.
+  PLATFORM_DEV_LOGIN_ENABLED: "false"
+  PLATFORM_DEV_USER_EMAIL: "test@mcpruntime.org"
+  PLATFORM_DEV_USER_PASSWORD: "test@123"
+  PLATFORM_DEV_ADMIN_EMAIL: "admin@mcpruntime.org"
+  PLATFORM_DEV_ADMIN_PASSWORD: "admin@123"
   # Platform identity database and token signing.
   POSTGRES_USER: "mcp_runtime"
   POSTGRES_PASSWORD: "change-me-postgres"

--- a/k8s/08-api.yaml
+++ b/k8s/08-api.yaml
@@ -96,6 +96,36 @@ spec:
                   name: mcp-sentinel-secrets
                   key: PLATFORM_ADMIN_EMAIL
                   optional: true
+            - name: PLATFORM_DEV_LOGIN_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-sentinel-secrets
+                  key: PLATFORM_DEV_LOGIN_ENABLED
+                  optional: true
+            - name: PLATFORM_DEV_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-sentinel-secrets
+                  key: PLATFORM_DEV_USER_EMAIL
+                  optional: true
+            - name: PLATFORM_DEV_USER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-sentinel-secrets
+                  key: PLATFORM_DEV_USER_PASSWORD
+                  optional: true
+            - name: PLATFORM_DEV_ADMIN_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-sentinel-secrets
+                  key: PLATFORM_DEV_ADMIN_EMAIL
+                  optional: true
+            - name: PLATFORM_DEV_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-sentinel-secrets
+                  key: PLATFORM_DEV_ADMIN_PASSWORD
+                  optional: true
             - name: OTEL_SERVICE_NAME
               value: mcp-sentinel-api
           resources:

--- a/pkg/sentinel/components.go
+++ b/pkg/sentinel/components.go
@@ -27,11 +27,20 @@ type PortTarget struct {
 }
 
 const (
-	DefaultNamespace = "mcp-sentinel"
+	DefaultNamespace  = "mcp-sentinel"
+	OperatorNamespace = "mcp-runtime"
 )
 
 // Components is the registry of all Sentinel stack components.
 var Components = []Component{
+	{
+		Key:       "operator",
+		Display:   "Operator",
+		Namespace: OperatorNamespace,
+		Kind:      "deployment",
+		Resource:  "mcp-runtime-operator-controller-manager",
+		Label:     "mcp-runtime-operator-controller-manager",
+	},
 	{
 		Key:       "clickhouse",
 		Display:   "ClickHouse",

--- a/services/api/admin.go
+++ b/services/api/admin.go
@@ -19,3 +19,22 @@ func (s *apiServer) handleAdminNamespaces(w http.ResponseWriter, r *http.Request
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"namespaces": namespaces})
 }
+
+func (s *apiServer) handleAdminAudit(w http.ResponseWriter, r *http.Request) {
+	if s.platform == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("allow", "GET")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return
+	}
+	limit := clampInt(queryInt(r, "limit", 50), 1, 200)
+	auditLogs, err := s.platform.ListAuditLogs(r.Context(), limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list audit logs"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"audit_logs": auditLogs})
+}

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -309,6 +309,7 @@ func main() {
 		mux.Handle("/api/deployments", server.auth(http.HandlerFunc(runtimeServer.handleDeployments)))
 		mux.Handle("/api/deployments/", server.auth(http.HandlerFunc(runtimeServer.handleDeploymentItem)))
 		mux.Handle("/api/admin/namespaces", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleAdminNamespaces))))
+		mux.Handle("/api/admin/audit", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleAdminAudit))))
 		mux.Handle("/api/admin/deployments", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.handleAdminDeployments))))
 		mux.Handle("/api/runtime/grants", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeGrants)))
 		mux.Handle("/api/runtime/sessions", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeSessions)))

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -68,6 +68,58 @@ type eventRow struct {
 	Payload   json.RawMessage `json:"payload"`
 }
 
+type analyticsServerUsage struct {
+	Server       string    `json:"server"`
+	Namespace    string    `json:"namespace"`
+	Events       uint64    `json:"events"`
+	Allowed      uint64    `json:"allowed"`
+	Denied       uint64    `json:"denied"`
+	UniqueHumans uint64    `json:"unique_humans"`
+	UniqueAgents uint64    `json:"unique_agents"`
+	LastSeen     time.Time `json:"last_seen"`
+}
+
+type analyticsActorUsage struct {
+	HumanID       string    `json:"human_id"`
+	AgentID       string    `json:"agent_id"`
+	Events        uint64    `json:"events"`
+	UniqueServers uint64    `json:"unique_servers"`
+	UniqueTools   uint64    `json:"unique_tools"`
+	Denied        uint64    `json:"denied"`
+	LastSeen      time.Time `json:"last_seen"`
+}
+
+type analyticsToolUsage struct {
+	Server   string    `json:"server"`
+	ToolName string    `json:"tool_name"`
+	Events   uint64    `json:"events"`
+	Denied   uint64    `json:"denied"`
+	LastSeen time.Time `json:"last_seen"`
+}
+
+type analyticsDecisionUsage struct {
+	Decision string `json:"decision"`
+	Events   uint64 `json:"events"`
+}
+
+type analyticsTotals struct {
+	Events         uint64 `json:"events"`
+	Allowed        uint64 `json:"allowed"`
+	Denied         uint64 `json:"denied"`
+	UniqueServers  uint64 `json:"unique_servers"`
+	UniqueHumans   uint64 `json:"unique_humans"`
+	UniqueAgents   uint64 `json:"unique_agents"`
+	UniqueSessions uint64 `json:"unique_sessions"`
+}
+
+type analyticsUsageResponse struct {
+	Totals    analyticsTotals          `json:"totals"`
+	Servers   []analyticsServerUsage   `json:"servers"`
+	Actors    []analyticsActorUsage    `json:"actors"`
+	Tools     []analyticsToolUsage     `json:"tools"`
+	Decisions []analyticsDecisionUsage `json:"decisions"`
+}
+
 type apiServer struct {
 	db           clickhouse.Conn
 	dbName       string
@@ -199,6 +251,9 @@ func main() {
 		if err := seedPlatformAdminFromEnv(ctx, store); err != nil {
 			log.Fatalf("failed to seed platform admin: %v", err)
 		}
+		if err := seedPlatformDevUsersFromEnv(ctx, store); err != nil {
+			log.Fatalf("failed to seed platform dev users: %v", err)
+		}
 		server.platform = store
 		server.userKeys = store
 	}
@@ -225,6 +280,7 @@ func main() {
 	mux.Handle("/api/stats", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleStats))))
 	mux.Handle("/api/sources", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleSources))))
 	mux.Handle("/api/event-types", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleEventTypes))))
+	mux.Handle("/api/analytics/usage", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleAnalyticsUsage))))
 	mux.Handle("/api/events/filter", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleEventsFilter))))
 	mux.Handle("/api/auth/me", server.auth(http.HandlerFunc(server.handleAuthMe)))
 	mux.Handle("/api/user/registry-credentials", server.auth(http.HandlerFunc(server.handleRegistryCredentials)))
@@ -473,6 +529,135 @@ func (s *apiServer) handleEventTypes(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"event_types": eventTypes})
+}
+
+func (s *apiServer) handleAnalyticsUsage(w http.ResponseWriter, r *http.Request) {
+	limit := clampInt(queryInt(r, "limit", 10), 1, 50)
+
+	totals, err := s.queryAnalyticsTotals(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+	servers, err := s.queryAnalyticsServers(r.Context(), limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+	actors, err := s.queryAnalyticsActors(r.Context(), limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+	tools, err := s.queryAnalyticsTools(r.Context(), limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+	decisions, err := s.queryAnalyticsDecisions(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, analyticsUsageResponse{
+		Totals:    totals,
+		Servers:   servers,
+		Actors:    actors,
+		Tools:     tools,
+		Decisions: decisions,
+	})
+}
+
+func (s *apiServer) queryAnalyticsTotals(ctx context.Context) (analyticsTotals, error) {
+	query := "SELECT count(), countIf(decision = 'allow'), countIf(decision = 'deny'), uniqExactIf(server, server != ''), uniqExactIf(human_id, human_id != ''), uniqExactIf(agent_id, agent_id != ''), uniqExactIf(session_id, session_id != '') FROM " + s.dbName + ".events"
+	var totals analyticsTotals
+	err := s.db.QueryRow(ctx, query).Scan(
+		&totals.Events,
+		&totals.Allowed,
+		&totals.Denied,
+		&totals.UniqueServers,
+		&totals.UniqueHumans,
+		&totals.UniqueAgents,
+		&totals.UniqueSessions,
+	)
+	return totals, err
+}
+
+func (s *apiServer) queryAnalyticsServers(ctx context.Context, limit int) ([]analyticsServerUsage, error) {
+	query := "SELECT server, namespace, count() AS events, countIf(decision = 'allow') AS allowed, countIf(decision = 'deny') AS denied, uniqExactIf(human_id, human_id != '') AS unique_humans, uniqExactIf(agent_id, agent_id != '') AS unique_agents, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE server != '' GROUP BY server, namespace ORDER BY events DESC LIMIT ?"
+	rows, err := s.db.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]analyticsServerUsage, 0, limit)
+	for rows.Next() {
+		var row analyticsServerUsage
+		if err := rows.Scan(&row.Server, &row.Namespace, &row.Events, &row.Allowed, &row.Denied, &row.UniqueHumans, &row.UniqueAgents, &row.LastSeen); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (s *apiServer) queryAnalyticsActors(ctx context.Context, limit int) ([]analyticsActorUsage, error) {
+	query := "SELECT human_id, agent_id, count() AS events, uniqExactIf(server, server != '') AS unique_servers, uniqExactIf(tool_name, tool_name != '') AS unique_tools, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE human_id != '' OR agent_id != '' GROUP BY human_id, agent_id ORDER BY events DESC LIMIT ?"
+	rows, err := s.db.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]analyticsActorUsage, 0, limit)
+	for rows.Next() {
+		var row analyticsActorUsage
+		if err := rows.Scan(&row.HumanID, &row.AgentID, &row.Events, &row.UniqueServers, &row.UniqueTools, &row.Denied, &row.LastSeen); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (s *apiServer) queryAnalyticsTools(ctx context.Context, limit int) ([]analyticsToolUsage, error) {
+	query := "SELECT server, tool_name, count() AS events, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE tool_name != '' GROUP BY server, tool_name ORDER BY events DESC LIMIT ?"
+	rows, err := s.db.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]analyticsToolUsage, 0, limit)
+	for rows.Next() {
+		var row analyticsToolUsage
+		if err := rows.Scan(&row.Server, &row.ToolName, &row.Events, &row.Denied, &row.LastSeen); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (s *apiServer) queryAnalyticsDecisions(ctx context.Context) ([]analyticsDecisionUsage, error) {
+	query := "SELECT if(decision = '', 'unknown', decision) AS decision_label, count() AS events FROM " + s.dbName + ".events GROUP BY decision_label ORDER BY events DESC"
+	rows, err := s.db.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]analyticsDecisionUsage, 0)
+	for rows.Next() {
+		var row analyticsDecisionUsage
+		if err := rows.Scan(&row.Decision, &row.Events); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
 }
 
 // handleEventsFilter handles GET /api/events/filter requests.

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -36,6 +36,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -113,11 +114,12 @@ type analyticsTotals struct {
 }
 
 type analyticsUsageResponse struct {
-	Totals    analyticsTotals          `json:"totals"`
-	Servers   []analyticsServerUsage   `json:"servers"`
-	Actors    []analyticsActorUsage    `json:"actors"`
-	Tools     []analyticsToolUsage     `json:"tools"`
-	Decisions []analyticsDecisionUsage `json:"decisions"`
+	Totals     analyticsTotals          `json:"totals"`
+	Servers    []analyticsServerUsage   `json:"servers"`
+	Actors     []analyticsActorUsage    `json:"actors"`
+	Tools      []analyticsToolUsage     `json:"tools"`
+	Decisions  []analyticsDecisionUsage `json:"decisions"`
+	WindowDays int                      `json:"window_days"`
 }
 
 type apiServer struct {
@@ -136,6 +138,11 @@ type apiServer struct {
 }
 
 const eventSelectColumns = "timestamp, source, event_type, server, namespace, cluster, human_id, agent_id, session_id, decision, tool_name, payload"
+
+const (
+	analyticsDefaultWindowDays = 30
+	analyticsMaxWindowDays     = 365
+)
 
 var auditFieldColumns = map[string]string{
 	"server":     "server",
@@ -533,46 +540,89 @@ func (s *apiServer) handleEventTypes(w http.ResponseWriter, r *http.Request) {
 
 func (s *apiServer) handleAnalyticsUsage(w http.ResponseWriter, r *http.Request) {
 	limit := clampInt(queryInt(r, "limit", 10), 1, 50)
+	windowDays := clampInt(queryInt(r, "window_days", analyticsDefaultWindowDays), 1, analyticsMaxWindowDays)
+	since := time.Now().AddDate(0, 0, -windowDays)
 
-	totals, err := s.queryAnalyticsTotals(r.Context())
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
-		return
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	var (
+		totals    analyticsTotals
+		servers   []analyticsServerUsage
+		actors    []analyticsActorUsage
+		tools     []analyticsToolUsage
+		decisions []analyticsDecisionUsage
+
+		wg          sync.WaitGroup
+		errOnce     sync.Once
+		firstErr    error
+		firstErrKey string
+	)
+
+	recordErr := func(key string, err error) {
+		if err == nil {
+			return
+		}
+		errOnce.Do(func() {
+			firstErr = err
+			firstErrKey = key
+			cancel()
+		})
 	}
-	servers, err := s.queryAnalyticsServers(r.Context(), limit)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
-		return
-	}
-	actors, err := s.queryAnalyticsActors(r.Context(), limit)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
-		return
-	}
-	tools, err := s.queryAnalyticsTools(r.Context(), limit)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
-		return
-	}
-	decisions, err := s.queryAnalyticsDecisions(r.Context())
-	if err != nil {
+
+	wg.Add(5)
+	go func() {
+		defer wg.Done()
+		var err error
+		totals, err = s.queryAnalyticsTotals(ctx, since)
+		recordErr("totals", err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		servers, err = s.queryAnalyticsServers(ctx, since, limit)
+		recordErr("servers", err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		actors, err = s.queryAnalyticsActors(ctx, since, limit)
+		recordErr("actors", err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		tools, err = s.queryAnalyticsTools(ctx, since, limit)
+		recordErr("tools", err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		decisions, err = s.queryAnalyticsDecisions(ctx, since)
+		recordErr("decisions", err)
+	}()
+	wg.Wait()
+
+	if firstErr != nil {
+		log.Printf("analytics usage query failed query=%s window_days=%d limit=%d since=%s err=%v", firstErrKey, windowDays, limit, since.Format(time.RFC3339), firstErr)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
 		return
 	}
 
 	writeJSON(w, http.StatusOK, analyticsUsageResponse{
-		Totals:    totals,
-		Servers:   servers,
-		Actors:    actors,
-		Tools:     tools,
-		Decisions: decisions,
+		Totals:     totals,
+		Servers:    servers,
+		Actors:     actors,
+		Tools:      tools,
+		Decisions:  decisions,
+		WindowDays: windowDays,
 	})
 }
 
-func (s *apiServer) queryAnalyticsTotals(ctx context.Context) (analyticsTotals, error) {
-	query := "SELECT count(), countIf(decision = 'allow'), countIf(decision = 'deny'), uniqExactIf(server, server != ''), uniqExactIf(human_id, human_id != ''), uniqExactIf(agent_id, agent_id != ''), uniqExactIf(session_id, session_id != '') FROM " + s.dbName + ".events"
+func (s *apiServer) queryAnalyticsTotals(ctx context.Context, since time.Time) (analyticsTotals, error) {
+	query := "SELECT count(), countIf(decision = 'allow'), countIf(decision = 'deny'), uniqIf(server, server != ''), uniqIf(human_id, human_id != ''), uniqIf(agent_id, agent_id != ''), uniqIf(session_id, session_id != '') FROM " + s.dbName + ".events WHERE timestamp >= ?"
 	var totals analyticsTotals
-	err := s.db.QueryRow(ctx, query).Scan(
+	err := s.db.QueryRow(ctx, query, since).Scan(
 		&totals.Events,
 		&totals.Allowed,
 		&totals.Denied,
@@ -584,9 +634,9 @@ func (s *apiServer) queryAnalyticsTotals(ctx context.Context) (analyticsTotals, 
 	return totals, err
 }
 
-func (s *apiServer) queryAnalyticsServers(ctx context.Context, limit int) ([]analyticsServerUsage, error) {
-	query := "SELECT server, namespace, count() AS events, countIf(decision = 'allow') AS allowed, countIf(decision = 'deny') AS denied, uniqExactIf(human_id, human_id != '') AS unique_humans, uniqExactIf(agent_id, agent_id != '') AS unique_agents, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE server != '' GROUP BY server, namespace ORDER BY events DESC LIMIT ?"
-	rows, err := s.db.Query(ctx, query, limit)
+func (s *apiServer) queryAnalyticsServers(ctx context.Context, since time.Time, limit int) ([]analyticsServerUsage, error) {
+	query := "SELECT server, namespace, count() AS events, countIf(decision = 'allow') AS allowed, countIf(decision = 'deny') AS denied, uniqIf(human_id, human_id != '') AS unique_humans, uniqIf(agent_id, agent_id != '') AS unique_agents, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE timestamp >= ? AND server != '' GROUP BY server, namespace ORDER BY events DESC LIMIT ?"
+	rows, err := s.db.Query(ctx, query, since, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -603,9 +653,9 @@ func (s *apiServer) queryAnalyticsServers(ctx context.Context, limit int) ([]ana
 	return out, rows.Err()
 }
 
-func (s *apiServer) queryAnalyticsActors(ctx context.Context, limit int) ([]analyticsActorUsage, error) {
-	query := "SELECT human_id, agent_id, count() AS events, uniqExactIf(server, server != '') AS unique_servers, uniqExactIf(tool_name, tool_name != '') AS unique_tools, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE human_id != '' OR agent_id != '' GROUP BY human_id, agent_id ORDER BY events DESC LIMIT ?"
-	rows, err := s.db.Query(ctx, query, limit)
+func (s *apiServer) queryAnalyticsActors(ctx context.Context, since time.Time, limit int) ([]analyticsActorUsage, error) {
+	query := "SELECT human_id, agent_id, count() AS events, uniqIf(server, server != '') AS unique_servers, uniqIf(tool_name, tool_name != '') AS unique_tools, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE timestamp >= ? AND (human_id != '' OR agent_id != '') GROUP BY human_id, agent_id ORDER BY events DESC LIMIT ?"
+	rows, err := s.db.Query(ctx, query, since, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -622,9 +672,9 @@ func (s *apiServer) queryAnalyticsActors(ctx context.Context, limit int) ([]anal
 	return out, rows.Err()
 }
 
-func (s *apiServer) queryAnalyticsTools(ctx context.Context, limit int) ([]analyticsToolUsage, error) {
-	query := "SELECT server, tool_name, count() AS events, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE tool_name != '' GROUP BY server, tool_name ORDER BY events DESC LIMIT ?"
-	rows, err := s.db.Query(ctx, query, limit)
+func (s *apiServer) queryAnalyticsTools(ctx context.Context, since time.Time, limit int) ([]analyticsToolUsage, error) {
+	query := "SELECT server, tool_name, count() AS events, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE timestamp >= ? AND tool_name != '' GROUP BY server, tool_name ORDER BY events DESC LIMIT ?"
+	rows, err := s.db.Query(ctx, query, since, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -641,9 +691,9 @@ func (s *apiServer) queryAnalyticsTools(ctx context.Context, limit int) ([]analy
 	return out, rows.Err()
 }
 
-func (s *apiServer) queryAnalyticsDecisions(ctx context.Context) ([]analyticsDecisionUsage, error) {
-	query := "SELECT if(decision = '', 'unknown', decision) AS decision_label, count() AS events FROM " + s.dbName + ".events GROUP BY decision_label ORDER BY events DESC"
-	rows, err := s.db.Query(ctx, query)
+func (s *apiServer) queryAnalyticsDecisions(ctx context.Context, since time.Time) ([]analyticsDecisionUsage, error) {
+	query := "SELECT if(decision = '', 'unknown', decision) AS decision_label, count() AS events FROM " + s.dbName + ".events WHERE timestamp >= ? GROUP BY decision_label ORDER BY events DESC"
+	rows, err := s.db.Query(ctx, query, since)
 	if err != nil {
 		return nil, err
 	}

--- a/services/api/platform_auth.go
+++ b/services/api/platform_auth.go
@@ -21,10 +21,20 @@ const (
 	apiLoginLockoutBase = 15 * time.Second
 	apiLoginLockoutMax  = 5 * time.Minute
 )
+const (
+	defaultDevUserEmail     = "test@mcpruntime.org"
+	defaultDevUserPassword  = "test@123"
+	defaultDevAdminEmail    = "admin@mcpruntime.org"
+	defaultDevAdminPassword = "admin@123"
+)
 
 var platformLoginAttempts = newAPILoginAttemptTracker(time.Now)
 var oidcLoginHook func(context.Context, *apiServer, string) (platformUser, error)
 var errOIDCUnauthorized = errors.New("oidc unauthorized")
+
+type passwordUserEnsurer interface {
+	EnsurePasswordUser(ctx context.Context, email, password string, role string) (platformUser, error)
+}
 
 type apiLoginAttempt struct {
 	failures    int
@@ -125,7 +135,7 @@ func runPlatformAdminBootstrap(ctx context.Context) error {
 	return seedPlatformAdminFromEnv(ctx, store)
 }
 
-func seedPlatformAdminFromEnv(ctx context.Context, store *platformStore) error {
+func seedPlatformAdminFromEnv(ctx context.Context, store passwordUserEnsurer) error {
 	email := strings.TrimSpace(os.Getenv("PLATFORM_ADMIN_EMAIL"))
 	password := strings.TrimSpace(os.Getenv("PLATFORM_ADMIN_PASSWORD"))
 	if email == "" && password == "" {
@@ -139,6 +149,51 @@ func seedPlatformAdminFromEnv(ctx context.Context, store *platformStore) error {
 		return err
 	}
 	log.Printf("platform admin user ensured email=%q namespace=%q", u.Email, u.Namespace)
+	return nil
+}
+
+func seedPlatformDevUsersFromEnv(ctx context.Context, store passwordUserEnsurer) error {
+	enabled, ok := boolEnv("PLATFORM_DEV_LOGIN_ENABLED")
+	if !ok || !enabled {
+		return nil
+	}
+	seeds := []struct {
+		label           string
+		role            string
+		emailEnv        string
+		passwordEnv     string
+		defaultEmail    string
+		defaultPassword string
+	}{
+		{
+			label:           "test",
+			role:            roleUser,
+			emailEnv:        "PLATFORM_DEV_USER_EMAIL",
+			passwordEnv:     "PLATFORM_DEV_USER_PASSWORD",
+			defaultEmail:    defaultDevUserEmail,
+			defaultPassword: defaultDevUserPassword,
+		},
+		{
+			label:           "admin",
+			role:            roleAdmin,
+			emailEnv:        "PLATFORM_DEV_ADMIN_EMAIL",
+			passwordEnv:     "PLATFORM_DEV_ADMIN_PASSWORD",
+			defaultEmail:    defaultDevAdminEmail,
+			defaultPassword: defaultDevAdminPassword,
+		},
+	}
+	for _, seed := range seeds {
+		email := strings.ToLower(strings.TrimSpace(envOr(seed.emailEnv, seed.defaultEmail)))
+		password := strings.TrimSpace(envOr(seed.passwordEnv, seed.defaultPassword))
+		if email == "" || password == "" {
+			return fmt.Errorf("%s dev login requires both email and password", seed.label)
+		}
+		u, err := store.EnsurePasswordUser(ctx, email, password, seed.role)
+		if err != nil {
+			return fmt.Errorf("ensure %s dev login: %w", seed.label, err)
+		}
+		log.Printf("platform dev %s login ensured email=%q namespace=%q", seed.label, u.Email, u.Namespace)
+	}
 	return nil
 }
 

--- a/services/api/platform_auth_test.go
+++ b/services/api/platform_auth_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakePasswordUserEnsurer struct {
+	calls []ensurePasswordUserCall
+	err   error
+}
+
+type ensurePasswordUserCall struct {
+	email    string
+	password string
+	role     string
+}
+
+func (f *fakePasswordUserEnsurer) EnsurePasswordUser(_ context.Context, email, password string, role string) (platformUser, error) {
+	f.calls = append(f.calls, ensurePasswordUserCall{email: email, password: password, role: role})
+	if f.err != nil {
+		return platformUser{}, f.err
+	}
+	return platformUser{Email: email, Role: role, Namespace: "user-test"}, nil
+}
+
+func TestSeedPlatformDevUsersFromEnvDisabledByDefault(t *testing.T) {
+	store := &fakePasswordUserEnsurer{}
+
+	if err := seedPlatformDevUsersFromEnv(context.Background(), store); err != nil {
+		t.Fatalf("seedPlatformDevUsersFromEnv() error = %v", err)
+	}
+	if len(store.calls) != 0 {
+		t.Fatalf("expected no dev users when disabled, got %#v", store.calls)
+	}
+}
+
+func TestSeedPlatformDevUsersFromEnvSeedsDefaultAccounts(t *testing.T) {
+	t.Setenv("PLATFORM_DEV_LOGIN_ENABLED", "true")
+	store := &fakePasswordUserEnsurer{}
+
+	if err := seedPlatformDevUsersFromEnv(context.Background(), store); err != nil {
+		t.Fatalf("seedPlatformDevUsersFromEnv() error = %v", err)
+	}
+	want := []ensurePasswordUserCall{
+		{email: defaultDevUserEmail, password: defaultDevUserPassword, role: roleUser},
+		{email: defaultDevAdminEmail, password: defaultDevAdminPassword, role: roleAdmin},
+	}
+	if len(store.calls) != len(want) {
+		t.Fatalf("seed calls = %#v, want %#v", store.calls, want)
+	}
+	for i := range want {
+		if store.calls[i] != want[i] {
+			t.Fatalf("seed call %d = %#v, want %#v", i, store.calls[i], want[i])
+		}
+	}
+}
+
+func TestSeedPlatformDevUsersFromEnvPropagatesEnsureErrors(t *testing.T) {
+	t.Setenv("PLATFORM_DEV_LOGIN_ENABLED", "true")
+	store := &fakePasswordUserEnsurer{err: errors.New("boom")}
+
+	err := seedPlatformDevUsersFromEnv(context.Background(), store)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("expected seeding to stop at first failure, got calls %#v", store.calls)
+	}
+}

--- a/services/api/platform_store.go
+++ b/services/api/platform_store.go
@@ -50,6 +50,20 @@ type auditEvent struct {
 	RequestID string
 }
 
+type platformAuditLog struct {
+	ID        int64     `json:"id"`
+	UserID    string    `json:"user_id,omitempty"`
+	Email     string    `json:"email,omitempty"`
+	Action    string    `json:"action"`
+	Resource  string    `json:"resource"`
+	Namespace string    `json:"namespace,omitempty"`
+	Status    string    `json:"status"`
+	Message   string    `json:"message,omitempty"`
+	ActorIP   string    `json:"actor_ip,omitempty"`
+	RequestID string    `json:"request_id,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 func newPlatformStore(ctx context.Context, dsn string, jwtSecret []byte) (*platformStore, error) {
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
@@ -592,6 +606,43 @@ func (s *platformStore) ListNamespaces(ctx context.Context) ([]map[string]any, e
 			return nil, err
 		}
 		out = append(out, map[string]any{"id": id, "user_id": userID, "email": email, "namespace": namespace, "created_at": createdAt})
+	}
+	return out, rows.Err()
+}
+
+func (s *platformStore) ListAuditLogs(ctx context.Context, limit int) ([]platformAuditLog, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT a.id, COALESCE(a.user_id::text, ''), COALESCE(u.email, ''), a.action, a.resource,
+       COALESCE(a.namespace, ''), a.status, COALESCE(a.message, ''),
+       COALESCE(a.actor_ip, ''), COALESCE(a.request_id, ''), a.created_at
+FROM audit_logs a
+LEFT JOIN users u ON u.id = a.user_id
+ORDER BY a.created_at DESC, a.id DESC
+LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]platformAuditLog, 0, limit)
+	for rows.Next() {
+		var item platformAuditLog
+		if err := rows.Scan(
+			&item.ID,
+			&item.UserID,
+			&item.Email,
+			&item.Action,
+			&item.Resource,
+			&item.Namespace,
+			&item.Status,
+			&item.Message,
+			&item.ActorIP,
+			&item.RequestID,
+			&item.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
 	}
 	return out, rows.Err()
 }

--- a/services/api/runtime.go
+++ b/services/api/runtime.go
@@ -588,8 +588,7 @@ func (s *RuntimeServer) handleRuntimeComponents(w http.ResponseWriter, r *http.R
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	// Only return core components for the dashboard
-	statuses, err := s.sentinelMgr.GetCoreComponentStatuses(ctx)
+	statuses, err := s.sentinelMgr.GetAllComponentStatuses(ctx)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get component statuses"})
 		return

--- a/services/api/runtime.go
+++ b/services/api/runtime.go
@@ -186,7 +186,7 @@ func (s *RuntimeServer) handleRuntimeServers(w http.ResponseWriter, r *http.Requ
 				log.Printf("runtime servers: convert MCPServer %s/%s: %v", obj.GetNamespace(), obj.GetName(), convertErr)
 				continue
 			}
-			servers = append(servers, serverInfoFromMCPServer(mcpServer, deploymentStatus[mcpServer.Name]))
+			servers = append(servers, serverInfoFromMCPServer(mcpServer, deploymentStatus[mcpServer.Name], r))
 		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{"servers": servers})
 		return
@@ -257,7 +257,7 @@ func statusForDeployment(d appsv1.Deployment) serverDeploymentStatus {
 	return serverDeploymentStatus{Ready: ready, Status: status}
 }
 
-func serverInfoFromMCPServer(mcpServer mcpv1alpha1.MCPServer, deploymentStatus serverDeploymentStatus) serverInfo {
+func serverInfoFromMCPServer(mcpServer mcpv1alpha1.MCPServer, deploymentStatus serverDeploymentStatus, r *http.Request) serverInfo {
 	if deploymentStatus.Ready == "" {
 		deploymentStatus = serverDeploymentStatus{Ready: "0/0", Status: strings.TrimSpace(mcpServer.Status.Phase)}
 		if deploymentStatus.Status == "" {
@@ -265,6 +265,7 @@ func serverInfoFromMCPServer(mcpServer mcpv1alpha1.MCPServer, deploymentStatus s
 		}
 	}
 	endpoint := publicMCPEndpoint(mcpServer)
+	connectEndpoint := publicMCPConnectEndpoint(endpoint, r)
 	info := serverInfo{
 		Name:      mcpServer.Name,
 		Namespace: mcpServer.Namespace,
@@ -278,12 +279,12 @@ func serverInfoFromMCPServer(mcpServer mcpv1alpha1.MCPServer, deploymentStatus s
 		Resources: inventoryItemsOrEmpty(mcpServer.Spec.MCPResources),
 		Tasks:     inventoryItemsOrEmpty(mcpServer.Spec.Tasks),
 	}
-	if endpoint != "" {
+	if connectEndpoint != "" {
 		info.AccessJSON = map[string]any{
 			"mcpServers": map[string]any{
 				mcpServer.Name: map[string]any{
 					"type": "http",
-					"url":  endpoint,
+					"url":  connectEndpoint,
 				},
 			},
 		}
@@ -327,6 +328,50 @@ func publicMCPEndpoint(mcpServer mcpv1alpha1.MCPServer) string {
 		scheme = "http"
 	}
 	return scheme + "://" + strings.TrimRight(host, "/") + path
+}
+
+func publicMCPConnectEndpoint(endpoint string, r *http.Request) string {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" || strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		return endpoint
+	}
+	path := endpoint
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	host := forwardedHost(r)
+	if host == "" {
+		return path
+	}
+	if strings.HasPrefix(strings.ToLower(host), "platform.") {
+		host = "mcp." + host[len("platform."):]
+	}
+	return forwardedScheme(r) + "://" + strings.TrimRight(host, "/") + path
+}
+
+func forwardedHost(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	return firstForwardedValue(r.Header.Get("X-Forwarded-Host"))
+}
+
+func forwardedScheme(r *http.Request) string {
+	if r == nil {
+		return "http"
+	}
+	proto := strings.ToLower(firstForwardedValue(r.Header.Get("X-Forwarded-Proto")))
+	if proto == "https" {
+		return "https"
+	}
+	return "http"
+}
+
+func firstForwardedValue(value string) string {
+	if idx := strings.IndexByte(value, ','); idx >= 0 {
+		value = value[:idx]
+	}
+	return strings.TrimSpace(value)
 }
 
 // handleRuntimeGrants returns MCPAccessGrant resources.

--- a/services/api/runtime_test.go
+++ b/services/api/runtime_test.go
@@ -217,6 +217,70 @@ func TestRuntimeServersIncludesMCPServerInventory(t *testing.T) {
 	}
 }
 
+func TestPublicMCPEndpointHonorsPlatformDomain(t *testing.T) {
+	t.Setenv("MCP_MCP_INGRESS_HOST", "")
+	t.Setenv("MCP_PLATFORM_DOMAIN", "example.com")
+
+	mcpServer := mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-one", Namespace: "mcp-servers"},
+	}
+	endpoint := publicMCPEndpoint(mcpServer)
+	if endpoint != "https://mcp.example.com/demo-one/mcp" {
+		t.Fatalf("endpoint = %q, want platform domain MCP URL", endpoint)
+	}
+}
+
+func TestRuntimeServerAccessJSONUsesForwardedLocalOrigin(t *testing.T) {
+	t.Setenv("MCP_MCP_INGRESS_HOST", "")
+	t.Setenv("MCP_PLATFORM_DOMAIN", "")
+
+	mcpServer := mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-one", Namespace: "mcp-servers"},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/servers", nil)
+	request.Header.Set("X-Forwarded-Host", "localhost:18080")
+	request.Header.Set("X-Forwarded-Proto", "http")
+
+	got := serverInfoFromMCPServer(mcpServer, serverDeploymentStatus{}, request)
+	if got.Endpoint != "/demo-one/mcp" {
+		t.Fatalf("endpoint = %q, want local path", got.Endpoint)
+	}
+	if url := accessJSONServerURL(t, got, "demo-one"); url != "http://localhost:18080/demo-one/mcp" {
+		t.Fatalf("access_json url = %q, want local origin URL", url)
+	}
+}
+
+func TestRuntimeServerAccessJSONMapsForwardedPlatformOrigin(t *testing.T) {
+	t.Setenv("MCP_MCP_INGRESS_HOST", "")
+	t.Setenv("MCP_PLATFORM_DOMAIN", "")
+
+	mcpServer := mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-one", Namespace: "mcp-servers"},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/servers", nil)
+	request.Header.Set("X-Forwarded-Host", "platform.mcpruntime.org")
+	request.Header.Set("X-Forwarded-Proto", "https")
+
+	got := serverInfoFromMCPServer(mcpServer, serverDeploymentStatus{}, request)
+	if url := accessJSONServerURL(t, got, "demo-one"); url != "https://mcp.mcpruntime.org/demo-one/mcp" {
+		t.Fatalf("access_json url = %q, want production MCP URL", url)
+	}
+}
+
+func accessJSONServerURL(t *testing.T, info serverInfo, name string) string {
+	t.Helper()
+	rawServers, ok := info.AccessJSON["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("access_json.mcpServers = %#v", info.AccessJSON["mcpServers"])
+	}
+	rawServer, ok := rawServers[name].(map[string]any)
+	if !ok {
+		t.Fatalf("access_json.mcpServers.%s = %#v", name, rawServers[name])
+	}
+	url, _ := rawServer["url"].(string)
+	return url
+}
+
 func TestRuntimeServersNonAdminDefaultsToSharedNamespace(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {

--- a/services/ui/main.go
+++ b/services/ui/main.go
@@ -235,9 +235,26 @@ func newAPIProxyWithTransport(target *url.URL, upstreamAPIKey, apiKeys string, s
 	}
 	originalDirector := proxy.Director
 	proxy.Director = func(req *http.Request) {
+		forwardedHost := strings.TrimSpace(req.Header.Get("X-Forwarded-Host"))
+		if forwardedHost == "" {
+			forwardedHost = req.Host
+		}
+		forwardedProto := strings.TrimSpace(req.Header.Get("X-Forwarded-Proto"))
+		if forwardedProto == "" {
+			forwardedProto = "http"
+			if req.TLS != nil {
+				forwardedProto = "https"
+			}
+		}
 		originalDirector(req)
 		req.Host = target.Host
 		req.Header.Del("Cookie")
+		if forwardedHost != "" {
+			req.Header.Set("X-Forwarded-Host", forwardedHost)
+		}
+		if forwardedProto != "" {
+			req.Header.Set("X-Forwarded-Proto", forwardedProto)
+		}
 		if strings.TrimSpace(req.Header.Get("authorization")) == "" && strings.TrimSpace(req.Header.Get("x-api-key")) == "" {
 			req.Header.Set("x-api-key", upstreamAPIKey)
 		}

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -138,6 +138,12 @@ func TestAPIProxyAllowsPublicRuntimeServers(t *testing.T) {
 		if got := r.URL.Query().Get("namespace"); got != "mcp-servers" {
 			t.Fatalf("namespace = %q, want %q", got, "mcp-servers")
 		}
+		if got := r.Header.Get("X-Forwarded-Host"); got != "localhost:18080" {
+			t.Fatalf("X-Forwarded-Host = %q, want localhost:18080", got)
+		}
+		if got := r.Header.Get("X-Forwarded-Proto"); got != "http" {
+			t.Fatalf("X-Forwarded-Proto = %q, want http", got)
+		}
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"content-type": []string{"application/json"}},
@@ -151,7 +157,7 @@ func TestAPIProxyAllowsPublicRuntimeServers(t *testing.T) {
 	proxy := newAPIProxyWithTransport(target, "api-secret", "api-secret", newUISessionStore(time.Now), transport)
 
 	recorder := httptest.NewRecorder()
-	proxy.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/runtime/servers?namespace=user-private", nil))
+	proxy.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "http://localhost:18080/api/runtime/servers?namespace=user-private", nil))
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("public runtime servers status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
 	}

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -96,7 +96,11 @@ function initTabs() {
       activateTab(target);
 
       // Load data when switching to certain tabs
-      if (target === "governance") {
+      if (target === "dashboard") {
+        loadDashboardSummary();
+        loadDashboardAnalytics();
+        loadEvents();
+      } else if (target === "governance") {
         loadGrants();
         loadSessions();
       } else if (target === "operations") {
@@ -130,6 +134,135 @@ async function loadDashboardSummary() {
     if (isUnauthorizedError(err)) return;
     console.error("Failed to load dashboard summary:", err);
   }
+}
+
+async function loadDashboardAnalytics() {
+  try {
+    const limit = document.getElementById("analytics-limit")?.value || "10";
+    const data = await fetchJSON(`/analytics/usage?limit=${encodeURIComponent(limit)}`);
+    renderDashboardAnalytics(data);
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load dashboard analytics:", err);
+    renderAnalyticsError();
+  }
+}
+
+function renderDashboardAnalytics(data) {
+  const totals = data?.totals || {};
+  document.getElementById("analytics-allowed").textContent = formatNumber(totals.allowed || 0);
+  document.getElementById("analytics-denied").textContent = formatNumber(totals.denied || 0);
+  document.getElementById("analytics-humans").textContent = formatNumber(totals.unique_humans || 0);
+  document.getElementById("analytics-agents").textContent = formatNumber(totals.unique_agents || 0);
+
+  renderAnalyticsServers(data?.servers || []);
+  renderAnalyticsActors(data?.actors || []);
+  renderAnalyticsTools(data?.tools || []);
+  renderAnalyticsDecisions(data?.decisions || []);
+}
+
+function renderAnalyticsServers(rows) {
+  const tbody = document.getElementById("analytics-servers-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="7" class="empty">No usage yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createTextCell(item.server || "-"));
+    row.appendChild(createTextCell(item.namespace || "-"));
+    row.appendChild(createTextCell(formatNumber(item.events || 0)));
+    row.appendChild(createTextCell(formatNumber(item.allowed || 0)));
+    row.appendChild(createTextCell(formatNumber(item.denied || 0)));
+    row.appendChild(createTextCell(formatNumber(item.unique_humans || 0)));
+    row.appendChild(createTextCell(formatNumber(item.unique_agents || 0)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderAnalyticsActors(rows) {
+  const tbody = document.getElementById("analytics-actors-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="empty">No actors yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createTextCell(item.human_id || "-"));
+    row.appendChild(createTextCell(item.agent_id || "-"));
+    row.appendChild(createTextCell(formatNumber(item.events || 0)));
+    row.appendChild(createTextCell(formatNumber(item.unique_servers || 0)));
+    row.appendChild(createTextCell(formatNumber(item.unique_tools || 0)));
+    row.appendChild(createTextCell(formatNumber(item.denied || 0)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderAnalyticsTools(rows) {
+  const tbody = document.getElementById("analytics-tools-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No tool calls yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createTextCell(item.server || "-"));
+    row.appendChild(createTextCell(item.tool_name || "-"));
+    row.appendChild(createTextCell(formatNumber(item.events || 0)));
+    row.appendChild(createTextCell(formatNumber(item.denied || 0)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderAnalyticsDecisions(rows) {
+  const tbody = document.getElementById("analytics-decisions-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="2" class="empty">No decisions yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createBadgeCell(item.decision || "unknown", decisionBadgeClass(item.decision)));
+    row.appendChild(createTextCell(formatNumber(item.events || 0)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function decisionBadgeClass(decision) {
+  if (decision === "allow") return "badge-success";
+  if (decision === "deny") return "badge-error";
+  return "badge-muted";
+}
+
+function renderAnalyticsError() {
+  document.getElementById("analytics-allowed").textContent = "-";
+  document.getElementById("analytics-denied").textContent = "-";
+  document.getElementById("analytics-humans").textContent = "-";
+  document.getElementById("analytics-agents").textContent = "-";
+  document.getElementById("analytics-servers-body").innerHTML =
+    '<tr><td colspan="7" class="empty">Error loading usage.</td></tr>';
+  document.getElementById("analytics-actors-body").innerHTML =
+    '<tr><td colspan="6" class="empty">Error loading actors.</td></tr>';
+  document.getElementById("analytics-tools-body").innerHTML =
+    '<tr><td colspan="4" class="empty">Error loading tools.</td></tr>';
+  document.getElementById("analytics-decisions-body").innerHTML =
+    '<tr><td colspan="2" class="empty">Error loading decisions.</td></tr>';
 }
 
 function formatNumber(num) {
@@ -283,6 +416,14 @@ async function handleAuthSubmit(event) {
   const password = passwordInput?.value || "";
 
   setAuthError("");
+  if ((email && !password) || (!email && password)) {
+    setAuthError("Enter both email and password, or use an API key.");
+    return;
+  }
+  if (!email && !password && !apiKey) {
+    setAuthError("Provide email and password, an API key, or sign in with Google.");
+    return;
+  }
   if (submit) submit.disabled = true;
   try {
     const payload =
@@ -441,6 +582,7 @@ function loadActiveTab() {
   const active = resolveActiveTab();
   if (active === "dashboard") {
     loadDashboardSummary();
+    loadDashboardAnalytics();
     loadEvents();
   } else if (active === "servers") {
     loadServers();
@@ -459,6 +601,18 @@ function resetDashboard() {
   document.getElementById("dash-active-servers").textContent = "-";
   document.getElementById("dash-active-grants").textContent = "-";
   document.getElementById("dash-active-sessions").textContent = "-";
+  document.getElementById("analytics-allowed").textContent = "-";
+  document.getElementById("analytics-denied").textContent = "-";
+  document.getElementById("analytics-humans").textContent = "-";
+  document.getElementById("analytics-agents").textContent = "-";
+  document.getElementById("analytics-servers-body").innerHTML =
+    '<tr><td colspan="7" class="empty">No usage yet.</td></tr>';
+  document.getElementById("analytics-actors-body").innerHTML =
+    '<tr><td colspan="6" class="empty">No actors yet.</td></tr>';
+  document.getElementById("analytics-tools-body").innerHTML =
+    '<tr><td colspan="4" class="empty">No tool calls yet.</td></tr>';
+  document.getElementById("analytics-decisions-body").innerHTML =
+    '<tr><td colspan="2" class="empty">No decisions yet.</td></tr>';
   document.getElementById("events-body").innerHTML =
     '<tr><td colspan="5" class="empty">No events yet.</td></tr>';
 }
@@ -584,6 +738,12 @@ function initDashboard() {
   document.getElementById("refresh-events")?.addEventListener("click", () => {
     loadEvents();
   });
+  document.getElementById("refresh-analytics")?.addEventListener("click", () => {
+    loadDashboardAnalytics();
+  });
+  document.getElementById("analytics-limit")?.addEventListener("change", () => {
+    loadDashboardAnalytics();
+  });
   document.getElementById("refresh-servers")?.addEventListener("click", () => {
     loadServers();
   });
@@ -597,6 +757,7 @@ function startAutoRefresh() {
   if (autoRefreshCheckbox && !autoRefreshCheckbox.checked) return;
   autoRefreshInterval = setInterval(() => {
     loadDashboardSummary();
+    loadDashboardAnalytics();
     loadEvents();
   }, 5000);
 }

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -180,15 +180,32 @@ async function loadDashboardAnalytics() {
 
 function renderDashboardAnalytics(data) {
   const totals = data?.totals || {};
-  document.getElementById("analytics-allowed").textContent = formatNumber(totals.allowed || 0);
-  document.getElementById("analytics-denied").textContent = formatNumber(totals.denied || 0);
-  document.getElementById("analytics-humans").textContent = formatNumber(totals.unique_humans || 0);
-  document.getElementById("analytics-agents").textContent = formatNumber(totals.unique_agents || 0);
+  const events = Number(totals.events || 0);
+  const allowed = Number(totals.allowed || 0);
+  const denied = Number(totals.denied || 0);
+  setText("analytics-total-events", formatNumber(events));
+  setText("analytics-allowed", formatNumber(allowed));
+  setText("analytics-denied", formatNumber(denied));
+  setText("analytics-humans", formatNumber(totals.unique_humans || 0));
+  setText("analytics-agents", formatNumber(totals.unique_agents || 0));
+  renderDecisionMeter(events, allowed, denied);
 
   renderAnalyticsServers(data?.servers || []);
   renderAnalyticsActors(data?.actors || []);
   renderAnalyticsTools(data?.tools || []);
   renderAnalyticsDecisions(data?.decisions || []);
+}
+
+function renderDecisionMeter(events, allowed, denied) {
+  const total = Math.max(Number(events || 0), allowed + denied);
+  const allowRate = total > 0 ? Math.round((allowed / total) * 100) : 0;
+  const denyRate = total > 0 ? Math.round((denied / total) * 100) : 0;
+  const allowEl = document.getElementById("decision-meter-allow");
+  const denyEl = document.getElementById("decision-meter-deny");
+  if (allowEl) allowEl.style.width = `${allowRate}%`;
+  if (denyEl) denyEl.style.width = `${denyRate}%`;
+  setText("analytics-allow-rate", total > 0 ? `${allowRate}% allow` : "-");
+  setText("analytics-deny-rate", total > 0 ? `${denyRate}%` : "-");
 }
 
 function renderAnalyticsServers(rows) {
@@ -281,10 +298,12 @@ function decisionBadgeClass(decision) {
 }
 
 function renderAnalyticsError() {
-  document.getElementById("analytics-allowed").textContent = "-";
-  document.getElementById("analytics-denied").textContent = "-";
-  document.getElementById("analytics-humans").textContent = "-";
-  document.getElementById("analytics-agents").textContent = "-";
+  setText("analytics-total-events", "-");
+  setText("analytics-allowed", "-");
+  setText("analytics-denied", "-");
+  setText("analytics-humans", "-");
+  setText("analytics-agents", "-");
+  renderDecisionMeter(0, 0, 0);
   document.getElementById("analytics-servers-body").innerHTML =
     '<tr><td colspan="7" class="empty">Error loading usage.</td></tr>';
   document.getElementById("analytics-actors-body").innerHTML =
@@ -363,6 +382,11 @@ function escapeHtml(text) {
   return div.innerHTML;
 }
 
+function setText(id, text) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = text;
+}
+
 function encodePathSegment(value) {
   return encodeURIComponent(String(value));
 }
@@ -386,13 +410,84 @@ function createTextCell(text) {
   return cell;
 }
 
-function createBadgeCell(text, className) {
-  const cell = document.createElement("td");
+function createBadge(text, className) {
   const badge = document.createElement("span");
   badge.className = `badge ${className}`;
   badge.textContent = text;
-  cell.appendChild(badge);
+  return badge;
+}
+
+function createBadgeCell(text, className) {
+  const cell = document.createElement("td");
+  cell.appendChild(createBadge(text, className));
   return cell;
+}
+
+function createIdentityCell(primary, secondary = "") {
+  const cell = document.createElement("td");
+  const stack = document.createElement("div");
+  stack.className = "identity-stack";
+
+  const primaryEl = document.createElement("strong");
+  primaryEl.className = "identity-primary";
+  primaryEl.textContent = primary || "-";
+  stack.appendChild(primaryEl);
+
+  if (secondary) {
+    const secondaryEl = document.createElement("span");
+    secondaryEl.className = "identity-secondary";
+    secondaryEl.textContent = secondary;
+    stack.appendChild(secondaryEl);
+  }
+
+  cell.appendChild(stack);
+  return cell;
+}
+
+function createSubjectCell(subject = {}) {
+  const cell = document.createElement("td");
+  const chips = document.createElement("div");
+  chips.className = "subject-chip-list";
+
+  if (subject.humanID) {
+    chips.appendChild(createSubjectChip("Human", subject.humanID));
+  }
+  if (subject.agentID) {
+    chips.appendChild(createSubjectChip("Agent", subject.agentID));
+  }
+  if (!chips.children.length) {
+    chips.textContent = "-";
+  }
+
+  cell.appendChild(chips);
+  return cell;
+}
+
+function createSubjectChip(label, value) {
+  const chip = document.createElement("span");
+  chip.className = "subject-chip";
+
+  const labelEl = document.createElement("span");
+  labelEl.className = "subject-chip-label";
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement("strong");
+  valueEl.textContent = value;
+
+  chip.append(labelEl, valueEl);
+  return chip;
+}
+
+function createTrustCell(trust) {
+  const value = trust || "-";
+  return createBadgeCell(value, trustBadgeClass(value));
+}
+
+function trustBadgeClass(trust) {
+  if (trust === "high") return "badge-trust-high";
+  if (trust === "medium") return "badge-trust-medium";
+  if (trust === "low") return "badge-trust-low";
+  return "badge-muted";
 }
 
 function createActionCell(label, onClick) {
@@ -568,6 +663,7 @@ async function logout() {
   authPrincipal = null;
   setAuthenticated(false);
   resetDashboard();
+  resetGovernance();
   resetUserAPIKeys();
   activateTab("servers");
   loadServers();
@@ -627,14 +723,16 @@ function loadActiveTab() {
 }
 
 function resetDashboard() {
-  document.getElementById("dash-total-events").textContent = "-";
-  document.getElementById("dash-active-servers").textContent = "-";
-  document.getElementById("dash-active-grants").textContent = "-";
-  document.getElementById("dash-active-sessions").textContent = "-";
-  document.getElementById("analytics-allowed").textContent = "-";
-  document.getElementById("analytics-denied").textContent = "-";
-  document.getElementById("analytics-humans").textContent = "-";
-  document.getElementById("analytics-agents").textContent = "-";
+  setText("dash-total-events", "-");
+  setText("dash-active-servers", "-");
+  setText("dash-active-grants", "-");
+  setText("dash-active-sessions", "-");
+  setText("analytics-total-events", "-");
+  setText("analytics-allowed", "-");
+  setText("analytics-denied", "-");
+  setText("analytics-humans", "-");
+  setText("analytics-agents", "-");
+  renderDecisionMeter(0, 0, 0);
   document.getElementById("analytics-servers-body").innerHTML =
     '<tr><td colspan="7" class="empty">No usage yet.</td></tr>';
   document.getElementById("analytics-actors-body").innerHTML =
@@ -645,6 +743,20 @@ function resetDashboard() {
     '<tr><td colspan="2" class="empty">No decisions yet.</td></tr>';
   document.getElementById("events-body").innerHTML =
     '<tr><td colspan="5" class="empty">No events yet.</td></tr>';
+}
+
+function resetGovernance() {
+  grantsCache = [];
+  sessionsCache = [];
+  renderGovernanceSummary();
+  const grantsBody = document.getElementById("grants-body");
+  const sessionsBody = document.getElementById("sessions-body");
+  if (grantsBody) {
+    grantsBody.innerHTML = '<tr><td colspan="6" class="empty">No grants found.</td></tr>';
+  }
+  if (sessionsBody) {
+    sessionsBody.innerHTML = '<tr><td colspan="6" class="empty">No sessions found.</td></tr>';
+  }
 }
 
 async function loadServers() {
@@ -1017,14 +1129,28 @@ async function loadGrants() {
   try {
     const data = await fetchJSON("/runtime/grants");
     grantsCache = Array.isArray(data.grants) ? data.grants : [];
+    renderGovernanceSummary();
     renderGrants();
   } catch (err) {
     if (isUnauthorizedError(err)) return;
     console.error("Failed to load grants:", err);
     grantsCache = [];
+    renderGovernanceSummary();
     document.getElementById("grants-body").innerHTML =
       '<tr><td colspan="6" class="empty">Error loading grants.</td></tr>';
   }
+}
+
+function renderGovernanceSummary() {
+  const activeGrants = grantsCache.filter((grant) => !grant.disabled).length;
+  const disabledGrants = grantsCache.length - activeGrants;
+  const activeSessions = sessionsCache.filter((session) => !session.revoked).length;
+  const revokedSessions = sessionsCache.length - activeSessions;
+
+  setText("gov-active-grants", formatNumber(activeGrants));
+  setText("gov-disabled-grants", formatNumber(disabledGrants));
+  setText("gov-active-sessions", formatNumber(activeSessions));
+  setText("gov-revoked-sessions", formatNumber(revokedSessions));
 }
 
 function renderGrants() {
@@ -1054,15 +1180,16 @@ function renderGrants() {
   const fragment = document.createDocumentFragment();
 
   filtered.forEach((grant) => {
-    const subject = grant.subject?.humanID || grant.subject?.agentID || "-";
     const status = grant.disabled ? "Disabled" : "Active";
     const statusClass = grant.disabled ? "badge-muted" : "badge-success";
+    const namespace = grant.namespace || defaults.namespace;
+    const serverNamespace = grant.serverRef?.namespace || namespace;
 
     const row = document.createElement("tr");
-    row.appendChild(createTextCell(grant.name || "-"));
-    row.appendChild(createTextCell(grant.serverRef?.name || "-"));
-    row.appendChild(createTextCell(subject));
-    row.appendChild(createTextCell(grant.maxTrust || "-"));
+    row.appendChild(createIdentityCell(grant.name || "-", namespace));
+    row.appendChild(createIdentityCell(grant.serverRef?.name || "-", serverNamespace));
+    row.appendChild(createSubjectCell(grant.subject));
+    row.appendChild(createTrustCell(grant.maxTrust));
     row.appendChild(createBadgeCell(status, statusClass));
     row.appendChild(
       createActionCell(grant.disabled ? "Enable" : "Disable", () =>
@@ -1092,6 +1219,7 @@ async function toggleGrant(namespace, name, currentlyDisabled) {
     );
     showToast(`Grant ${action}d successfully`);
     loadGrants();
+    loadDashboardSummary();
   } catch (err) {
     if (isUnauthorizedError(err)) return;
     showToast(`Failed to ${action} grant: ${err.message}`, "error");
@@ -1192,11 +1320,13 @@ async function loadSessions() {
   try {
     const data = await fetchJSON("/runtime/sessions");
     sessionsCache = Array.isArray(data.sessions) ? data.sessions : [];
+    renderGovernanceSummary();
     renderSessions();
   } catch (err) {
     if (isUnauthorizedError(err)) return;
     console.error("Failed to load sessions:", err);
     sessionsCache = [];
+    renderGovernanceSummary();
     document.getElementById("sessions-body").innerHTML =
       '<tr><td colspan="6" class="empty">Error loading sessions.</td></tr>';
   }
@@ -1229,16 +1359,16 @@ function renderSessions() {
   const fragment = document.createDocumentFragment();
 
   filtered.forEach((session) => {
-    const subject =
-      session.subject?.humanID || session.subject?.agentID || "-";
     const status = session.revoked ? "Revoked" : "Active";
     const statusClass = session.revoked ? "badge-error" : "badge-success";
+    const namespace = session.namespace || defaults.namespace;
+    const serverNamespace = session.serverRef?.namespace || namespace;
 
     const row = document.createElement("tr");
-    row.appendChild(createTextCell(session.name || "-"));
-    row.appendChild(createTextCell(session.serverRef?.name || "-"));
-    row.appendChild(createTextCell(subject));
-    row.appendChild(createTextCell(session.consentedTrust || "-"));
+    row.appendChild(createIdentityCell(session.name || "-", namespace));
+    row.appendChild(createIdentityCell(session.serverRef?.name || "-", serverNamespace));
+    row.appendChild(createSubjectCell(session.subject));
+    row.appendChild(createTrustCell(session.consentedTrust));
     row.appendChild(createBadgeCell(status, statusClass));
     row.appendChild(
       createActionCell(session.revoked ? "Unrevoke" : "Revoke", () =>
@@ -1272,6 +1402,7 @@ async function toggleSession(namespace, name, currentlyRevoked) {
     );
     showToast(`Session ${action}d successfully`);
     loadSessions();
+    loadDashboardSummary();
   } catch (err) {
     if (isUnauthorizedError(err)) return;
     showToast(`Failed to ${action} session: ${err.message}`, "error");

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -583,23 +583,25 @@ async function handleAuthSubmit(event) {
   const emailInput = document.getElementById("auth-email-input");
   const passwordInput = document.getElementById("auth-password-input");
   const submit = document.getElementById("auth-submit");
-  const apiKey = apiKeyInput?.value || "";
-  const email = emailInput?.value || "";
+  const apiKey = apiKeyInput?.value.trim() || "";
+  const email = emailInput?.value.trim() || "";
   const password = passwordInput?.value || "";
+  const hasAPIKey = apiKey !== "";
+  const hasEmail = email !== "";
+  const hasPassword = password !== "";
 
   setAuthError("");
-  if ((email && !password) || (!email && password)) {
+  if (!hasAPIKey && ((hasEmail && !hasPassword) || (!hasEmail && hasPassword))) {
     setAuthError("Enter both email and password, or use an API key.");
     return;
   }
-  if (!email && !password && !apiKey) {
+  if (!hasAPIKey && !hasEmail && !hasPassword) {
     setAuthError("Provide email and password, an API key, or sign in with Google.");
     return;
   }
   if (submit) submit.disabled = true;
   try {
-    const payload =
-      email || password ? { email, password } : { api_key: apiKey };
+    const payload = hasAPIKey ? { api_key: apiKey } : { email, password };
     const data = await performLogin(payload);
     authPrincipal = data?.principal || null;
     if (apiKeyInput) apiKeyInput.value = "";

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -772,6 +772,9 @@ function renderServerHero(server) {
 }
 
 function renderServerMeta(server) {
+  const wrap = document.createElement("div");
+  wrap.className = "server-meta-wrap";
+
   const meta = document.createElement("div");
   meta.className = "server-meta-row";
   meta.appendChild(serverMetaPill("HTTP MCP"));
@@ -779,7 +782,31 @@ function renderServerMeta(server) {
   meta.appendChild(serverMetaPill(`${(server.prompts || []).length} prompts`));
   meta.appendChild(serverMetaPill(`${(server.resources || []).length} resources`));
   meta.appendChild(serverMetaPill(`Created ${formatServerAge(server.age)}`));
-  return meta;
+  wrap.appendChild(meta);
+
+  const actions = document.createElement("div");
+  actions.className = "server-card-actions";
+  if (server.endpoint) {
+    const copyURL = document.createElement("button");
+    copyURL.className = "ghost server-action";
+    copyURL.type = "button";
+    copyURL.textContent = "Copy URL";
+    copyURL.addEventListener("click", () => copyTextToClipboard(server.endpoint, "Endpoint copied"));
+    actions.appendChild(copyURL);
+  }
+  if (server.access_json && Object.keys(server.access_json).length) {
+    const jsonText = JSON.stringify(server.access_json || {}, null, 2);
+    const copyJSON = document.createElement("button");
+    copyJSON.className = "ghost server-action";
+    copyJSON.type = "button";
+    copyJSON.textContent = "Copy JSON";
+    copyJSON.addEventListener("click", () => copyTextToClipboard(jsonText, "Connect JSON copied"));
+    actions.appendChild(copyJSON);
+  }
+  if (actions.children.length) {
+    wrap.appendChild(actions);
+  }
+  return wrap;
 }
 
 function serverMetaPill(text) {
@@ -797,15 +824,6 @@ function renderServerEndpoint(server) {
   endpoint.textContent = server.endpoint || "No public endpoint";
   row.appendChild(endpoint);
 
-  if (server.endpoint) {
-    const copy = document.createElement("button");
-    copy.className = "ghost server-action";
-    copy.type = "button";
-    copy.textContent = "Copy URL";
-    copy.addEventListener("click", () => copyTextToClipboard(server.endpoint, "Endpoint copied"));
-    row.appendChild(copy);
-  }
-
   return row;
 }
 
@@ -822,12 +840,7 @@ function renderServerConnectConfig(server) {
   json.className = "access-json";
   const jsonText = JSON.stringify(server.access_json || {}, null, 2);
   json.textContent = jsonText;
-  const copy = document.createElement("button");
-  copy.className = "ghost server-action";
-  copy.type = "button";
-  copy.textContent = "Copy JSON";
-  copy.addEventListener("click", () => copyTextToClipboard(jsonText, "Connect JSON copied"));
-  body.append(json, copy);
+  body.appendChild(json);
   details.appendChild(body);
   return details;
 }
@@ -932,9 +945,14 @@ function initDashboard() {
     serverSearchQuery = event.target.value || "";
     renderServers();
   });
-  document.getElementById("server-status-filter")?.addEventListener("change", (event) => {
-    serverStatusFilter = event.target.value || "all";
-    renderServers();
+  document.querySelectorAll("[data-server-status]").forEach((button) => {
+    button.addEventListener("click", () => {
+      serverStatusFilter = button.dataset.serverStatus || "all";
+      document.querySelectorAll("[data-server-status]").forEach((node) => {
+        node.classList.toggle("active", node === button);
+      });
+      renderServers();
+    });
   });
 }
 

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -1240,7 +1240,7 @@ function renderGrants() {
     row.appendChild(createBadgeCell(status, statusClass));
     row.appendChild(
       createActionCell(grant.disabled ? "Enable" : "Disable", () =>
-        toggleGrant(grant.namespace || "", grant.name || "", grant.disabled)
+        toggleGrant(namespace, grant.name || "", grant.disabled)
       )
     );
     fragment.appendChild(row);
@@ -1419,11 +1419,7 @@ function renderSessions() {
     row.appendChild(createBadgeCell(status, statusClass));
     row.appendChild(
       createActionCell(session.revoked ? "Unrevoke" : "Revoke", () =>
-        toggleSession(
-          session.namespace || "",
-          session.name || "",
-          session.revoked
-        )
+        toggleSession(namespace, session.name || "", session.revoked)
       )
     );
     fragment.appendChild(row);

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -9,9 +9,13 @@ let grantsCache = [];
 let sessionsCache = [];
 let userAPIKeysCache = [];
 let serversCache = [];
+let operationsServersCache = [];
+let operationsEventsCache = [];
+let operationsAuditCache = [];
 let userAPIKeyClearTimer = null;
 let serverSearchQuery = "";
 let serverStatusFilter = "all";
+let selectedOperationsServerKey = "";
 
 // API Helper
 async function fetchJSON(path, options = {}) {
@@ -134,7 +138,9 @@ function initTabs() {
         loadGrants();
         loadSessions();
       } else if (target === "operations") {
-        loadComponents();
+        loadMCPOperations();
+      } else if (target === "platform") {
+        loadPlatformManagement();
       } else if (target === "userkeys") {
         loadUserAPIKeys();
       } else if (target === "servers") {
@@ -765,7 +771,9 @@ function loadActiveTab() {
     loadGrants();
     loadSessions();
   } else if (active === "operations") {
-    loadComponents();
+    loadMCPOperations();
+  } else if (active === "platform") {
+    loadPlatformManagement();
   } else if (active === "userkeys") {
     loadUserAPIKeys();
   }
@@ -1709,9 +1717,364 @@ function initUserAPIKeys() {
   document.getElementById("create-user-api-key")?.addEventListener("click", createUserAPIKey);
 }
 
-// Operations - Components
+// Operations - MCP runtime
+async function loadMCPOperations() {
+  setOperationLoadingState();
+  await Promise.allSettled([
+    loadOperationServers(),
+    loadOperationEvents(),
+    loadOperationAudit(),
+  ]);
+}
+
+function setOperationLoadingState() {
+  const serversBody = document.getElementById("ops-server-health-body");
+  const activityBody = document.getElementById("ops-activity-body");
+  const usersBody = document.getElementById("ops-user-activity-body");
+  if (serversBody) {
+    serversBody.innerHTML = '<tr><td colspan="6" class="empty">Loading MCP servers...</td></tr>';
+  }
+  if (activityBody) {
+    activityBody.innerHTML = '<tr><td colspan="4" class="empty">Loading MCP activity...</td></tr>';
+  }
+  if (usersBody) {
+    usersBody.innerHTML = '<tr><td colspan="4" class="empty">Loading user activity...</td></tr>';
+  }
+}
+
+async function loadOperationServers() {
+  try {
+    const data = await fetchJSON("/runtime/servers");
+    operationsServersCache = Array.isArray(data.servers) ? data.servers : [];
+    const selectedStillExists = operationsServersCache.some(
+      (server) => operationServerKey(server) === selectedOperationsServerKey
+    );
+    if (!selectedStillExists) {
+      selectedOperationsServerKey = operationsServersCache.length
+        ? operationServerKey(operationsServersCache[0])
+        : "";
+    }
+    renderOperationsSummary();
+    renderOperationServers();
+    renderOperationServerSelect();
+    renderSelectedOperationServer();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load operation servers:", err);
+    operationsServersCache = [];
+    renderOperationsSummary();
+    const tbody = document.getElementById("ops-server-health-body");
+    if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="6" class="empty">Error loading MCP servers.</td></tr>';
+    }
+    renderOperationServerSelect();
+    renderSelectedOperationServer();
+  }
+}
+
+async function loadOperationEvents() {
+  try {
+    const data = await fetchJSON("/events?limit=20");
+    operationsEventsCache = Array.isArray(data.events) ? data.events : [];
+    renderOperationsSummary();
+    renderOperationEvents();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load operation events:", err);
+    operationsEventsCache = [];
+    renderOperationsSummary();
+    const tbody = document.getElementById("ops-activity-body");
+    if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="4" class="empty">Error loading MCP activity.</td></tr>';
+    }
+  }
+}
+
+async function loadOperationAudit() {
+  try {
+    const data = await fetchJSON("/admin/audit?limit=20");
+    operationsAuditCache = Array.isArray(data.audit_logs) ? data.audit_logs : [];
+    renderOperationsSummary();
+    renderUserActivity();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load user activity:", err);
+    operationsAuditCache = [];
+    renderOperationsSummary();
+    const tbody = document.getElementById("ops-user-activity-body");
+    if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="4" class="empty">Platform audit is unavailable.</td></tr>';
+    }
+  }
+}
+
+function renderOperationsSummary() {
+  const total = operationsServersCache.length;
+  const ready = operationsServersCache.filter((server) => server.status === "Ready").length;
+  const loginCount = operationsAuditCache.filter((item) => {
+    const action = String(item.action || "");
+    return action.includes("login") && item.status === "success";
+  }).length;
+  setText("ops-mcp-total", formatNumber(total));
+  setText("ops-mcp-ready", formatNumber(ready));
+  setText("ops-mcp-issues", formatNumber(Math.max(total - ready, 0)));
+  setText("ops-login-count", formatNumber(loginCount));
+  setText("ops-mcp-events", formatNumber(operationsEventsCache.length));
+}
+
+function renderOperationServers() {
+  const tbody = document.getElementById("ops-server-health-body");
+  if (!tbody) return;
+  if (!operationsServersCache.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="empty">No MCP servers found.</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  operationsServersCache.forEach((server) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(server.name || "-", server.namespace || "-"));
+    row.appendChild(createBadgeCell(server.status || "Unknown", serverBadgeClass(server.status)));
+    row.appendChild(createTextCell(server.ready || "0/0"));
+    row.appendChild(createTextCell(operationInventoryLabel(server)));
+    row.appendChild(createTextCell(formatDateTime(server.age)));
+    row.appendChild(createEndpointCell(server.endpoint));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderOperationServerSelect() {
+  const select = document.getElementById("ops-server-select");
+  if (!select) return;
+  select.innerHTML = '<option value="">Select server...</option>';
+  operationsServersCache.forEach((server) => {
+    const option = document.createElement("option");
+    option.value = operationServerKey(server);
+    option.textContent = `${server.namespace || "-"} / ${server.name || "-"}`;
+    select.appendChild(option);
+  });
+  select.value = selectedOperationsServerKey;
+}
+
+function renderSelectedOperationServer() {
+  const detail = document.getElementById("ops-server-detail");
+  if (!detail) return;
+  const server = operationsServersCache.find(
+    (item) => operationServerKey(item) === selectedOperationsServerKey
+  );
+  if (!server) {
+    detail.innerHTML = '<div class="empty">Select a server to inspect deployment details.</div>';
+    return;
+  }
+
+  const labels = server.labels && typeof server.labels === "object"
+    ? Object.entries(server.labels)
+    : [];
+  detail.innerHTML = `
+    <div class="server-inspector-head">
+      <div class="server-identity">
+        <span class="server-avatar" aria-hidden="true">${escapeHtml(serverInitials(server.name))}</span>
+        <div class="server-title-stack">
+          <h3>${escapeHtml(server.name || "-")}</h3>
+          <p>${escapeHtml(server.namespace || "-")}</p>
+        </div>
+      </div>
+      <span class="badge ${serverBadgeClass(server.status)}">${escapeHtml(server.status || "Unknown")}</span>
+    </div>
+    <div class="server-detail-grid">
+      ${serverDetailStat("Ready Pods", server.ready || "0/0")}
+      ${serverDetailStat("Deployed", formatDateTime(server.age))}
+      ${serverDetailStat("Tools", String((server.tools || []).length))}
+      ${serverDetailStat("Prompts", String((server.prompts || []).length))}
+      ${serverDetailStat("Resources", String((server.resources || []).length))}
+      ${serverDetailStat("Tasks", String((server.tasks || []).length))}
+    </div>
+    <div class="server-detail-block">
+      <span class="server-detail-label">Endpoint</span>
+      <code class="server-endpoint">${escapeHtml(server.endpoint || "No public endpoint")}</code>
+    </div>
+    <div class="server-detail-block">
+      <span class="server-detail-label">Labels</span>
+      <div class="server-label-list">
+        ${
+          labels.length
+            ? labels
+                .map(([key, value]) => `<span>${escapeHtml(key)}=${escapeHtml(value)}</span>`)
+                .join("")
+            : '<span class="muted-text">None</span>'
+        }
+      </div>
+    </div>
+  `;
+}
+
+function renderOperationEvents() {
+  const tbody = document.getElementById("ops-activity-body");
+  if (!tbody) return;
+  if (!operationsEventsCache.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No MCP events yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  operationsEventsCache.forEach((event) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${renderAuditTime(event)}</td>
+      <td>${renderOperationSubject(event)}</td>
+      <td>${renderAuditTarget(event)}</td>
+      <td>${renderDecision(event.decision)}</td>
+    `;
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderUserActivity() {
+  const tbody = document.getElementById("ops-user-activity-body");
+  if (!tbody) return;
+  if (!operationsAuditCache.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No user activity yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  operationsAuditCache.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createTextCell(formatDateTime(item.created_at)));
+    row.appendChild(createIdentityCell(item.email || item.resource || "-", item.namespace || item.actor_ip || ""));
+    row.appendChild(createIdentityCell(item.action || "-", item.resource || item.message || ""));
+    row.appendChild(createBadgeCell(item.status || "unknown", auditStatusBadgeClass(item.status)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderOperationSubject(event) {
+  const chips = [
+    event.human_id ? renderAuditIdentity("Human", event.human_id) : "",
+    event.agent_id ? renderAuditIdentity("Agent", event.agent_id) : "",
+  ].filter(Boolean);
+  return chips.length ? `<div class="subject-chip-list">${chips.join("")}</div>` : '<span class="muted-text">-</span>';
+}
+
+function operationServerKey(server) {
+  return `${server.namespace || ""}/${server.name || ""}`;
+}
+
+function operationInventoryLabel(server) {
+  const pieces = [
+    `${(server.tools || []).length} tools`,
+    `${(server.prompts || []).length} prompts`,
+    `${(server.resources || []).length} resources`,
+    `${(server.tasks || []).length} tasks`,
+  ];
+  return pieces.join(" / ");
+}
+
+function createEndpointCell(endpoint) {
+  const cell = document.createElement("td");
+  const code = document.createElement("code");
+  code.className = "table-code";
+  code.textContent = endpoint || "No public endpoint";
+  cell.appendChild(code);
+  return cell;
+}
+
+function serverDetailStat(label, value) {
+  return `
+    <div class="server-detail-stat">
+      <span>${escapeHtml(label)}</span>
+      <strong>${escapeHtml(value || "-")}</strong>
+    </div>
+  `;
+}
+
+function auditStatusBadgeClass(status) {
+  if (status === "success") return "badge-success";
+  if (status === "denied") return "badge-warning";
+  if (status === "error") return "badge-error";
+  return "badge-muted";
+}
+
+function formatDateTime(value) {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function initOperations() {
+  document.getElementById("refresh-mcp-ops")?.addEventListener("click", loadMCPOperations);
+  document.getElementById("ops-server-select")?.addEventListener("change", (event) => {
+    selectedOperationsServerKey = event.target.value || "";
+    renderSelectedOperationServer();
+  });
+}
+
+// Platform management
+async function loadPlatformManagement() {
+  await Promise.allSettled([loadComponents(), loadPlatformServerHealth()]);
+}
+
+async function loadPlatformServerHealth() {
+  const tbody = document.getElementById("platform-server-health-body");
+  if (tbody) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">Loading MCP server health...</td></tr>';
+  }
+  try {
+    const data = await fetchJSON("/runtime/servers");
+    const servers = Array.isArray(data.servers) ? data.servers : [];
+    renderPlatformServerHealth(servers);
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load platform server health:", err);
+    setText("platform-mcp-total", "-");
+    setText("platform-mcp-ready", "-");
+    setText("platform-mcp-issues", "-");
+    if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="4" class="empty">Error loading MCP server health.</td></tr>';
+    }
+  }
+}
+
+function renderPlatformServerHealth(servers) {
+  const total = servers.length;
+  const ready = servers.filter((server) => server.status === "Ready").length;
+  setText("platform-mcp-total", formatNumber(total));
+  setText("platform-mcp-ready", formatNumber(ready));
+  setText("platform-mcp-issues", formatNumber(Math.max(total - ready, 0)));
+
+  const tbody = document.getElementById("platform-server-health-body");
+  if (!tbody) return;
+  if (!servers.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No MCP servers found.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  servers.forEach((server) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(server.name || "-", server.namespace || "-"));
+    row.appendChild(createBadgeCell(server.status || "Unknown", serverBadgeClass(server.status)));
+    row.appendChild(createTextCell(server.ready || "0/0"));
+    row.appendChild(createTextCell(formatDateTime(server.age)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+// Platform - Components
 async function loadComponents() {
   const grid = document.getElementById("components-grid");
+  if (!grid) return;
   grid.innerHTML = '<div class="component-card loading">Loading components...</div>';
 
   try {
@@ -1742,6 +2105,7 @@ async function loadComponents() {
         <div class="component-name">${escapeHtml(comp.display)}</div>
         <div class="component-status">${escapeHtml(comp.status)}</div>
         <div class="component-ready">${escapeHtml(comp.ready)}</div>
+        <div class="component-meta">${escapeHtml(comp.namespace || "-")} / ${escapeHtml(comp.resource || comp.key || "-")}</div>
         ${comp.message ? `<div style="font-size: 11px; color: var(--muted); margin-top: 4px;">${escapeHtml(comp.message)}</div>` : ""}
       `;
       fragment.appendChild(card);
@@ -1759,6 +2123,7 @@ async function loadComponents() {
 // Operations - Restart
 async function restartComponent() {
   const select = document.getElementById("restart-component-select");
+  if (!select) return;
   const component = select.value;
 
   if (!component) {
@@ -1787,9 +2152,13 @@ async function restartComponent() {
   }
 }
 
-function initOperations() {
-  document.getElementById("refresh-components")?.addEventListener("click", loadComponents);
+function initPlatform() {
+  document.getElementById("refresh-components")?.addEventListener("click", loadPlatformManagement);
   document.getElementById("restart-component-btn")?.addEventListener("click", restartComponent);
+  document.getElementById("open-mcp-operations")?.addEventListener("click", () => {
+    activateTab("operations");
+    loadMCPOperations();
+  });
 }
 
 // Modal
@@ -1828,6 +2197,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initGovernance();
   initUserAPIKeys();
   initOperations();
+  initPlatform();
   initModal();
   initAuth();
 });

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -336,7 +336,7 @@ async function loadEvents() {
 
     if (!data.events || data.events.length === 0) {
       tbody.innerHTML =
-        '<tr><td colspan="5" class="empty">No events yet.</td></tr>';
+        '<tr><td colspan="6" class="empty">No events yet.</td></tr>';
       return;
     }
 
@@ -346,11 +346,12 @@ async function loadEvents() {
     data.events.forEach((event) => {
       const row = document.createElement("tr");
       row.innerHTML = `
-        <td>${new Date(event.timestamp).toLocaleString()}</td>
-        <td>${escapeHtml(event.source || "-")}</td>
-        <td>${escapeHtml(event.event_type || "-")}</td>
-        <td>${escapeHtml(event.server || "-")}</td>
+        <td>${renderAuditTime(event)}</td>
+        <td>${renderAuditIdentity("Human", event.human_id)}</td>
+        <td>${renderAuditIdentity("Agent", event.agent_id)}</td>
+        <td>${renderAuditTarget(event)}</td>
         <td>${renderDecision(event.decision)}</td>
+        <td>${renderPolicySummary(event)}</td>
       `;
       fragment.appendChild(row);
     });
@@ -362,17 +363,63 @@ async function loadEvents() {
   }
 }
 
+function renderAuditTime(event) {
+  const timestamp = event.timestamp ? new Date(event.timestamp).toLocaleString() : "-";
+  const source = event.source || event.event_type
+    ? [event.source, event.event_type].filter(Boolean).join(" / ")
+    : "";
+  return `
+    <div class="audit-cell">
+      <strong>${escapeHtml(timestamp)}</strong>
+      ${source ? `<span>${escapeHtml(source)}</span>` : ""}
+    </div>
+  `;
+}
+
+function renderAuditIdentity(label, value) {
+  if (!value) return '<span class="muted-text">-</span>';
+  return `
+    <span class="subject-chip">
+      <span class="subject-chip-label">${escapeHtml(label)}</span>
+      <strong>${escapeHtml(value)}</strong>
+    </span>
+  `;
+}
+
+function renderAuditTarget(event) {
+  const payload = event.payload || {};
+  const server = event.server || payload.server || "-";
+  const namespace = event.namespace || payload.namespace || "";
+  const action = event.tool_name || payload.tool_name || payload.rpc_method || event.event_type || "-";
+  return `
+    <div class="audit-cell">
+      <strong>${escapeHtml(server)}</strong>
+      ${namespace ? `<span>${escapeHtml(namespace)}</span>` : ""}
+      <span class="audit-action">${escapeHtml(action)}</span>
+    </div>
+  `;
+}
+
 function renderDecision(decision) {
-  if (!decision) return "-";
-  const color =
-    decision === "allow"
-      ? "var(--success)"
-      : decision === "deny"
-      ? "var(--error)"
-      : "var(--muted)";
-  return `<span style="color: ${color}; font-weight: 600;">${escapeHtml(
-    decision
-  )}</span>`;
+  if (!decision) return '<span class="muted-text">-</span>';
+  return `<span class="badge ${decisionBadgeClass(decision)}">${escapeHtml(decision)}</span>`;
+}
+
+function renderPolicySummary(event) {
+  const payload = event.payload || {};
+  const reason = payload.reason || event.decision || "-";
+  const trustParts = [
+    payload.effective_trust ? `effective ${payload.effective_trust}` : "",
+    payload.required_trust ? `required ${payload.required_trust}` : "",
+  ].filter(Boolean);
+  const session = event.session_id || payload.session_id || "";
+  return `
+    <div class="audit-cell">
+      <strong>${escapeHtml(reason)}</strong>
+      ${trustParts.length ? `<span>${escapeHtml(trustParts.join(" / "))}</span>` : ""}
+      ${session ? `<span>session ${escapeHtml(session)}</span>` : ""}
+    </div>
+  `;
 }
 
 function escapeHtml(text) {
@@ -742,7 +789,7 @@ function resetDashboard() {
   document.getElementById("analytics-decisions-body").innerHTML =
     '<tr><td colspan="2" class="empty">No decisions yet.</td></tr>';
   document.getElementById("events-body").innerHTML =
-    '<tr><td colspan="5" class="empty">No events yet.</td></tr>';
+    '<tr><td colspan="6" class="empty">No events yet.</td></tr>';
 }
 
 function resetGovernance() {

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -10,6 +10,8 @@ let sessionsCache = [];
 let userAPIKeysCache = [];
 let serversCache = [];
 let userAPIKeyClearTimer = null;
+let serverSearchQuery = "";
+let serverStatusFilter = "all";
 
 // API Helper
 async function fetchJSON(path, options = {}) {
@@ -42,6 +44,34 @@ function unauthorizedError() {
 
 function isUnauthorizedError(err) {
   return err?.name === "UnauthorizedError";
+}
+
+async function copyTextToClipboard(text, successMessage = "Copied") {
+  const value = String(text || "");
+  if (!value) {
+    showToast("Nothing to copy", "warning");
+    return;
+  }
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+    } else {
+      const textarea = document.createElement("textarea");
+      textarea.value = value;
+      textarea.setAttribute("readonly", "");
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      textarea.remove();
+    }
+    showToast(successMessage);
+  } catch (err) {
+    console.error("Failed to copy text:", err);
+    showToast("Copy failed", "error");
+  }
 }
 
 // Toast Notifications
@@ -636,48 +666,199 @@ async function loadServers() {
 function renderServers() {
   const grid = document.getElementById("servers-grid");
   if (!grid) return;
+  renderServerCatalogSummary();
+
   if (serversCache.length === 0) {
-    grid.innerHTML = '<div class="component-card">No MCP servers found.</div>';
+    grid.innerHTML = '<div class="server-empty-state">No MCP servers found.</div>';
+    return;
+  }
+
+  const servers = filteredServers();
+  if (servers.length === 0) {
+    grid.innerHTML = '<div class="server-empty-state">No servers match this search.</div>';
     return;
   }
 
   grid.innerHTML = "";
   const fragment = document.createDocumentFragment();
-  serversCache.forEach((server) => {
+  servers.forEach((server) => {
     const card = document.createElement("article");
     card.className = "server-card";
 
-    const title = document.createElement("div");
-    title.className = "server-card-head";
-    title.innerHTML = `
-      <div>
-        <h3>${escapeHtml(server.name || "-")}</h3>
-        <p>${escapeHtml(server.namespace || "-")}</p>
-      </div>
-      <span class="badge ${server.status === "Ready" ? "badge-success" : "badge-muted"}">${escapeHtml(server.status || "Unknown")}</span>
-    `;
-    card.appendChild(title);
+    card.appendChild(renderServerHero(server));
+    card.appendChild(renderServerMeta(server));
+    card.appendChild(renderServerEndpoint(server));
 
-    if (server.endpoint) {
-      const endpoint = document.createElement("code");
-      endpoint.className = "server-endpoint";
-      endpoint.textContent = server.endpoint;
-      card.appendChild(endpoint);
+    const inventory = document.createElement("div");
+    inventory.className = "server-inventory-grid";
+    inventory.appendChild(renderInventoryBlock("Tools", server.tools || [], renderToolItem));
+    inventory.appendChild(renderInventoryBlock("Prompts", server.prompts || [], renderInventoryItem));
+    inventory.appendChild(renderInventoryBlock("Resources", server.resources || [], renderInventoryItem));
+    inventory.appendChild(renderInventoryBlock("Tasks", server.tasks || [], renderInventoryItem));
+    card.appendChild(inventory);
+
+    if (server.access_json && Object.keys(server.access_json).length) {
+      card.appendChild(renderServerConnectConfig(server));
     }
-
-    card.appendChild(renderInventoryBlock("Tools", server.tools || [], renderToolItem));
-    card.appendChild(renderInventoryBlock("Prompts", server.prompts || [], renderInventoryItem));
-    card.appendChild(renderInventoryBlock("Resources", server.resources || [], renderInventoryItem));
-    card.appendChild(renderInventoryBlock("Tasks", server.tasks || [], renderInventoryItem));
-
-    const json = document.createElement("pre");
-    json.className = "access-json";
-    json.textContent = JSON.stringify(server.access_json || {}, null, 2);
-    card.appendChild(json);
 
     fragment.appendChild(card);
   });
   grid.appendChild(fragment);
+}
+
+function filteredServers() {
+  const query = serverSearchQuery.trim().toLowerCase();
+  return serversCache.filter((server) => {
+    const status = String(server.status || "Unknown").toLowerCase();
+    if (serverStatusFilter === "ready" && status !== "ready") return false;
+    if (serverStatusFilter === "attention" && status === "ready") return false;
+    if (!query) return true;
+    return serverSearchText(server).includes(query);
+  });
+}
+
+function serverSearchText(server) {
+  const values = [
+    server.name,
+    server.namespace,
+    server.status,
+    server.ready,
+    server.endpoint,
+    ...(server.tools || []).map((tool) => `${tool.name || ""} ${tool.requiredTrust || ""} ${tool.description || ""}`),
+    ...(server.prompts || []).map(inventorySearchText),
+    ...(server.resources || []).map(inventorySearchText),
+    ...(server.tasks || []).map(inventorySearchText),
+  ];
+  return values.filter(Boolean).join(" ").toLowerCase();
+}
+
+function inventorySearchText(item) {
+  if (typeof item === "string") return item;
+  const labels =
+    item?.labels && typeof item.labels === "object"
+      ? Object.entries(item.labels)
+          .map(([k, v]) => `${k} ${v}`)
+          .join(" ")
+      : "";
+  return `${item?.name || ""} ${item?.description || ""} ${labels}`;
+}
+
+function renderServerCatalogSummary() {
+  const total = serversCache.length;
+  const ready = serversCache.filter((server) => server.status === "Ready").length;
+  const tools = serversCache.reduce((sum, server) => sum + (server.tools || []).length, 0);
+  setText("server-count-total", formatNumber(total));
+  setText("server-count-ready", formatNumber(ready));
+  setText("server-count-tools", formatNumber(tools));
+}
+
+function renderServerHero(server) {
+  const hero = document.createElement("div");
+  hero.className = "server-card-hero";
+  hero.innerHTML = `
+    <div class="server-identity">
+      <span class="server-avatar" aria-hidden="true">${escapeHtml(serverInitials(server.name))}</span>
+      <div class="server-title-stack">
+        <h3>${escapeHtml(server.name || "-")}</h3>
+        <p>${escapeHtml(server.namespace || "-")}</p>
+      </div>
+    </div>
+    <div class="server-status-stack">
+      <span class="badge ${serverBadgeClass(server.status)}">${escapeHtml(server.status || "Unknown")}</span>
+      <span>${escapeHtml(server.ready || "0/0")} pods</span>
+    </div>
+  `;
+  return hero;
+}
+
+function renderServerMeta(server) {
+  const meta = document.createElement("div");
+  meta.className = "server-meta-row";
+  meta.appendChild(serverMetaPill("HTTP MCP"));
+  meta.appendChild(serverMetaPill(`${(server.tools || []).length} tools`));
+  meta.appendChild(serverMetaPill(`${(server.prompts || []).length} prompts`));
+  meta.appendChild(serverMetaPill(`${(server.resources || []).length} resources`));
+  meta.appendChild(serverMetaPill(`Created ${formatServerAge(server.age)}`));
+  return meta;
+}
+
+function serverMetaPill(text) {
+  const item = document.createElement("span");
+  item.className = "server-meta-pill";
+  item.textContent = text;
+  return item;
+}
+
+function renderServerEndpoint(server) {
+  const row = document.createElement("div");
+  row.className = "server-endpoint-row";
+  const endpoint = document.createElement("code");
+  endpoint.className = "server-endpoint";
+  endpoint.textContent = server.endpoint || "No public endpoint";
+  row.appendChild(endpoint);
+
+  if (server.endpoint) {
+    const copy = document.createElement("button");
+    copy.className = "ghost server-action";
+    copy.type = "button";
+    copy.textContent = "Copy URL";
+    copy.addEventListener("click", () => copyTextToClipboard(server.endpoint, "Endpoint copied"));
+    row.appendChild(copy);
+  }
+
+  return row;
+}
+
+function renderServerConnectConfig(server) {
+  const details = document.createElement("details");
+  details.className = "server-connect";
+  const summary = document.createElement("summary");
+  summary.textContent = "Connect config";
+  details.appendChild(summary);
+
+  const body = document.createElement("div");
+  body.className = "server-connect-body";
+  const json = document.createElement("pre");
+  json.className = "access-json";
+  const jsonText = JSON.stringify(server.access_json || {}, null, 2);
+  json.textContent = jsonText;
+  const copy = document.createElement("button");
+  copy.className = "ghost server-action";
+  copy.type = "button";
+  copy.textContent = "Copy JSON";
+  copy.addEventListener("click", () => copyTextToClipboard(jsonText, "Connect JSON copied"));
+  body.append(json, copy);
+  details.appendChild(body);
+  return details;
+}
+
+function serverInitials(name) {
+  return String(name || "MCP")
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+}
+
+function serverBadgeClass(status) {
+  if (status === "Ready") return "badge-success";
+  if (status === "Degraded") return "badge-warning";
+  if (status === "NotReady") return "badge-error";
+  return "badge-muted";
+}
+
+function formatServerAge(value) {
+  if (!value) return "-";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function setText(id, value) {
+  const node = document.getElementById(id);
+  if (node) node.textContent = value;
 }
 
 function renderInventoryBlock(label, items, itemRenderer) {
@@ -689,7 +870,7 @@ function renderInventoryBlock(label, items, itemRenderer) {
   if (!items.length) {
     const empty = document.createElement("p");
     empty.className = "inventory-empty";
-    empty.textContent = "None declared.";
+    empty.textContent = "None";
     block.appendChild(empty);
     return block;
   }
@@ -704,7 +885,7 @@ function renderInventoryBlock(label, items, itemRenderer) {
 }
 
 function renderToolItem(tool) {
-  const trust = tool.requiredTrust ? ` <span>${escapeHtml(tool.requiredTrust)}</span>` : "";
+  const trust = tool.requiredTrust ? ` <span class="trust-chip">${escapeHtml(tool.requiredTrust)}</span>` : "";
   const desc = tool.description ? `<small>${escapeHtml(tool.description)}</small>` : "";
   return `<strong>${escapeHtml(tool.name || "-")}</strong>${trust}${desc}`;
 }
@@ -746,6 +927,14 @@ function initDashboard() {
   });
   document.getElementById("refresh-servers")?.addEventListener("click", () => {
     loadServers();
+  });
+  document.getElementById("server-search")?.addEventListener("input", (event) => {
+    serverSearchQuery = event.target.value || "";
+    renderServers();
+  });
+  document.getElementById("server-status-filter")?.addEventListener("change", (event) => {
+    serverStatusFilter = event.target.value || "all";
+    renderServers();
   });
 }
 

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -209,22 +209,42 @@
             </div>
           </div>
 
-          <div class="analytics-summary-grid">
-            <div class="metric-card compact">
-              <span class="metric-label">Allowed</span>
-              <strong class="metric-value" id="analytics-allowed">-</strong>
+          <div class="analytics-overview">
+            <div class="analytics-summary-grid">
+              <div class="metric-card compact">
+                <span class="metric-label">Events</span>
+                <strong class="metric-value" id="analytics-total-events">-</strong>
+              </div>
+              <div class="metric-card compact">
+                <span class="metric-label">Allowed</span>
+                <strong class="metric-value" id="analytics-allowed">-</strong>
+              </div>
+              <div class="metric-card compact">
+                <span class="metric-label">Denied</span>
+                <strong class="metric-value" id="analytics-denied">-</strong>
+              </div>
+              <div class="metric-card compact">
+                <span class="metric-label">Humans</span>
+                <strong class="metric-value" id="analytics-humans">-</strong>
+              </div>
+              <div class="metric-card compact">
+                <span class="metric-label">Agents</span>
+                <strong class="metric-value" id="analytics-agents">-</strong>
+              </div>
             </div>
-            <div class="metric-card compact">
-              <span class="metric-label">Denied</span>
-              <strong class="metric-value" id="analytics-denied">-</strong>
-            </div>
-            <div class="metric-card compact">
-              <span class="metric-label">Humans</span>
-              <strong class="metric-value" id="analytics-humans">-</strong>
-            </div>
-            <div class="metric-card compact">
-              <span class="metric-label">Agents</span>
-              <strong class="metric-value" id="analytics-agents">-</strong>
+            <div class="decision-health-card">
+              <div class="decision-health-head">
+                <span class="metric-label">Decision Health</span>
+                <strong id="analytics-allow-rate">-</strong>
+              </div>
+              <div class="decision-meter" aria-label="Allowed and denied event share">
+                <span class="decision-meter-allow" id="decision-meter-allow"></span>
+                <span class="decision-meter-deny" id="decision-meter-deny"></span>
+              </div>
+              <div class="decision-health-foot">
+                <span><i class="legend-dot allow"></i>Allow</span>
+                <span><i class="legend-dot deny"></i>Deny <strong id="analytics-deny-rate">-</strong></span>
+              </div>
             </div>
           </div>
 
@@ -359,6 +379,25 @@
         aria-labelledby="tab-button-governance"
         hidden
       >
+        <div class="governance-summary-grid">
+          <div class="governance-summary-card">
+            <span class="metric-label">Active Grants</span>
+            <strong class="metric-value" id="gov-active-grants">-</strong>
+          </div>
+          <div class="governance-summary-card">
+            <span class="metric-label">Disabled Grants</span>
+            <strong class="metric-value" id="gov-disabled-grants">-</strong>
+          </div>
+          <div class="governance-summary-card">
+            <span class="metric-label">Active Sessions</span>
+            <strong class="metric-value" id="gov-active-sessions">-</strong>
+          </div>
+          <div class="governance-summary-card">
+            <span class="metric-label">Revoked Sessions</span>
+            <strong class="metric-value" id="gov-revoked-sessions">-</strong>
+          </div>
+        </div>
+
         <div class="panel">
           <div class="panel-head">
             <h2>Access Grants</h2>
@@ -417,11 +456,11 @@
             </div>
           </form>
           <div class="table-wrap">
-            <table>
+            <table class="governance-table">
               <thead>
                 <tr>
-                  <th>Name</th>
-                  <th>Server</th>
+                  <th>Grant</th>
+                  <th>Scope</th>
                   <th>Subject</th>
                   <th>Trust</th>
                   <th>Status</th>
@@ -496,11 +535,11 @@
             </div>
           </form>
           <div class="table-wrap">
-            <table>
+            <table class="governance-table">
               <thead>
                 <tr>
-                  <th>Name</th>
-                  <th>Server</th>
+                  <th>Session</th>
+                  <th>Scope</th>
                   <th>Subject</th>
                   <th>Trust</th>
                   <th>Status</th>

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -84,6 +84,18 @@
         >
           Operations
         </button>
+        <button
+          id="tab-button-platform"
+          class="tab"
+          data-tab="platform"
+          data-admin-only="true"
+          role="tab"
+          type="button"
+          aria-controls="tab-platform"
+          aria-selected="false"
+        >
+          Platform
+        </button>
       </nav>
 
       <!-- MCP Servers Tab -->
@@ -568,9 +580,155 @@
       >
         <div class="panel">
           <div class="panel-head">
-            <h2>Component Health</h2>
+            <div>
+              <h2>MCP Operations</h2>
+              <p class="panel-kicker">Track deployed MCP servers, user activity, and recent tool decisions.</p>
+            </div>
             <div class="panel-actions">
-              <button class="ghost" id="refresh-components">Refresh</button>
+              <button class="ghost" id="refresh-mcp-ops" type="button">Refresh</button>
+            </div>
+          </div>
+          <div class="ops-summary-grid" aria-label="MCP operations summary">
+            <div class="metric-card compact">
+              <span class="metric-label">MCP Servers</span>
+              <strong class="metric-value" id="ops-mcp-total">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Ready</span>
+              <strong class="metric-value" id="ops-mcp-ready">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Issues</span>
+              <strong class="metric-value" id="ops-mcp-issues">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Recent Logins</span>
+              <strong class="metric-value" id="ops-login-count">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">MCP Events</span>
+              <strong class="metric-value" id="ops-mcp-events">-</strong>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>MCP Server Health</h2>
+              <p class="panel-kicker">See which MCP servers are deployed, their rollout state, and when they were created.</p>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table class="server-health-table">
+              <thead>
+                <tr>
+                  <th>Server</th>
+                  <th>Status</th>
+                  <th>Ready</th>
+                  <th>Inventory</th>
+                  <th>Deployed</th>
+                  <th>Endpoint</th>
+                </tr>
+              </thead>
+              <tbody id="ops-server-health-body">
+                <tr>
+                  <td colspan="6" class="empty">Loading MCP servers...</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="ops-two-column">
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>User Activity</h2>
+                <p class="panel-kicker">Recent login and platform audit activity for debugging access.</p>
+              </div>
+            </div>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>User</th>
+                    <th>Action</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody id="ops-user-activity-body">
+                  <tr>
+                    <td colspan="4" class="empty">Loading user activity...</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>MCP Activity</h2>
+                <p class="panel-kicker">Recent allow and deny decisions from the MCP gateway path.</p>
+              </div>
+            </div>
+            <div class="table-wrap">
+              <table class="audit-table compact-audit-table">
+                <thead>
+                  <tr>
+                    <th>Time</th>
+                    <th>Subject</th>
+                    <th>MCP Action</th>
+                    <th>Decision</th>
+                  </tr>
+                </thead>
+                <tbody id="ops-activity-body">
+                  <tr>
+                    <td colspan="4" class="empty">Loading MCP activity...</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>MCP Server Inspector</h2>
+              <p class="panel-kicker">Select a server to inspect deployment metadata and MCP inventory.</p>
+            </div>
+            <div class="panel-actions">
+              <select id="ops-server-select" aria-label="Select MCP server">
+                <option value="">Select server...</option>
+              </select>
+            </div>
+          </div>
+          <div class="server-inspector" id="ops-server-detail">
+            <div class="empty">Select a server to inspect deployment details.</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Platform Tab -->
+      <section
+        id="tab-platform"
+        class="tab-content"
+        data-admin-only="true"
+        role="tabpanel"
+        aria-labelledby="tab-button-platform"
+        hidden
+      >
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Platform Health</h2>
+              <p class="panel-kicker">Operator, Sentinel services, and observability components.</p>
+            </div>
+            <div class="panel-actions">
+              <button class="ghost" id="refresh-components" type="button">Refresh</button>
             </div>
           </div>
           <div class="components-grid" id="components-grid">
@@ -580,15 +738,59 @@
 
         <div class="panel">
           <div class="panel-head">
-            <h2>Safe Operations</h2>
+            <div>
+              <h2>MCP Server Fleet Health</h2>
+              <p class="panel-kicker">Readiness view for servers governed by the platform.</p>
+            </div>
+          </div>
+          <div class="ops-summary-grid platform-fleet-summary" aria-label="MCP server fleet summary">
+            <div class="metric-card compact">
+              <span class="metric-label">Servers</span>
+              <strong class="metric-value" id="platform-mcp-total">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Ready</span>
+              <strong class="metric-value" id="platform-mcp-ready">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Issues</span>
+              <strong class="metric-value" id="platform-mcp-issues">-</strong>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Server</th>
+                  <th>Status</th>
+                  <th>Ready</th>
+                  <th>Deployed</th>
+                </tr>
+              </thead>
+              <tbody id="platform-server-health-body">
+                <tr>
+                  <td colspan="4" class="empty">Loading MCP server health...</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Safe Platform Operations</h2>
+              <p class="panel-kicker">Use these for local development recovery and debugging.</p>
+            </div>
           </div>
           <div class="ops-grid">
             <div class="ops-section">
               <h3>Restart Component</h3>
-              <p class="ops-desc">Perform a rolling restart of a Sentinel component.</p>
+              <p class="ops-desc">Perform a rolling restart of a platform component.</p>
               <div class="ops-form">
                 <select id="restart-component-select">
                   <option value="">Select component...</option>
+                  <option value="operator">Operator</option>
                   <option value="api">API</option>
                   <option value="ingest">Ingest</option>
                   <option value="processor">Processor</option>
@@ -599,14 +801,9 @@
               </div>
             </div>
             <div class="ops-section">
-              <h3>MCP Server Operations</h3>
-              <p class="ops-desc">Manage MCP server deployments (coming soon).</p>
-              <div class="ops-form disabled">
-                <select disabled>
-                  <option>Select server...</option>
-                </select>
-                <button class="primary" disabled>Restart</button>
-              </div>
+              <h3>MCP Server Health</h3>
+              <p class="ops-desc">MCP rollout status and deployed-at timestamps now live in the Operations tab.</p>
+              <button class="ghost" id="open-mcp-operations" type="button">Open Operations</button>
             </div>
           </div>
         </div>

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -340,7 +340,7 @@
 
         <div class="panel">
           <div class="panel-head">
-            <h2>Recent Events</h2>
+            <h2>Decision Audit</h2>
             <div class="panel-actions">
               <button class="ghost" id="refresh-events">Refresh</button>
               <label class="toggle">
@@ -350,19 +350,20 @@
             </div>
           </div>
           <div class="table-wrap">
-            <table>
+            <table class="audit-table">
               <thead>
                 <tr>
-                  <th>Timestamp</th>
-                  <th>Source</th>
-                  <th>Type</th>
-                  <th>Server</th>
+                  <th>Time</th>
+                  <th>Human</th>
+                  <th>Agent</th>
+                  <th>MCP Action</th>
                   <th>Decision</th>
+                  <th>Policy</th>
                 </tr>
               </thead>
               <tbody id="events-body">
                 <tr>
-                  <td colspan="5" class="empty">No events yet.</td>
+                  <td colspan="6" class="empty">No events yet.</td>
                 </tr>
               </tbody>
             </table>

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -175,6 +175,128 @@
 
         <div class="panel">
           <div class="panel-head">
+            <h2>Usage Analytics</h2>
+            <div class="panel-actions">
+              <select id="analytics-limit" aria-label="Analytics row limit">
+                <option value="10" selected>Top 10</option>
+                <option value="25">Top 25</option>
+                <option value="50">Top 50</option>
+              </select>
+              <button class="ghost" id="refresh-analytics" type="button">Refresh</button>
+            </div>
+          </div>
+
+          <div class="analytics-summary-grid">
+            <div class="metric-card compact">
+              <span class="metric-label">Allowed</span>
+              <strong class="metric-value" id="analytics-allowed">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Denied</span>
+              <strong class="metric-value" id="analytics-denied">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Humans</span>
+              <strong class="metric-value" id="analytics-humans">-</strong>
+            </div>
+            <div class="metric-card compact">
+              <span class="metric-label">Agents</span>
+              <strong class="metric-value" id="analytics-agents">-</strong>
+            </div>
+          </div>
+
+          <div class="analytics-grid">
+            <section class="analytics-section">
+              <h3>MCP Servers</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Namespace</th>
+                      <th>Events</th>
+                      <th>Allow</th>
+                      <th>Deny</th>
+                      <th>Humans</th>
+                      <th>Agents</th>
+                    </tr>
+                  </thead>
+                  <tbody id="analytics-servers-body">
+                    <tr>
+                      <td colspan="7" class="empty">No usage yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="analytics-section">
+              <h3>Users & Agents</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Human</th>
+                      <th>Agent</th>
+                      <th>Events</th>
+                      <th>Servers</th>
+                      <th>Tools</th>
+                      <th>Deny</th>
+                    </tr>
+                  </thead>
+                  <tbody id="analytics-actors-body">
+                    <tr>
+                      <td colspan="6" class="empty">No actors yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="analytics-section">
+              <h3>Tools</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Tool</th>
+                      <th>Events</th>
+                      <th>Deny</th>
+                    </tr>
+                  </thead>
+                  <tbody id="analytics-tools-body">
+                    <tr>
+                      <td colspan="4" class="empty">No tool calls yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="analytics-section">
+              <h3>Decisions</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Decision</th>
+                      <th>Events</th>
+                    </tr>
+                  </thead>
+                  <tbody id="analytics-decisions-body">
+                    <tr>
+                      <td colspan="2" class="empty">No decisions yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
             <h2>Recent Events</h2>
             <div class="panel-actions">
               <button class="ghost" id="refresh-events">Refresh</button>
@@ -430,7 +552,7 @@
 
     <!-- Authentication Modal -->
     <div id="auth-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="auth-title">
-      <form class="modal-content" id="auth-form" method="dialog">
+      <form class="modal-content auth-modal-content" id="auth-form" method="dialog">
         <h3 id="auth-title">Sign In</h3>
         <p>Use your platform account, Google sign-in, or an MCP Sentinel API key.</p>
         <input
@@ -449,7 +571,7 @@
           type="password"
           id="api-key-input"
           autocomplete="off"
-          placeholder="API key"
+          placeholder="API key (optional alternative)"
         />
         <p id="auth-error" class="auth-error hidden"></p>
         <div class="modal-actions">

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -95,9 +95,32 @@
       >
         <div class="panel">
           <div class="panel-head">
-            <h2>MCP Servers</h2>
+            <div>
+              <h2>MCP Servers</h2>
+              <p class="panel-kicker">Browse deployed MCP endpoints and client connection details.</p>
+            </div>
             <div class="panel-actions">
               <button class="ghost" id="refresh-servers" type="button">Refresh</button>
+            </div>
+          </div>
+          <div class="server-catalog-toolbar">
+            <div class="server-catalog-stats" aria-label="MCP server summary">
+              <span><strong id="server-count-total">-</strong> servers</span>
+              <span><strong id="server-count-ready">-</strong> ready</span>
+              <span><strong id="server-count-tools">-</strong> tools</span>
+            </div>
+            <div class="server-catalog-controls">
+              <input
+                type="search"
+                id="server-search"
+                placeholder="Search servers, namespaces, routes, tools"
+                aria-label="Search MCP servers"
+              />
+              <select id="server-status-filter" aria-label="Filter MCP servers by status">
+                <option value="all">All statuses</option>
+                <option value="ready">Ready</option>
+                <option value="attention">Needs attention</option>
+              </select>
             </div>
           </div>
           <div class="server-grid" id="servers-grid">

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -97,7 +97,7 @@
           <div class="panel-head">
             <div>
               <h2>MCP Servers</h2>
-              <p class="panel-kicker">Browse deployed MCP endpoints and client connection details.</p>
+              <p class="panel-kicker">Browse deployed MCP endpoints and connection details.</p>
             </div>
             <div class="panel-actions">
               <button class="ghost" id="refresh-servers" type="button">Refresh</button>
@@ -109,6 +109,11 @@
               <span><strong id="server-count-ready">-</strong> ready</span>
               <span><strong id="server-count-tools">-</strong> tools</span>
             </div>
+            <div class="server-status-segment" aria-label="Filter MCP servers by status">
+              <button class="active" data-server-status="all" type="button">All</button>
+              <button data-server-status="ready" type="button">Ready</button>
+              <button data-server-status="attention" type="button">Issues</button>
+            </div>
             <div class="server-catalog-controls">
               <input
                 type="search"
@@ -116,11 +121,6 @@
                 placeholder="Search servers, namespaces, routes, tools"
                 aria-label="Search MCP servers"
               />
-              <select id="server-status-filter" aria-label="Filter MCP servers by status">
-                <option value="all">All statuses</option>
-                <option value="ready">Ready</option>
-                <option value="attention">Needs attention</option>
-              </select>
             </div>
           </div>
           <div class="server-grid" id="servers-grid">

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -177,7 +177,88 @@ h1 {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
+}
+
+.analytics-overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  gap: 16px;
   margin-bottom: 20px;
+}
+
+.decision-health-card {
+  background:
+    linear-gradient(160deg, rgba(242, 184, 75, 0.12), transparent 55%),
+    var(--bg-secondary);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 16px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.decision-health-head {
+  align-items: baseline;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.decision-health-head strong {
+  font-size: 24px;
+}
+
+.decision-meter {
+  background: rgba(247, 245, 239, 0.08);
+  border-radius: 999px;
+  display: flex;
+  height: 12px;
+  overflow: hidden;
+}
+
+.decision-meter span {
+  display: block;
+  min-width: 0;
+  transition: width 0.2s ease;
+}
+
+.decision-meter-allow {
+  background: var(--success);
+}
+
+.decision-meter-deny {
+  background: var(--error);
+}
+
+.decision-health-foot {
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: 12px;
+}
+
+.decision-health-foot span {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.legend-dot {
+  border-radius: 999px;
+  display: inline-block;
+  height: 8px;
+  width: 8px;
+}
+
+.legend-dot.allow {
+  background: var(--success);
+}
+
+.legend-dot.deny {
+  background: var(--error);
 }
 
 .analytics-grid {
@@ -381,6 +462,75 @@ select:disabled {
   width: 100%;
 }
 
+.governance-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.governance-summary-card {
+  background:
+    linear-gradient(150deg, rgba(156, 182, 171, 0.12), transparent 55%),
+    var(--bg-secondary);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 16px;
+  min-width: 0;
+  padding: 18px;
+}
+
+.governance-table td {
+  vertical-align: top;
+}
+
+.identity-stack {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.identity-primary {
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.identity-secondary {
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.subject-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+}
+
+.subject-chip {
+  align-items: center;
+  background: rgba(247, 245, 239, 0.06);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 999px;
+  display: inline-flex;
+  gap: 6px;
+  max-width: 100%;
+  padding: 5px 9px;
+}
+
+.subject-chip strong {
+  color: var(--text);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.subject-chip-label {
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .form-actions {
   display: flex;
   gap: 12px;
@@ -449,6 +599,21 @@ tr:hover td {
 }
 
 .badge-muted {
+  background: rgba(156, 182, 171, 0.2);
+  color: var(--muted);
+}
+
+.badge-trust-high {
+  background: rgba(242, 106, 75, 0.2);
+  color: var(--accent-strong);
+}
+
+.badge-trust-medium {
+  background: rgba(242, 184, 75, 0.2);
+  color: var(--accent);
+}
+
+.badge-trust-low {
   background: rgba(156, 182, 171, 0.2);
   color: var(--muted);
 }
@@ -1046,6 +1211,11 @@ tr:hover td {
   }
 
   .analytics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .analytics-overview,
+  .governance-summary-grid {
     grid-template-columns: 1fr;
   }
 

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -18,17 +18,24 @@
   box-sizing: border-box;
 }
 
+html {
+  min-height: 100%;
+  background: radial-gradient(circle at top left, #2b4f46, var(--bg));
+}
+
 body {
   margin: 0;
   font-family: "Space Grotesk", "Helvetica Neue", sans-serif;
   color: var(--text);
   background: radial-gradient(circle at top left, #2b4f46, var(--bg));
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .canvas {
   max-width: 1400px;
   margin: 0 auto;
+  min-height: 100vh;
   padding: 40px 24px 64px;
 }
 
@@ -52,7 +59,9 @@ body {
 h1 {
   font-family: "DM Serif Display", serif;
   font-size: clamp(32px, 4vw, 48px);
+  line-height: 1.05;
   margin: 0 0 12px;
+  overflow-wrap: break-word;
 }
 
 .lede {
@@ -217,6 +226,12 @@ h1 {
   font-size: 20px;
 }
 
+.panel-kicker {
+  color: var(--muted);
+  font-size: 13px;
+  margin: 6px 0 0;
+}
+
 .panel-actions {
   display: flex;
   align-items: center;
@@ -279,6 +294,7 @@ input[type="text"],
 input[type="email"],
 input[type="number"],
 input[type="password"],
+input[type="search"],
 input[type="datetime-local"],
 textarea,
 select {
@@ -293,6 +309,7 @@ select {
 
 input[type="text"]::placeholder,
 input[type="email"]::placeholder,
+input[type="search"]::placeholder,
 textarea::placeholder {
   color: var(--muted);
   opacity: 0.7;
@@ -612,17 +629,121 @@ tr:hover td {
 
 .server-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 460px), 1fr));
+  gap: 18px;
+  align-items: start;
+}
+
+.server-catalog-toolbar {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(320px, 0.9fr);
   gap: 16px;
+  align-items: center;
+  background: rgba(11, 24, 21, 0.42);
+  border: 1px solid rgba(247, 245, 239, 0.1);
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 18px;
+}
+
+.server-catalog-stats,
+.server-catalog-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.server-catalog-stats {
+  flex-wrap: wrap;
+}
+
+.server-catalog-stats span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.server-catalog-stats strong {
+  color: var(--text);
+  font-size: 18px;
+}
+
+.server-catalog-controls {
+  justify-content: flex-end;
+}
+
+.server-catalog-controls input {
+  min-width: 0;
+  width: min(100%, 340px);
+}
+
+.server-catalog-controls select {
+  width: 160px;
+  flex: 0 0 auto;
+}
+
+.server-empty-state {
+  background: rgba(11, 24, 21, 0.42);
+  border: 1px dashed rgba(247, 245, 239, 0.2);
+  border-radius: 8px;
+  color: var(--muted);
+  padding: 24px;
+  text-align: center;
 }
 
 .server-card {
-  background: rgba(11, 24, 21, 0.45);
-  border: 1px solid rgba(247, 245, 239, 0.12);
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(12, 31, 27, 0.96), rgba(26, 56, 49, 0.84));
+  border: 1px solid rgba(247, 245, 239, 0.14);
   border-radius: 8px;
-  padding: 18px;
+  padding: 20px;
   display: grid;
-  gap: 14px;
+  gap: 16px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.24);
+}
+
+.server-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong), #8bd3ff);
+}
+
+.server-card-hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.server-identity {
+  display: flex;
+  gap: 12px;
+  min-width: 0;
+}
+
+.server-avatar {
+  align-items: center;
+  background: rgba(242, 184, 75, 0.14);
+  border: 1px solid rgba(242, 184, 75, 0.38);
+  border-radius: 8px;
+  color: var(--accent);
+  display: inline-flex;
+  flex: 0 0 44px;
+  font-weight: 700;
+  height: 44px;
+  justify-content: center;
+  width: 44px;
+}
+
+.server-title-stack {
+  min-width: 0;
 }
 
 .server-card-head {
@@ -640,21 +761,79 @@ tr:hover td {
 
 .server-card h3 {
   font-size: 18px;
+  overflow-wrap: anywhere;
 }
 
 .server-card p {
   color: var(--muted);
   font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.server-status-stack {
+  align-items: flex-end;
+  display: grid;
+  gap: 6px;
+  justify-items: end;
+  min-width: fit-content;
+}
+
+.server-status-stack span:last-child {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.server-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.server-meta-pill {
+  background: rgba(247, 245, 239, 0.07);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 12px;
+  padding: 6px 10px;
+}
+
+.server-endpoint-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: stretch;
 }
 
 .server-endpoint {
-  display: block;
+  align-items: center;
+  display: flex;
   overflow-wrap: anywhere;
   color: #fff8dc;
-  background: rgba(0, 0, 0, 0.24);
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(247, 245, 239, 0.08);
   border-radius: 6px;
-  padding: 10px;
+  min-height: 40px;
+  padding: 10px 12px;
   font-size: 12px;
+}
+
+.server-action {
+  border-color: rgba(247, 245, 239, 0.35);
+  border-radius: 8px;
+  min-height: 40px;
+  padding: 8px 12px;
+  white-space: nowrap;
+}
+
+.server-inventory-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.inventory-block {
+  min-width: 0;
 }
 
 .inventory-block h4 {
@@ -673,11 +852,16 @@ tr:hover td {
 }
 
 .inventory-block li {
-  display: grid;
-  gap: 2px;
-  padding: 8px 10px;
+  align-items: center;
   background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(247, 245, 239, 0.06);
   border-radius: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: space-between;
+  min-height: 40px;
+  padding: 8px 10px;
 }
 
 .inventory-block span {
@@ -691,9 +875,44 @@ tr:hover td {
   font-size: 12px;
 }
 
+.inventory-empty {
+  background: rgba(247, 245, 239, 0.04);
+  border: 1px dashed rgba(247, 245, 239, 0.12);
+  border-radius: 6px;
+  margin: 0;
+  min-height: 40px;
+  padding: 10px;
+}
+
+.trust-chip {
+  background: rgba(139, 211, 255, 0.14);
+  border: 1px solid rgba(139, 211, 255, 0.28);
+  border-radius: 999px;
+  color: #c8edff !important;
+  padding: 3px 8px;
+}
+
+.server-connect {
+  border-top: 1px solid rgba(247, 245, 239, 0.1);
+  padding-top: 4px;
+}
+
+.server-connect summary {
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 8px 0;
+}
+
+.server-connect-body {
+  display: grid;
+  gap: 10px;
+}
+
 .access-json {
   margin: 0;
-  max-height: 240px;
+  max-height: 180px;
   overflow: auto;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -757,6 +976,18 @@ tr:hover td {
     justify-content: center;
   }
 
+  h1 {
+    max-width: 12ch;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .lede {
+    max-width: 30ch;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   .tabs {
     overflow-x: auto;
     flex-wrap: nowrap;
@@ -777,6 +1008,33 @@ tr:hover td {
 
   .panel-actions {
     flex-wrap: wrap;
+  }
+
+  .server-catalog-toolbar,
+  .server-endpoint-row,
+  .server-inventory-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .server-catalog-controls {
+    align-items: stretch;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  .server-catalog-controls input,
+  .server-catalog-controls select {
+    width: 100%;
+  }
+
+  .server-card-hero {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .server-status-stack {
+    align-items: flex-start;
+    justify-items: start;
   }
 
   .ops-form {
@@ -809,6 +1067,14 @@ tr:hover td {
 }
 
 @media (max-width: 480px) {
+  .canvas {
+    padding: 36px 16px 48px;
+  }
+
+  h1 {
+    font-size: 28px;
+  }
+
   .metrics-grid {
     grid-template-columns: 1fr;
   }

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -202,6 +202,7 @@ h1 {
 .panel {
   background: rgba(27, 59, 52, 0.75);
   border-radius: 20px;
+  min-width: 0;
   padding: 24px;
   backdrop-filter: blur(8px);
   box-shadow: 0 20px 40px var(--shadow);
@@ -230,6 +231,8 @@ h1 {
   color: var(--muted);
   font-size: 13px;
   margin: 6px 0 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .panel-actions {
@@ -632,18 +635,20 @@ tr:hover td {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 460px), 1fr));
   gap: 18px;
   align-items: start;
+  min-width: 0;
 }
 
 .server-catalog-toolbar {
   display: grid;
-  grid-template-columns: minmax(240px, 1fr) minmax(320px, 0.9fr);
-  gap: 16px;
+  grid-template-columns: auto auto minmax(240px, 1fr);
+  gap: 12px;
   align-items: center;
   background: rgba(11, 24, 21, 0.42);
   border: 1px solid rgba(247, 245, 239, 0.1);
   border-radius: 8px;
   padding: 14px;
   margin-bottom: 18px;
+  min-width: 0;
 }
 
 .server-catalog-stats,
@@ -652,6 +657,7 @@ tr:hover td {
   align-items: center;
   gap: 10px;
   min-width: 0;
+  max-width: 100%;
 }
 
 .server-catalog-stats {
@@ -678,12 +684,31 @@ tr:hover td {
 
 .server-catalog-controls input {
   min-width: 0;
-  width: min(100%, 340px);
+  width: min(100%, 420px);
 }
 
-.server-catalog-controls select {
-  width: 160px;
-  flex: 0 0 auto;
+.server-status-segment {
+  background: rgba(247, 245, 239, 0.06);
+  border: 1px solid rgba(247, 245, 239, 0.1);
+  border-radius: 8px;
+  display: inline-flex;
+  gap: 3px;
+  min-width: 0;
+  padding: 3px;
+}
+
+.server-status-segment button {
+  background: transparent;
+  border-radius: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  min-width: 0;
+  padding: 7px 10px;
+}
+
+.server-status-segment button.active {
+  background: rgba(242, 184, 75, 0.16);
+  color: var(--text);
 }
 
 .server-empty-state {
@@ -704,6 +729,7 @@ tr:hover td {
   padding: 20px;
   display: grid;
   gap: 16px;
+  min-width: 0;
   box-shadow: 0 18px 36px rgba(0, 0, 0, 0.24);
 }
 
@@ -783,10 +809,19 @@ tr:hover td {
   font-size: 12px;
 }
 
+.server-meta-wrap {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  min-width: 0;
+}
+
 .server-meta-row {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  min-width: 0;
 }
 
 .server-meta-pill {
@@ -798,17 +833,25 @@ tr:hover td {
   padding: 6px 10px;
 }
 
+.server-card-actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
 .server-endpoint-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
   gap: 10px;
-  align-items: stretch;
 }
 
 .server-endpoint {
   align-items: center;
   display: flex;
   overflow-wrap: anywhere;
+  min-width: 0;
   color: #fff8dc;
   background: rgba(0, 0, 0, 0.28);
   border: 1px solid rgba(247, 245, 239, 0.08);
@@ -821,8 +864,8 @@ tr:hover td {
 .server-action {
   border-color: rgba(247, 245, 239, 0.35);
   border-radius: 8px;
-  min-height: 40px;
-  padding: 8px 12px;
+  min-height: 34px;
+  padding: 7px 11px;
   white-space: nowrap;
 }
 
@@ -1010,26 +1053,47 @@ tr:hover td {
     flex-wrap: wrap;
   }
 
+  .panel {
+    border-radius: 14px;
+    padding: 18px;
+  }
+
   .server-catalog-toolbar,
-  .server-endpoint-row,
   .server-inventory-grid {
     grid-template-columns: 1fr;
   }
 
   .server-catalog-controls {
-    align-items: stretch;
-    flex-direction: column;
     justify-content: flex-start;
   }
 
-  .server-catalog-controls input,
-  .server-catalog-controls select {
+  .server-catalog-controls input {
     width: 100%;
+  }
+
+  .server-status-segment {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .server-status-segment button {
+    font-size: 11px;
+    padding: 7px 4px;
+    white-space: nowrap;
   }
 
   .server-card-hero {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .server-meta-wrap {
+    flex-direction: column;
+  }
+
+  .server-card-actions {
+    justify-content: flex-start;
   }
 
   .server-status-stack {

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -156,6 +156,39 @@ h1 {
   display: block;
 }
 
+.metric-card.compact {
+  padding: 14px 16px;
+}
+
+.metric-card.compact .metric-value {
+  font-size: 24px;
+}
+
+.analytics-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.analytics-section {
+  min-width: 0;
+}
+
+.analytics-section h3 {
+  color: var(--accent);
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
 /* Panels */
 .panel {
   background: rgba(27, 59, 52, 0.75);
@@ -243,6 +276,7 @@ button:disabled {
 
 /* Inputs */
 input[type="text"],
+input[type="email"],
 input[type="number"],
 input[type="password"],
 input[type="datetime-local"],
@@ -258,6 +292,7 @@ select {
 }
 
 input[type="text"]::placeholder,
+input[type="email"]::placeholder,
 textarea::placeholder {
   color: var(--muted);
   opacity: 0.7;
@@ -269,11 +304,13 @@ textarea {
   resize: vertical;
 }
 
+input[type="email"],
 input[type="password"] {
   width: 100%;
   margin-bottom: 12px;
 }
 
+input[type="email"]::placeholder,
 input[type="password"]::placeholder {
   color: var(--muted);
   opacity: 0.7;
@@ -508,9 +545,13 @@ tr:hover td {
   background: var(--panel);
   border-radius: 20px;
   padding: 32px;
-  max-width: 400px;
+  max-width: 420px;
   width: 90%;
   box-shadow: 0 24px 48px var(--shadow);
+}
+
+.auth-modal-content {
+  border: 1px solid rgba(247, 245, 239, 0.08);
 }
 
 .modal-content h3 {
@@ -728,6 +769,10 @@ tr:hover td {
 
   .metrics-grid {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .analytics-grid {
+    grid-template-columns: 1fr;
   }
 
   .panel-actions {

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -697,6 +697,13 @@ tr:hover td {
   color: var(--muted);
 }
 
+.component-meta {
+  color: var(--muted);
+  font-size: 11px;
+  margin-top: 6px;
+  overflow-wrap: anywhere;
+}
+
 .component-card.loading {
   text-align: center;
   color: var(--muted);
@@ -704,6 +711,22 @@ tr:hover td {
 }
 
 /* Operations */
+.ops-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
+}
+
+.platform-fleet-summary {
+  margin-bottom: 16px;
+}
+
+.ops-two-column {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 24px;
+}
+
 .ops-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -738,6 +761,106 @@ tr:hover td {
 
 .ops-form select {
   flex: 1;
+}
+
+.server-health-table td {
+  vertical-align: top;
+}
+
+.compact-audit-table th:nth-child(2),
+.compact-audit-table td:nth-child(2) {
+  min-width: 180px;
+}
+
+.table-code {
+  background: rgba(11, 24, 21, 0.58);
+  border-radius: 6px;
+  color: var(--text);
+  display: inline-block;
+  max-width: min(46vw, 520px);
+  overflow: hidden;
+  padding: 6px 8px;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.server-inspector {
+  background: rgba(11, 24, 21, 0.36);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.server-inspector-head {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  min-width: 0;
+}
+
+.server-inspector-head .server-title-stack h3 {
+  margin: 0;
+}
+
+.server-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.server-detail-stat {
+  background: rgba(247, 245, 239, 0.05);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 8px;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.server-detail-stat span,
+.server-detail-label {
+  color: var(--muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.server-detail-stat strong {
+  overflow-wrap: anywhere;
+}
+
+.server-detail-block {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+  min-width: 0;
+}
+
+.server-detail-block .server-endpoint {
+  max-width: 100%;
+}
+
+.server-label-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.server-label-list span {
+  background: rgba(247, 245, 239, 0.06);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 12px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  padding: 5px 9px;
 }
 
 /* Action Buttons */
@@ -1251,6 +1374,7 @@ tr:hover td {
   }
 
   .analytics-overview,
+  .ops-two-column,
   .governance-summary-grid {
     grid-template-columns: 1fr;
   }
@@ -1305,6 +1429,15 @@ tr:hover td {
   .server-status-stack {
     align-items: flex-start;
     justify-items: start;
+  }
+
+  .server-inspector-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .table-code {
+    max-width: 72vw;
   }
 
   .ops-form {

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -483,6 +483,42 @@ select:disabled {
   vertical-align: top;
 }
 
+.audit-table td {
+  vertical-align: top;
+}
+
+.audit-cell {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.audit-cell strong {
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.audit-cell span {
+  color: var(--muted);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.audit-action {
+  background: rgba(247, 245, 239, 0.06);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 999px;
+  color: var(--text) !important;
+  display: inline-flex;
+  justify-self: start;
+  max-width: 100%;
+  padding: 3px 8px;
+}
+
+.muted-text {
+  color: var(--muted);
+}
+
 .identity-stack {
   display: grid;
   gap: 4px;


### PR DESCRIPTION
## Summary

- Seed test-mode platform users for local development: `test@mcpruntime.org` / `test@123` and `admin@mcpruntime.org` / `admin@123`.
- Add an admin-only `/api/analytics/usage` endpoint backed by ClickHouse rollups.
- Bound analytics queries to a default 30-day window, run independent ClickHouse rollups in parallel, log query failures, and use approximate unique counts for dashboard cardinality.
- Extend the Dashboard tab with usage analytics for MCP servers, users/agents, tools, decisions, total traffic, and allow/deny decision health.
- Rework recent dashboard events into a decision-audit table showing time, human, agent, MCP action, decision, policy reason, session, and trust context.
- Redesign the MCP Servers tab into a searchable server catalog with summary counts, compact segmented status filters, cleaner server cards, grouped copy actions, tool/trust chips, and collapsed connect JSON.
- Polish the Governance tab into an access-console view with grant/session summary cards, richer scope/subject rows, and trust/status badges.
- Tighten mobile responsiveness for the server catalog, analytics, and governance layouts.
- Disable and clear test-mode dev-login seed credentials when setup runs outside test mode, and let API-key login proceed when browser autofill partially fills email/password fields.
- Update contributor docs for dev credentials, one-service Sentinel iteration, analytics verification, and Kind `PartiallyReady` behavior.

## Validation

- `GOCACHE=/private/tmp/mcp-runtime-gocache go test ./internal/cli/setup -count=1`
- `GOCACHE=/private/tmp/mcp-runtime-gocache go test -race ./... -count=1` in `services/api`
- `GOCACHE=/private/tmp/mcp-runtime-gocache go test -race ./... -count=1` in `services/ui`
- `GOCACHE=/private/tmp/mcp-runtime-gocache go test ./... -count=1` in `services/ui`
- `GOCACHE=/private/tmp/mcp-runtime-gocache go test ./... -count=1` in `services/api`
- `node --check services/ui/static/app.js`
- `git diff --check`
- Pre-commit hook suite on commits: gitleaks, go fmt, staticcheck, go vet, Go unit tests, generated file drift
- Live Kind verification: deployed `go-example-mcp`, applied grant/session, called `add` and `upper`, confirmed `/api/analytics/usage?limit=10` and `/api/events?limit=3` returned ClickHouse events, rolled the updated UI images, verified the served `/app.js` and `/`, and checked the grants/sessions APIs through the admin cookie.

Draft PR because this is ready for review but still tied to the local test-mode validation context.
