### PR TITLE
fix(ci): use patched Go builder for operator image

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,6 +1,6 @@
 # Keep the operator image on the latest patched Go 1.26.x builder so Trivy
 # does not flag fixed stdlib CVEs in the shipped binary.
-FROM golang:1.26.0-alpine3.23 AS builder
+FROM golang:1.26.2-alpine3.23 AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updates the Go builder image for the operator from `golang:1.26.0-alpine3.23` to `golang:1.26.2-alpine3.23`. This change ensures the operator image is built with a patched Go version, addressing standard library CVEs and preventing them from being flagged by Trivy scans.
<!-- kody-pr-summary:end -->