### PR TITLE
feat(api): implement team-scoped internal multi-tenancy + ci patchset…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,6 +36,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,7 +253,8 @@ Manage access grants, sessions, and view runtime state. All `/api/runtime/*` rou
 For `POST /api/runtime/grants` and `POST /api/runtime/sessions`, the API resolves `serverRef` to an `MCPServer` in the cluster. If that server does not exist, the call returns `400` with a clear `unknown serverRef` message. The server lookup is **not** part of a single distributed transaction with the grant/session write — a concurrent delete can leave a stale reference (same as `kubectl apply`). Kubernetes apply errors are surfaced with the status the API server would use, when available.
 
 ```text
-GET  /api/runtime/servers              # List MCP server deployments
+GET  /api/runtime/servers              # List MCP server deployments (team-scoped for non-admin)
+POST /api/runtime/servers              # Create/update MCPServer in an authorized namespace
 GET  /api/runtime/grants               # List MCPAccessGrant resources
 GET  /api/runtime/grants/{namespace}/{name}   # Get one MCPAccessGrant
 POST /api/runtime/grants               # Create or update an MCPAccessGrant (x-api-key)
@@ -262,9 +263,19 @@ GET  /api/runtime/sessions             # List MCPAgentSession resources
 GET  /api/runtime/sessions/{namespace}/{name} # Get one MCPAgentSession
 POST /api/runtime/sessions             # Create or update an MCPAgentSession (x-api-key)
 DELETE /api/runtime/sessions/{namespace}/{name} # Delete one MCPAgentSession
+GET  /api/runtime/teams                # Admin: all teams; user: caller memberships
+POST /api/runtime/teams                # Admin-only team + namespace provisioning
+GET  /api/runtime/teams/{team}         # Team metadata (admin/member)
+POST /api/runtime/teams/{team}/members # Admin/team-owner membership upsert
+DELETE /api/runtime/teams/{team}/members/{userID}
+GET  /api/runtime/namespaces           # Allowed namespaces + shared catalog metadata
+GET  /api/runtime/namespaces/{namespace}
 GET  /api/runtime/components           # Sentinel component health status
 GET  /api/runtime/policy?namespace=&server=   # Get rendered policy for a server
 ```
+
+For non-admin users, runtime write paths enforce namespace ownership through
+team membership and reject writes to the shared `mcp-servers` catalog namespace.
 
 ### Grant apply body
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,8 +51,9 @@ mcp-runtime <group> <subcommand> --help
 | `auth` | Save and inspect platform API credentials for non-kubeconfig platform flows. | `login`, `logout`, `status` |
 | `cluster` | Initialize clusters, inspect health, configure kubeconfig and ingress, provision clusters, manage cert-manager. | `init`, `status`, `config`, `provision`, `cert status\|apply\|wait`, `doctor` |
 | `registry` | Inspect the internal registry, configure an external one, push images. | `status`, `info`, `provision`, `push` |
-| `server` | Manage `MCPServer` resources and operator-facing actions. | `list`, `get`, `create`, `apply`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
+| `server` | Manage `MCPServer` resources and operator-facing actions. | `list`, `get`, `create`, `apply`, `deploy`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
 | `access` | Manage `MCPAccessGrant` and `MCPAgentSession` resources that feed the gateway policy layer. | `grant list/get/apply/delete/disable/enable`, `session list/get/apply/delete/revoke/unrevoke` |
+| `team` | Manage internal team tenancy through the platform API. | `list`, `create` |
 | `sentinel` | Inspect and operate the bundled analytics, gateway, and observability stack. | `status`, `events`, `logs`, `port-forward`, `restart` |
 | `pipeline` | Generate `MCPServer` manifests from metadata and deploy them. | `generate`, `deploy` |
 | `status` | Aggregated platform health (cluster, registry, operator, servers, sentinel). | `status` |

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -3907,17 +3907,23 @@ _No package overview is documented._
 - [`func NewPlatformClient() (*PlatformClient, error)`](#cli-platform-api-func-newplatformclient-platformclient-error)
 - [`func ResolvePlatformOrKube(useKube bool) (*PlatformClient, bool, error)`](#cli-platform-api-func-resolveplatformorkube-usekube-bool-platformclient-bool-error)
 - [`func (c *PlatformClient) ApplyAccessFromYAMLFile(ctx context.Context, path string) error`](#cli-platform-api-func-c-platformclient-applyaccessfromyamlfile-ctx-context-context-path-string-error)
+- [`func (c *PlatformClient) ApplyRuntimeServer(ctx context.Context, name, namespace string, spec mcpv1alpha1.MCPServerSpec) (ServerListItem, error)`](#cli-platform-api-func-c-platformclient-applyruntimeserver-ctx-context-context-name-namespace-string-spec-mcpv1alpha1-mcpserverspec-serverlistitem-error)
+- [`func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Team, error)`](#cli-platform-api-func-c-platformclient-createteam-ctx-context-context-slug-name-string-team-error)
 - [`func (c *PlatformClient) DeleteGrant(ctx context.Context, namespace, name string) error`](#cli-platform-api-func-c-platformclient-deletegrant-ctx-context-context-namespace-name-string-error)
 - [`func (c *PlatformClient) DeleteSession(ctx context.Context, namespace, name string) error`](#cli-platform-api-func-c-platformclient-deletesession-ctx-context-context-namespace-name-string-error)
 - [`func (c *PlatformClient) GetGrant(ctx context.Context, namespace, name string) (sentinelaccess.GrantSummary, error)`](#cli-platform-api-func-c-platformclient-getgrant-ctx-context-context-namespace-name-string-sentinelaccess-grantsummary-error)
 - [`func (c *PlatformClient) GetRuntimePolicy(ctx context.Context, namespace, server string) ([]byte, error)`](#cli-platform-api-func-c-platformclient-getruntimepolicy-ctx-context-context-namespace-server-string-byte-error)
 - [`func (c *PlatformClient) GetSession(ctx context.Context, namespace, name string) (sentinelaccess.SessionSummary, error)`](#cli-platform-api-func-c-platformclient-getsession-ctx-context-context-namespace-name-string-sentinelaccess-sessionsummary-error)
+- [`func (c *PlatformClient) GetTeam(ctx context.Context, slug string) (Team, error)`](#cli-platform-api-func-c-platformclient-getteam-ctx-context-context-slug-string-team-error)
 - [`func (c *PlatformClient) ListGrants(ctx context.Context, namespace string) ([]sentinelaccess.GrantSummary, error)`](#cli-platform-api-func-c-platformclient-listgrants-ctx-context-context-namespace-string-sentinelaccess-grantsummary-error)
+- [`func (c *PlatformClient) ListNamespaces(ctx context.Context) ([]namespaceListItem, error)`](#cli-platform-api-func-c-platformclient-listnamespaces-ctx-context-context-namespacelistitem-error)
 - [`func (c *PlatformClient) ListRuntimeServers(ctx context.Context, namespace string) ([]ServerListItem, error)`](#cli-platform-api-func-c-platformclient-listruntimeservers-ctx-context-context-namespace-string-serverlistitem-error)
 - [`func (c *PlatformClient) ListSessions(ctx context.Context, namespace string) ([]sentinelaccess.SessionSummary, error)`](#cli-platform-api-func-c-platformclient-listsessions-ctx-context-context-namespace-string-sentinelaccess-sessionsummary-error)
+- [`func (c *PlatformClient) ListTeams(ctx context.Context) ([]Team, error)`](#cli-platform-api-func-c-platformclient-listteams-ctx-context-context-team-error)
 - [`func (c *PlatformClient) PostGrantToggle(ctx context.Context, namespace, name, action string) error`](#cli-platform-api-func-c-platformclient-postgranttoggle-ctx-context-context-namespace-name-action-string-error)
 - [`func (c *PlatformClient) PostSessionToggle(ctx context.Context, namespace, name, action string) error`](#cli-platform-api-func-c-platformclient-postsessiontoggle-ctx-context-context-namespace-name-action-string-error)
 - [`type ServerListItem struct`](#cli-platform-api-type-serverlistitem-struct)
+- [`type Team struct`](#cli-platform-api-type-team-struct)
 
 <a id="cli-platform-api-functions"></a>
 ### Functions
@@ -3969,6 +3975,18 @@ func (c *PlatformClient) ApplyAccessFromYAMLFile(ctx context.Context, path strin
 
 ```
 
+<a id="cli-platform-api-func-c-platformclient-applyruntimeserver-ctx-context-context-name-namespace-string-spec-mcpv1alpha1-mcpserverspec-serverlistitem-error"></a>
+```text
+func (c *PlatformClient) ApplyRuntimeServer(ctx context.Context, name, namespace string, spec mcpv1alpha1.MCPServerSpec) (ServerListItem, error)
+
+```
+
+<a id="cli-platform-api-func-c-platformclient-createteam-ctx-context-context-slug-name-string-team-error"></a>
+```text
+func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Team, error)
+
+```
+
 <a id="cli-platform-api-func-c-platformclient-deletegrant-ctx-context-context-namespace-name-string-error"></a>
 ```text
 func (c *PlatformClient) DeleteGrant(ctx context.Context, namespace, name string) error
@@ -3999,9 +4017,21 @@ func (c *PlatformClient) GetSession(ctx context.Context, namespace, name string)
 
 ```
 
+<a id="cli-platform-api-func-c-platformclient-getteam-ctx-context-context-slug-string-team-error"></a>
+```text
+func (c *PlatformClient) GetTeam(ctx context.Context, slug string) (Team, error)
+
+```
+
 <a id="cli-platform-api-func-c-platformclient-listgrants-ctx-context-context-namespace-string-sentinelaccess-grantsummary-error"></a>
 ```text
 func (c *PlatformClient) ListGrants(ctx context.Context, namespace string) ([]sentinelaccess.GrantSummary, error)
+
+```
+
+<a id="cli-platform-api-func-c-platformclient-listnamespaces-ctx-context-context-namespacelistitem-error"></a>
+```text
+func (c *PlatformClient) ListNamespaces(ctx context.Context) ([]namespaceListItem, error)
 
 ```
 
@@ -4014,6 +4044,12 @@ func (c *PlatformClient) ListRuntimeServers(ctx context.Context, namespace strin
 <a id="cli-platform-api-func-c-platformclient-listsessions-ctx-context-context-namespace-string-sentinelaccess-sessionsummary-error"></a>
 ```text
 func (c *PlatformClient) ListSessions(ctx context.Context, namespace string) ([]sentinelaccess.SessionSummary, error)
+
+```
+
+<a id="cli-platform-api-func-c-platformclient-listteams-ctx-context-context-team-error"></a>
+```text
+func (c *PlatformClient) ListTeams(ctx context.Context) ([]Team, error)
 
 ```
 
@@ -4040,6 +4076,18 @@ type ServerListItem struct {
 	Age       string            `json:"age"`
 }
     ServerListItem is one row from the platform API runtime servers list.
+
+```
+
+<a id="cli-platform-api-type-team-struct"></a>
+```text
+type Team struct {
+	ID        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	CreatedAt time.Time `json:"created_at"`
+}
 ```
 
 <a id="cli-platform-status"></a>
@@ -4569,10 +4617,11 @@ Package server owns routing for the server top-level command.
 - [`func (m *ServerManager) CreateServer(name, namespace, image, imageTag string) error`](#cli-server-func-m-servermanager-createserver-name-namespace-image-imagetag-string-error)
 - [`func (m *ServerManager) CreateServerFromFile(file string) error`](#cli-server-func-m-servermanager-createserverfromfile-file-string-error)
 - [`func (m *ServerManager) DeleteServer(name, namespace string) error`](#cli-server-func-m-servermanager-deleteserver-name-namespace-string-error)
+- [`func (m *ServerManager) DeployServer(name, namespace, team, image, imageTag string, replicas, port, servicePort int32) error`](#cli-server-func-m-servermanager-deployserver-name-namespace-team-image-imagetag-string-replicas-port-serviceport-int32-error)
 - [`func (m *ServerManager) ExportServer(name, namespace, file string) error`](#cli-server-func-m-servermanager-exportserver-name-namespace-file-string-error)
 - [`func (m *ServerManager) GetServer(name, namespace string) error`](#cli-server-func-m-servermanager-getserver-name-namespace-string-error)
 - [`func (m *ServerManager) InspectServerPolicy(name, namespace string) error`](#cli-server-func-m-servermanager-inspectserverpolicy-name-namespace-string-error)
-- [`func (m *ServerManager) ListServers(namespace string) error`](#cli-server-func-m-servermanager-listservers-namespace-string-error)
+- [`func (m *ServerManager) ListServers(namespace, team string) error`](#cli-server-func-m-servermanager-listservers-namespace-team-string-error)
 - [`func (m *ServerManager) Logger() *zap.Logger`](#cli-server-func-m-servermanager-logger-zap-logger)
 - [`func (m *ServerManager) PatchServer(name, namespace, patchType, patch, patchFile string) error`](#cli-server-func-m-servermanager-patchserver-name-namespace-patchtype-patch-patchfile-string-error)
 - [`func (m *ServerManager) ServerStatus(namespace string) error`](#cli-server-func-m-servermanager-serverstatus-namespace-string-error)
@@ -4663,6 +4712,12 @@ func (m *ServerManager) DeleteServer(name, namespace string) error
 
 ```
 
+<a id="cli-server-func-m-servermanager-deployserver-name-namespace-team-image-imagetag-string-replicas-port-serviceport-int32-error"></a>
+```text
+func (m *ServerManager) DeployServer(name, namespace, team, image, imageTag string, replicas, port, servicePort int32) error
+
+```
+
 <a id="cli-server-func-m-servermanager-exportserver-name-namespace-file-string-error"></a>
 ```text
 func (m *ServerManager) ExportServer(name, namespace, file string) error
@@ -4685,9 +4740,9 @@ func (m *ServerManager) InspectServerPolicy(name, namespace string) error
 
 ```
 
-<a id="cli-server-func-m-servermanager-listservers-namespace-string-error"></a>
+<a id="cli-server-func-m-servermanager-listservers-namespace-team-string-error"></a>
 ```text
-func (m *ServerManager) ListServers(namespace string) error
+func (m *ServerManager) ListServers(namespace, team string) error
     ListServers lists all MCP servers in the given namespace.
 
 ```

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -123,7 +123,7 @@ metrics on `METRICS_PORT` (default `9090`).
 | `GET` | `/api/stats` | Total event count. Admin role required. |
 | `GET` | `/api/sources` | Event counts grouped by source. Admin role required. |
 | `GET` | `/api/event-types` | Event counts grouped by event type. Admin role required. |
-| `GET` | `/api/runtime/servers` | List MCP servers and connect config JSON. Non-admin users may read `mcp-servers` and their own namespace. Local test-mode configs use the browser origin, for example `http://localhost:18080/go-example-mcp/mcp`; production platform hosts map `platform.<domain>` to `https://mcp.<domain>/<server-name>/mcp`. |
+| `GET`, `POST` | `/api/runtime/servers` | List or apply `MCPServer` resources through runtime authz scope. Non-admin writes to shared `mcp-servers` are rejected; team users write within authorized team namespaces. |
 | `GET`, `POST` | `/api/runtime/grants` | List or apply `MCPAccessGrant` resources. |
 | `GET`, `DELETE` | `/api/runtime/grants/{namespace}/{name}` | Read or delete one grant. |
 | `POST` | `/api/runtime/grants/{namespace}/{name}/disable` | Set `spec.disabled=true`. |
@@ -132,6 +132,12 @@ metrics on `METRICS_PORT` (default `9090`).
 | `GET`, `DELETE` | `/api/runtime/sessions/{namespace}/{name}` | Read or delete one session. |
 | `POST` | `/api/runtime/sessions/{namespace}/{name}/revoke` | Set `spec.revoked=true`. |
 | `POST` | `/api/runtime/sessions/{namespace}/{name}/unrevoke` | Set `spec.revoked=false`. |
+| `GET`, `POST` | `/api/runtime/teams` | List teams (admin: all, user: memberships) or create a team+namespace (admin-only). |
+| `GET` | `/api/runtime/teams/{team}` | Read team metadata for admins and team members. |
+| `POST` | `/api/runtime/teams/{team}/members` | Add/update team membership (admin or team owner). |
+| `DELETE` | `/api/runtime/teams/{team}/members/{userID}` | Remove team membership (admin or team owner). |
+| `GET` | `/api/runtime/namespaces` | List allowed namespaces and shared catalog metadata for caller scope. |
+| `GET` | `/api/runtime/namespaces/{namespace}` | Read one namespace metadata entry when authorized. |
 | `GET` | `/api/runtime/components` | Operator, Sentinel service, and observability component health from Kubernetes. |
 | `GET` | `/api/runtime/policy?namespace=&server=` | Rendered gateway policy for one server. |
 | `POST` | `/api/runtime/actions/restart` | Restart one Sentinel component or all components. Admin role required. |

--- a/internal/cli/bootstrap/bootstrap.go
+++ b/internal/cli/bootstrap/bootstrap.go
@@ -22,7 +22,7 @@ func newManager(runtime *core.Runtime) *manager {
 func detectProvider(kubectl core.KubectlRunner) (string, error) {
 	out, err := kubectlOutput(kubectl, []string{"get", "nodes", "-o", "jsonpath={range .items[*]}{.status.nodeInfo.kubeletVersion}{\"\\n\"}{end}"})
 	if err != nil {
-		return "", core.WrapWithSentinel(core.ErrClusterNotAccessible, err, fmt.Sprintf("kubectl get nodes failed: %v", err))
+		return "", core.WrapWithSentinel(core.ErrClusterNotAccessible, err, formatKubectlFailure("kubectl get nodes failed", out, err))
 	}
 	lower := strings.ToLower(string(out))
 	switch {
@@ -40,8 +40,9 @@ func runBootstrapPreflight(kubectl core.KubectlRunner) error {
 	if err := kubectl.Run([]string{"version", "--client=true"}); err != nil {
 		return core.WrapWithSentinel(core.ErrClusterNotAccessible, err, fmt.Sprintf("kubectl not available: %v", err))
 	}
-	if err := kubectl.Run([]string{"get", "nodes"}); err != nil {
-		return core.WrapWithSentinel(core.ErrClusterNotAccessible, err, fmt.Sprintf("kubectl cannot reach cluster: %v", err))
+	out, err := kubectlOutput(kubectl, []string{"get", "nodes"})
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrClusterNotAccessible, err, formatKubectlFailure("kubectl cannot reach cluster", out, err))
 	}
 
 	core.Info("Preflight: CoreDNS")
@@ -132,6 +133,24 @@ func kubectlOutput(kubectl core.KubectlRunner, args []string) ([]byte, error) {
 		return nil, err
 	}
 	return cmd.CombinedOutput()
+}
+
+func formatKubectlFailure(prefix string, out []byte, err error) string {
+	detail := strings.TrimSpace(string(out))
+	if detail == "" {
+		detail = strings.TrimSpace(err.Error())
+	}
+	hint := ""
+	lower := strings.ToLower(detail)
+	switch {
+	case strings.Contains(lower, "connection refused"), strings.Contains(lower, " was refused"):
+		hint = " (kube-apiserver endpoint refused the connection; verify the active context points to a running cluster)"
+	case strings.Contains(lower, "no such host"), strings.Contains(lower, "name or service not known"):
+		hint = " (cluster endpoint hostname could not be resolved; verify kubeconfig server host/DNS)"
+	case strings.Contains(lower, "timeout"), strings.Contains(lower, "i/o timeout"):
+		hint = " (cluster endpoint timed out; verify network path and API server health)"
+	}
+	return fmt.Sprintf("%s: %s%s", prefix, detail, hint)
 }
 
 // New returns the bootstrap command.

--- a/internal/cli/bootstrap/bootstrap_test.go
+++ b/internal/cli/bootstrap/bootstrap_test.go
@@ -1,0 +1,42 @@
+package bootstrap
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mcp-runtime/internal/cli/core"
+)
+
+func TestDetectProviderReportsKubectlOutputOnFailure(t *testing.T) {
+	mock := &core.MockExecutor{
+		DefaultOutput: []byte(`The connection to the server 127.0.0.1:59146 was refused - did you specify the right host or port?`),
+		DefaultErr:    errors.New("exit status 1"),
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	_, err := detectProvider(kubectl)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"kubectl get nodes failed",
+		"127.0.0.1:59146",
+		"refused the connection",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestFormatKubectlFailureFallsBackToErrorString(t *testing.T) {
+	msg := formatKubectlFailure("kubectl cannot reach cluster", nil, errors.New("exit status 1"))
+	if !strings.Contains(msg, "kubectl cannot reach cluster") {
+		t.Fatalf("message = %q", msg)
+	}
+	if !strings.Contains(msg, "exit status 1") {
+		t.Fatalf("message = %q", msg)
+	}
+}

--- a/internal/cli/platformapi/client.go
+++ b/internal/cli/platformapi/client.go
@@ -25,7 +25,6 @@ import (
 )
 
 const maxAPIBodyRead = 4 << 20
-const defaultMCPServersNamespace = "mcp-servers"
 
 // errPlatformNoBaseURL is returned when a token exists but the API base URL is missing.
 var errPlatformNoBaseURL = errors.New("set MCP_PLATFORM_API_URL or run mcp-runtime auth login with --api-url to use the platform API")
@@ -442,12 +441,51 @@ type serverListResponse struct {
 	Servers []ServerListItem `json:"servers"`
 }
 
+type runtimeServerApplyRequest struct {
+	Name      string                    `json:"name"`
+	Namespace string                    `json:"namespace,omitempty"`
+	Labels    map[string]string         `json:"labels,omitempty"`
+	Spec      mcpv1alpha1.MCPServerSpec `json:"spec"`
+}
+
+type runtimeServerApplyResponse struct {
+	Server ServerListItem `json:"server"`
+}
+
+type Team struct {
+	ID        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type teamsResponse struct {
+	Teams []Team `json:"teams"`
+}
+
+type teamResponse struct {
+	Team Team `json:"team"`
+}
+
+type namespaceListItem struct {
+	Namespace string `json:"namespace"`
+	Scope     string `json:"scope,omitempty"`
+	TeamID    string `json:"team_id,omitempty"`
+	TeamSlug  string `json:"team_slug,omitempty"`
+	TeamName  string `json:"team_name,omitempty"`
+	TeamRole  string `json:"team_role,omitempty"`
+	IsShared  bool   `json:"is_shared,omitempty"`
+}
+
+type namespacesResponse struct {
+	Namespaces []namespaceListItem `json:"namespaces"`
+}
+
 func (c *PlatformClient) ListRuntimeServers(ctx context.Context, namespace string) ([]ServerListItem, error) {
 	v := url.Values{}
 	if strings.TrimSpace(namespace) != "" {
 		v.Set("namespace", namespace)
-	} else {
-		v.Set("namespace", defaultMCPServersNamespace)
 	}
 	resp, err := c.do(ctx, http.MethodGet, "/runtime/servers", v.Encode(), nil)
 	if err != nil {
@@ -466,6 +504,124 @@ func (c *PlatformClient) ListRuntimeServers(ctx context.Context, namespace strin
 		return nil, err
 	}
 	return out.Servers, nil
+}
+
+func (c *PlatformClient) ApplyRuntimeServer(ctx context.Context, name, namespace string, spec mcpv1alpha1.MCPServerSpec) (ServerListItem, error) {
+	body := runtimeServerApplyRequest{
+		Name:      strings.TrimSpace(name),
+		Namespace: strings.TrimSpace(namespace),
+		Spec:      spec,
+	}
+	js, err := json.Marshal(body)
+	if err != nil {
+		return ServerListItem{}, err
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/runtime/servers", "", bytes.NewReader(js))
+	if err != nil {
+		return ServerListItem{}, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return ServerListItem{}, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ServerListItem{}, httpAPIError(resp.StatusCode, b)
+	}
+	var out runtimeServerApplyResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return ServerListItem{}, err
+	}
+	return out.Server, nil
+}
+
+func (c *PlatformClient) ListTeams(ctx context.Context) ([]Team, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/runtime/teams", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, httpAPIError(resp.StatusCode, b)
+	}
+	var out teamsResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out.Teams, nil
+}
+
+func (c *PlatformClient) GetTeam(ctx context.Context, slug string) (Team, error) {
+	rel := "/runtime/teams/" + url.PathEscape(strings.TrimSpace(slug))
+	resp, err := c.do(ctx, http.MethodGet, rel, "", nil)
+	if err != nil {
+		return Team{}, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return Team{}, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Team{}, httpAPIError(resp.StatusCode, b)
+	}
+	var out teamResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return Team{}, err
+	}
+	return out.Team, nil
+}
+
+func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Team, error) {
+	payload := map[string]string{
+		"slug": strings.TrimSpace(slug),
+		"name": strings.TrimSpace(name),
+	}
+	js, err := json.Marshal(payload)
+	if err != nil {
+		return Team{}, err
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/runtime/teams", "", bytes.NewReader(js))
+	if err != nil {
+		return Team{}, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return Team{}, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Team{}, httpAPIError(resp.StatusCode, b)
+	}
+	var out teamResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return Team{}, err
+	}
+	return out.Team, nil
+}
+
+func (c *PlatformClient) ListNamespaces(ctx context.Context) ([]namespaceListItem, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/runtime/namespaces", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, httpAPIError(resp.StatusCode, b)
+	}
+	var out namespacesResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out.Namespaces, nil
 }
 
 func readFileAtPath(path string) ([]byte, error) {

--- a/internal/cli/platformapi/client_test.go
+++ b/internal/cli/platformapi/client_test.go
@@ -2,12 +2,15 @@ package platformapi
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
 )
 
 func TestApplyAccessFromYAMLFile_MultiDocument(t *testing.T) {
@@ -76,6 +79,82 @@ spec:
 	}
 	if grantCalls != 1 || sessionCalls != 1 {
 		t.Fatalf("calls = grant:%d session:%d, want 1/1", grantCalls, sessionCalls)
+	}
+}
+
+func TestPlatformClientTeamAndServerRoutes(t *testing.T) {
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Header.Get("x-api-key") != "token-1" {
+				t.Fatalf("x-api-key = %q, want token-1", r.Header.Get("x-api-key"))
+			}
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/runtime/teams":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"teams":[{"slug":"core","name":"Core","namespace":"mcp-team-core"}]}`)),
+				}, nil
+			case r.Method == http.MethodGet && r.URL.Path == "/api/runtime/teams/core":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"team":{"slug":"core","name":"Core","namespace":"mcp-team-core"}}`)),
+				}, nil
+			case r.Method == http.MethodPost && r.URL.Path == "/api/runtime/teams":
+				body, _ := io.ReadAll(r.Body)
+				var payload map[string]string
+				_ = json.Unmarshal(body, &payload)
+				if payload["slug"] != "core" || payload["name"] != "Core Team" {
+					t.Fatalf("create team payload = %#v", payload)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"team":{"slug":"core","name":"Core Team","namespace":"mcp-team-core"}}`)),
+				}, nil
+			case r.Method == http.MethodGet && r.URL.Path == "/api/runtime/servers":
+				if got := r.URL.Query().Get("namespace"); got != "" {
+					t.Fatalf("list runtime servers namespace query = %q, want empty", got)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"servers":[]}`)),
+				}, nil
+			case r.Method == http.MethodPost && r.URL.Path == "/api/runtime/servers":
+				body, _ := io.ReadAll(r.Body)
+				var payload map[string]any
+				_ = json.Unmarshal(body, &payload)
+				if payload["name"] != "demo" {
+					t.Fatalf("server name payload = %#v", payload)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"server":{"name":"demo","namespace":"mcp-team-core"}}`)),
+				}, nil
+			default:
+				t.Fatalf("unexpected route %s %s", r.Method, r.URL.Path)
+				return nil, nil
+			}
+		}),
+	}
+	client := &PlatformClient{
+		baseURL:   "https://platform.example.com",
+		token:     "token-1",
+		http:      httpClient,
+		apiPrefix: "/api",
+	}
+	if _, err := client.ListTeams(context.Background()); err != nil {
+		t.Fatalf("ListTeams() error = %v", err)
+	}
+	if _, err := client.GetTeam(context.Background(), "core"); err != nil {
+		t.Fatalf("GetTeam() error = %v", err)
+	}
+	if _, err := client.CreateTeam(context.Background(), "core", "Core Team"); err != nil {
+		t.Fatalf("CreateTeam() error = %v", err)
+	}
+	if _, err := client.ListRuntimeServers(context.Background(), ""); err != nil {
+		t.Fatalf("ListRuntimeServers() error = %v", err)
+	}
+	if _, err := client.ApplyRuntimeServer(context.Background(), "demo", "mcp-team-core", mcpv1alpha1.MCPServerSpec{Image: "registry.example/core/demo", ImageTag: "latest"}); err != nil {
+		t.Fatalf("ApplyRuntimeServer() error = %v", err)
 	}
 }
 

--- a/internal/cli/root/commands.go
+++ b/internal/cli/root/commands.go
@@ -15,6 +15,7 @@ import (
 	"mcp-runtime/internal/cli/server"
 	"mcp-runtime/internal/cli/setup"
 	"mcp-runtime/internal/cli/status"
+	"mcp-runtime/internal/cli/team"
 )
 
 // AddCommands registers every top-level mcp-runtime command on root.
@@ -32,4 +33,5 @@ func AddCommands(root *cobra.Command, logger *zap.Logger) {
 	root.AddCommand(status.New(runtime))
 	root.AddCommand(sentinel.New(runtime))
 	root.AddCommand(pipeline.New(runtime))
+	root.AddCommand(team.New(runtime))
 }

--- a/internal/cli/root/commands_test.go
+++ b/internal/cli/root/commands_test.go
@@ -23,6 +23,7 @@ func TestAddCommandsRegistersTopLevelCommands(t *testing.T) {
 		"status",
 		"sentinel",
 		"pipeline",
+		"team",
 	}
 	got := root.Commands()
 	if len(got) != len(want) {

--- a/internal/cli/server/manager.go
+++ b/internal/cli/server/manager.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
+	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
 	"mcp-runtime/internal/cli/core"
 	"mcp-runtime/internal/cli/kube"
 	"mcp-runtime/internal/cli/kubeerr"
@@ -65,17 +66,30 @@ func (m *ServerManager) Logger() *zap.Logger {
 }
 
 // ListServers lists all MCP servers in the given namespace.
-func (m *ServerManager) ListServers(namespace string) error {
-	namespace, err := validateManifestValue("namespace", namespace)
-	if err != nil {
-		return err
+func (m *ServerManager) ListServers(namespace, team string) error {
+	namespace = strings.TrimSpace(namespace)
+	team = strings.TrimSpace(team)
+	if namespace != "" && team != "" {
+		return core.NewWithSentinel(nil, "use either --namespace or --team, not both")
 	}
-
 	plat, useK, err := platformapi.ResolvePlatformOrKube(m.useKube)
 	if err != nil {
 		return err
 	}
 	if !useK {
+		if team != "" {
+			t, err := plat.GetTeam(context.Background(), team)
+			if err != nil {
+				return err
+			}
+			namespace = t.Namespace
+		}
+		if namespace != "" {
+			namespace, err = validateManifestValue("namespace", namespace)
+			if err != nil {
+				return err
+			}
+		}
 		items, err := plat.ListRuntimeServers(context.Background(), namespace)
 		if err != nil {
 			return err
@@ -87,6 +101,13 @@ func (m *ServerManager) ListServers(namespace string) error {
 		}
 		_ = tw.Flush()
 		return nil
+	}
+	if namespace == "" {
+		namespace = core.NamespaceMCPServers
+	}
+	namespace, err = validateManifestValue("namespace", namespace)
+	if err != nil {
+		return err
 	}
 
 	// #nosec G204 -- namespace validated above; kubectl validates resource names.
@@ -209,6 +230,61 @@ func (m *ServerManager) CreateServer(name, namespace, image, imageTag string) er
 		core.LogStructuredError(m.logger, wrappedErr, "Failed to create server")
 		return wrappedErr
 	}
+	return nil
+}
+
+func (m *ServerManager) DeployServer(name, namespace, team, image, imageTag string, replicas, port, servicePort int32) error {
+	if m.useKube {
+		return core.NewWithSentinel(nil, "server deploy uses the platform API; remove --use-kube")
+	}
+	name, err := validateManifestValue("name", name)
+	if err != nil {
+		return err
+	}
+	image, err = validateManifestValue("image", image)
+	if err != nil {
+		return err
+	}
+	imageTag, err = validateManifestValue("tag", imageTag)
+	if err != nil {
+		return err
+	}
+	namespace = strings.TrimSpace(namespace)
+	team = strings.TrimSpace(team)
+	if namespace != "" && team != "" {
+		return core.NewWithSentinel(nil, "use either --namespace or --team, not both")
+	}
+	plat, err := platformapi.NewPlatformClient()
+	if err != nil {
+		return err
+	}
+	if team != "" {
+		t, err := plat.GetTeam(context.Background(), team)
+		if err != nil {
+			return err
+		}
+		namespace = t.Namespace
+	}
+	if namespace != "" {
+		namespace, err = validateManifestValue("namespace", namespace)
+		if err != nil {
+			return err
+		}
+	}
+	spec := mcpv1alpha1.MCPServerSpec{
+		Image:            image,
+		ImageTag:         imageTag,
+		Replicas:         &replicas,
+		Port:             port,
+		ServicePort:      servicePort,
+		PublicPathPrefix: name,
+		IngressPath:      "/" + name + "/mcp",
+	}
+	applied, err := plat.ApplyRuntimeServer(context.Background(), name, namespace, spec)
+	if err != nil {
+		return err
+	}
+	core.Success(fmt.Sprintf("Deployed server %s in namespace %s", applied.Name, applied.Namespace))
 	return nil
 }
 

--- a/internal/cli/server/manager.go
+++ b/internal/cli/server/manager.go
@@ -76,6 +76,9 @@ func (m *ServerManager) ListServers(namespace, team string) error {
 	if err != nil {
 		return err
 	}
+	if useK && team != "" {
+		return core.NewWithSentinel(nil, "cannot use --team with --use-kube")
+	}
 	if !useK {
 		if team != "" {
 			t, err := plat.GetTeam(context.Background(), team)

--- a/internal/cli/server/manager_test.go
+++ b/internal/cli/server/manager_test.go
@@ -93,6 +93,23 @@ func TestServerManager_ListServers(t *testing.T) {
 			t.Errorf("expected default namespace %q in args, got %v", core.NamespaceMCPServers, cmd.Args)
 		}
 	})
+
+	t.Run("rejects --team when using kubectl mode", func(t *testing.T) {
+		mock := &core.MockExecutor{}
+		kubectl := core.NewTestKubectlClient(mock)
+		mgr := NewServerManager(kubectl, zap.NewNop())
+
+		err := mgr.ListServers("", "team-a")
+		if err == nil {
+			t.Fatal("expected error when team is set in --use-kube mode")
+		}
+		if !strings.Contains(err.Error(), "cannot use --team with --use-kube") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(mock.Commands) != 0 {
+			t.Fatalf("expected no kubectl command on validation error, got %d", len(mock.Commands))
+		}
+	})
 }
 
 func TestServerManager_DeleteServer(t *testing.T) {

--- a/internal/cli/server/manager_test.go
+++ b/internal/cli/server/manager_test.go
@@ -22,7 +22,7 @@ func TestServerManager_ListServers(t *testing.T) {
 		kubectl := core.NewTestKubectlClient(mock)
 		mgr := NewServerManager(kubectl, zap.NewNop())
 
-		err := mgr.ListServers("test-ns")
+		err := mgr.ListServers("test-ns", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -54,7 +54,7 @@ func TestServerManager_ListServers(t *testing.T) {
 		kubectl := core.NewTestKubectlClient(mock)
 		mgr := NewServerManager(kubectl, zap.NewNop())
 
-		err := mgr.ListServers(" test-ns ")
+		err := mgr.ListServers(" test-ns ", "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -77,12 +77,20 @@ func TestServerManager_ListServers(t *testing.T) {
 		kubectl := core.NewTestKubectlClient(mock)
 		mgr := NewServerManager(kubectl, zap.NewNop())
 
-		err := mgr.ListServers("   ")
-		if err == nil {
-			t.Fatal("expected error for empty namespace")
+		err := mgr.ListServers("   ", "")
+		if err != nil {
+			t.Fatalf("unexpected error for empty namespace: %v", err)
 		}
-		if len(mock.Commands) > 0 {
-			t.Error("should not call kubectl with empty namespace")
+		cmd := mock.LastCommand()
+		found := false
+		for i, arg := range cmd.Args {
+			if arg == "-n" && i+1 < len(cmd.Args) && cmd.Args[i+1] == core.NamespaceMCPServers {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected default namespace %q in args, got %v", core.NamespaceMCPServers, cmd.Args)
 		}
 	})
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -2,6 +2,8 @@
 package server
 
 import (
+	"math"
+
 	"github.com/spf13/cobra"
 
 	"mcp-runtime/internal/cli/core"
@@ -107,7 +109,7 @@ For pushing images, use 'registry push'.`,
 	deployCmd.Flags().StringVar(&deployImage, "image", "", "Container image repository")
 	deployCmd.Flags().StringVar(&deployTag, "tag", "latest", "Container image tag")
 	deployCmd.Flags().Int32Var(&deployReplicas, "replicas", 1, "Replica count")
-	deployCmd.Flags().Int32Var(&deployPort, "port", int32(core.GetDefaultServerPort()), "Container port")
+	deployCmd.Flags().Int32Var(&deployPort, "port", defaultDeployPort(), "Container port")
 	deployCmd.Flags().Int32Var(&deployServicePort, "service-port", 80, "Service port")
 	_ = deployCmd.MarkFlagRequired("image")
 
@@ -208,4 +210,12 @@ For pushing images, use 'registry push'.`,
 
 	cmd.AddCommand(listCmd, getCmd, createCmd, applyCmd, deployCmd, exportCmd, patchCmd, deleteCmd, logsCmd, statusCmd, policyCmd, buildCmd)
 	return cmd
+}
+
+func defaultDeployPort() int32 {
+	port := core.GetDefaultServerPort()
+	if port <= 0 || port > math.MaxInt32 {
+		return 8088
+	}
+	return int32(port)
 }

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -30,15 +30,17 @@ For pushing images, use 'registry push'.`,
 	mgr.BindUseKubeFlag(cmd)
 
 	var namespace string
+	var team string
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List MCP servers",
 		Long:  "List all MCP server deployments",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return mgr.ListServers(namespace)
+			return mgr.ListServers(namespace, team)
 		},
 	}
-	listCmd.Flags().StringVar(&namespace, "namespace", core.NamespaceMCPServers, "Namespace to list servers from")
+	listCmd.Flags().StringVar(&namespace, "namespace", "", "Namespace to list servers from")
+	listCmd.Flags().StringVar(&team, "team", "", "Team slug to resolve namespace from via the platform API")
 
 	var getNamespace string
 	getCmd := &cobra.Command{
@@ -83,6 +85,31 @@ For pushing images, use 'registry push'.`,
 	}
 	applyCmd.Flags().StringVar(&applyFile, "file", "", "YAML file with MCPServer manifest")
 	_ = applyCmd.MarkFlagRequired("file")
+
+	var deployNamespace string
+	var deployTeam string
+	var deployImage string
+	var deployTag string
+	var deployReplicas int32
+	var deployPort int32
+	var deployServicePort int32
+	deployCmd := &cobra.Command{
+		Use:   "deploy [name]",
+		Short: "Deploy an MCP server through the platform API",
+		Long:  "Apply an MCPServer resource using the authenticated platform API identity.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mgr.DeployServer(args[0], deployNamespace, deployTeam, deployImage, deployTag, deployReplicas, deployPort, deployServicePort)
+		},
+	}
+	deployCmd.Flags().StringVar(&deployNamespace, "namespace", "", "Target namespace (optional when --team is provided)")
+	deployCmd.Flags().StringVar(&deployTeam, "team", "", "Team slug to resolve target namespace")
+	deployCmd.Flags().StringVar(&deployImage, "image", "", "Container image repository")
+	deployCmd.Flags().StringVar(&deployTag, "tag", "latest", "Container image tag")
+	deployCmd.Flags().Int32Var(&deployReplicas, "replicas", 1, "Replica count")
+	deployCmd.Flags().Int32Var(&deployPort, "port", int32(core.GetDefaultServerPort()), "Container port")
+	deployCmd.Flags().Int32Var(&deployServicePort, "service-port", 80, "Service port")
+	_ = deployCmd.MarkFlagRequired("image")
 
 	var exportNamespace string
 	var exportFile string
@@ -179,6 +206,6 @@ For pushing images, use 'registry push'.`,
 	}
 	buildCmd.AddCommand(newBuildImageCmd(mgr.Logger()))
 
-	cmd.AddCommand(listCmd, getCmd, createCmd, applyCmd, exportCmd, patchCmd, deleteCmd, logsCmd, statusCmd, policyCmd, buildCmd)
+	cmd.AddCommand(listCmd, getCmd, createCmd, applyCmd, deployCmd, exportCmd, patchCmd, deleteCmd, logsCmd, statusCmd, policyCmd, buildCmd)
 	return cmd
 }

--- a/internal/cli/team/manager.go
+++ b/internal/cli/team/manager.go
@@ -1,0 +1,59 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"go.uber.org/zap"
+
+	"mcp-runtime/internal/cli/core"
+	"mcp-runtime/internal/cli/platformapi"
+)
+
+type Manager struct {
+	logger *zap.Logger
+}
+
+func NewManager(logger *zap.Logger) *Manager {
+	return &Manager{logger: logger}
+}
+
+func (m *Manager) ListTeams() error {
+	client, err := platformapi.NewPlatformClient()
+	if err != nil {
+		return err
+	}
+	teams, err := client.ListTeams(context.Background())
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "SLUG\tNAME\tNAMESPACE")
+	for _, team := range teams {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\n", team.Slug, team.Name, team.Namespace)
+	}
+	_ = tw.Flush()
+	return nil
+}
+
+func (m *Manager) CreateTeam(slug, name string) error {
+	client, err := platformapi.NewPlatformClient()
+	if err != nil {
+		return err
+	}
+	slug = strings.TrimSpace(slug)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = slug
+	}
+	team, err := client.CreateTeam(context.Background(), slug, name)
+	if err != nil {
+		return err
+	}
+	core.Success(fmt.Sprintf("Created team %s (namespace: %s)", team.Slug, team.Namespace))
+	return nil
+}

--- a/internal/cli/team/team.go
+++ b/internal/cli/team/team.go
@@ -1,0 +1,41 @@
+package team
+
+import (
+	"github.com/spf13/cobra"
+
+	"mcp-runtime/internal/cli/core"
+)
+
+func New(runtime *core.Runtime) *cobra.Command {
+	return NewWithManager(NewManager(runtime.Logger()))
+}
+
+func NewWithManager(mgr *Manager) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team",
+		Short: "Manage internal platform teams",
+		Long:  "Create and list internal teams through the platform API.",
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List teams",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mgr.ListTeams()
+		},
+	}
+
+	var name string
+	createCmd := &cobra.Command{
+		Use:   "create [slug]",
+		Short: "Create a team and managed namespace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mgr.CreateTeam(args[0], name)
+		},
+	}
+	createCmd.Flags().StringVar(&name, "name", "", "Display name for the team (defaults to slug)")
+
+	cmd.AddCommand(listCmd, createCmd)
+	return cmd
+}

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -89,6 +89,7 @@ type resourceReadiness = operatorutil.ResourceReadiness
 //+kubebuilder:rbac:groups=mcpruntime.org,resources=mcpservers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingressclasses,verbs=get;list;watch
@@ -359,6 +360,9 @@ func (r *MCPServerReconciler) reconcileDeployment(ctx context.Context, mcpServer
 	if err != nil {
 		return err
 	}
+	if err := r.ensureWorkloadServiceAccount(ctx, mcpServer.Namespace); err != nil {
+		return err
+	}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -447,6 +451,9 @@ func (r *MCPServerReconciler) reconcileCanaryDeployment(ctx context.Context, mcp
 	logger := log.FromContext(ctx)
 	image, err := r.resolveImage(ctx, mcpServer)
 	if err != nil {
+		return err
+	}
+	if err := r.ensureWorkloadServiceAccount(ctx, mcpServer.Namespace); err != nil {
 		return err
 	}
 
@@ -649,6 +656,20 @@ func applyContainerResources(container *corev1.Container, resources mcpv1alpha1.
 	}
 
 	return nil
+}
+
+func (r *MCPServerReconciler) ensureWorkloadServiceAccount(ctx context.Context, namespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultWorkloadServiceAccount,
+			Namespace: namespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, sa, func() error {
+		sa.AutomountServiceAccountToken = boolPtr(false)
+		return nil
+	})
+	return err
 }
 
 func (r *MCPServerReconciler) resolveImage(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer) (string, error) {

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -73,11 +73,12 @@ const (
 )
 
 const (
-	gatewayPolicyVolumeName = "gateway-policy"
-	gatewayPolicyMountDir   = "/var/run/mcp-runtime/policy"
-	gatewayPolicyFileName   = "policy.json"
-	gatewayPolicyFilePath   = gatewayPolicyMountDir + "/" + gatewayPolicyFileName
-	restrictedRunAsUser     = int64(65532)
+	gatewayPolicyVolumeName       = "gateway-policy"
+	gatewayPolicyMountDir         = "/var/run/mcp-runtime/policy"
+	gatewayPolicyFileName         = "policy.json"
+	gatewayPolicyFilePath         = gatewayPolicyMountDir + "/" + gatewayPolicyFileName
+	restrictedRunAsUser           = int64(65532)
+	defaultWorkloadServiceAccount = "mcp-workload"
 )
 
 // resourceReadiness tracks the readiness state of different resources.
@@ -398,6 +399,7 @@ func (r *MCPServerReconciler) reconcileDeployment(ctx context.Context, mcpServer
 			return err
 		}
 		deployment.Spec.Template.Spec = corev1.PodSpec{
+			ServiceAccountName:           defaultWorkloadServiceAccount,
 			AutomountServiceAccountToken: boolPtr(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: boolPtr(true),
@@ -486,6 +488,7 @@ func (r *MCPServerReconciler) reconcileCanaryDeployment(ctx context.Context, mcp
 			return err
 		}
 		deployment.Spec.Template.Spec = corev1.PodSpec{
+			ServiceAccountName:           defaultWorkloadServiceAccount,
 			AutomountServiceAccountToken: boolPtr(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: boolPtr(true),

--- a/internal/operator/controller_test.go
+++ b/internal/operator/controller_test.go
@@ -484,6 +484,9 @@ func TestReconcileDeploymentLabels(t *testing.T) {
 	if deployment.Spec.Template.Spec.AutomountServiceAccountToken == nil || *deployment.Spec.Template.Spec.AutomountServiceAccountToken {
 		t.Fatal("expected MCPServer pods to disable service account token automount")
 	}
+	if deployment.Spec.Template.Spec.ServiceAccountName != defaultWorkloadServiceAccount {
+		t.Fatalf("serviceAccountName = %q, want %q", deployment.Spec.Template.Spec.ServiceAccountName, defaultWorkloadServiceAccount)
+	}
 	if deployment.Spec.Template.Spec.SecurityContext == nil || deployment.Spec.Template.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatal("expected MCPServer pod security context with seccomp profile")
 	}

--- a/k8s/08-api-rbac.yaml
+++ b/k8s/08-api-rbac.yaml
@@ -29,9 +29,9 @@ rules:
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "delete"]
-  # User namespace provisioning guardrails
+  # User/team namespace provisioning guardrails
   - apiGroups: [""]
-    resources: ["namespaces", "resourcequotas", "limitranges"]
+    resources: ["namespaces", "resourcequotas", "limitranges", "serviceaccounts"]
     verbs: ["get", "list", "watch", "create"]
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
@@ -53,10 +53,10 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-  # Read MCPServer resources
+  # MCPServer lifecycle via /api/runtime/servers and scoped runtime flows
   - apiGroups: ["mcpruntime.org"]
     resources: ["mcpservers"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/services/api/authz.go
+++ b/services/api/authz.go
@@ -11,17 +11,63 @@ const (
 )
 
 type principal struct {
+	Role              string          `json:"role"`
+	Subject           string          `json:"subject,omitempty"`
+	Email             string          `json:"email,omitempty"`
+	Namespace         string          `json:"namespace,omitempty"`
+	AllowedNamespaces []string        `json:"allowed_namespaces,omitempty"`
+	Teams             []principalTeam `json:"teams,omitempty"`
+	AuthType          string          `json:"auth_type,omitempty"`
+	APIKeyID          string          `json:"api_key_id,omitempty"`
+	IsService         bool            `json:"is_service,omitempty"`
+}
+
+type principalTeam struct {
+	ID        string `json:"id"`
+	Slug      string `json:"slug"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 	Role      string `json:"role"`
-	Subject   string `json:"subject,omitempty"`
-	Email     string `json:"email,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	AuthType  string `json:"auth_type,omitempty"`
-	APIKeyID  string `json:"api_key_id,omitempty"`
-	IsService bool   `json:"is_service,omitempty"`
 }
 
 func (p principal) userID() string {
 	return strings.TrimSpace(p.Subject)
+}
+
+func (p principal) hasNamespace(namespace string) bool {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return false
+	}
+	if strings.TrimSpace(p.Namespace) == namespace {
+		return true
+	}
+	for _, allowed := range p.AllowedNamespaces {
+		if strings.TrimSpace(allowed) == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+func (p principal) teamRole(slug string) string {
+	slug = strings.TrimSpace(slug)
+	for _, team := range p.Teams {
+		if strings.TrimSpace(team.Slug) == slug {
+			return strings.TrimSpace(team.Role)
+		}
+	}
+	return ""
+}
+
+func (p principal) teamForNamespace(namespace string) (principalTeam, bool) {
+	namespace = strings.TrimSpace(namespace)
+	for _, team := range p.Teams {
+		if strings.TrimSpace(team.Namespace) == namespace {
+			return team, true
+		}
+	}
+	return principalTeam{}, false
 }
 
 type principalContextKey struct{}

--- a/services/api/deployments.go
+++ b/services/api/deployments.go
@@ -350,17 +350,24 @@ func (s *RuntimeServer) ensureManagedNamespace(ctx context.Context, namespace st
 }
 
 func ensureWorkloadServiceAccount(ctx context.Context, client kubernetes.Interface, namespace string) error {
-	sa := &corev1.ServiceAccount{
+	desired := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultWorkloadServiceAccount,
 			Namespace: namespace,
 		},
 		AutomountServiceAccountToken: boolPtr(false),
 	}
-	if _, err := client.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+	existing, err := client.CoreV1().ServiceAccounts(namespace).Get(ctx, defaultWorkloadServiceAccount, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, createErr := client.CoreV1().ServiceAccounts(namespace).Create(ctx, desired, metav1.CreateOptions{})
+		return createErr
+	}
+	if err != nil {
 		return err
 	}
-	return nil
+	existing.AutomountServiceAccountToken = boolPtr(false)
+	_, err = client.CoreV1().ServiceAccounts(namespace).Update(ctx, existing, metav1.UpdateOptions{})
+	return err
 }
 
 func ensureResourceQuota(ctx context.Context, client kubernetes.Interface, ns string) error {

--- a/services/api/deployments.go
+++ b/services/api/deployments.go
@@ -21,11 +21,15 @@ import (
 )
 
 const (
-	platformManagedLabel = "platform.mcpruntime.org/managed"
-	platformUserIDLabel  = "platform.mcpruntime.org/user-id"
-	createdByLabel       = "created-by"
-	defaultDeployPort    = int32(8088)
-	restrictedRunAsUser  = int64(65532)
+	platformManagedLabel          = "platform.mcpruntime.org/managed"
+	platformUserIDLabel           = "platform.mcpruntime.org/user-id"
+	platformTeamIDLabel           = "mcpruntime.org/team-id"
+	platformTeamSlugLabel         = "mcpruntime.org/team-slug"
+	platformScopeLabel            = "mcpruntime.org/scope"
+	createdByLabel                = "created-by"
+	defaultDeployPort             = int32(8088)
+	restrictedRunAsUser           = int64(65532)
+	defaultWorkloadServiceAccount = "mcp-workload"
 )
 
 var errPrincipalIdentityRequired = errors.New("authenticated user identity required")
@@ -67,7 +71,7 @@ func (s *RuntimeServer) handleDeploymentItem(w http.ResponseWriter, r *http.Requ
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	if p.Role != roleAdmin && ns != p.Namespace {
+	if p.Role != roleAdmin && (!p.hasNamespace(ns) || ns == sharedCatalogNamespace) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
 		return
 	}
@@ -103,9 +107,19 @@ func (s *RuntimeServer) handleDeploymentList(w http.ResponseWriter, r *http.Requ
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
 		return
 	}
-	namespace := p.Namespace
-	if p.Role == roleAdmin {
-		namespace = strings.TrimSpace(r.URL.Query().Get("namespace"))
+	namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	if p.Role != roleAdmin {
+		if namespace == "" {
+			namespace = strings.TrimSpace(p.Namespace)
+		}
+		if namespace == "" {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			return
+		}
+		if !p.hasNamespace(namespace) || namespace == sharedCatalogNamespace {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			return
+		}
 	}
 	client, err := s.clientForPrincipal(p)
 	if err != nil {
@@ -187,11 +201,14 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	if p.Role == roleAdmin && strings.TrimSpace(req.Namespace) != "" {
 		namespace = strings.TrimSpace(req.Namespace)
 	}
+	if p.Role != roleAdmin && strings.TrimSpace(req.Namespace) != "" {
+		namespace = strings.TrimSpace(req.Namespace)
+	}
 	if namespace == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace required"})
 		return
 	}
-	if p.Role != roleAdmin && namespace != p.Namespace {
+	if p.Role != roleAdmin && (!p.hasNamespace(namespace) || namespace == sharedCatalogNamespace) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
 		return
 	}
@@ -199,7 +216,12 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	if req.Version != "" && !strings.Contains(image[strings.LastIndex(image, "/")+1:], ":") {
 		image += ":" + req.Version
 	}
-	if err := validateDeployImage(image, namespace, p.Role); err != nil {
+	team, teamNamespace := p.teamForNamespace(namespace)
+	teamSlug := ""
+	if teamNamespace {
+		teamSlug = strings.TrimSpace(team.Slug)
+	}
+	if err := validateDeployImage(image, namespace, teamSlug, p.Role); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
@@ -216,9 +238,21 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	defer cancel()
 	target := p
 	target.Namespace = namespace
-	if err := s.ensureUserNamespace(ctx, target); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to ensure namespace"})
-		return
+	if teamNamespace {
+		if err := s.ensureTeamNamespace(ctx, teamRecord{
+			ID:        team.ID,
+			Slug:      team.Slug,
+			Name:      team.Name,
+			Namespace: team.Namespace,
+		}); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to ensure team namespace"})
+			return
+		}
+	} else {
+		if err := s.ensureUserNamespace(ctx, target); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to ensure namespace"})
+			return
+		}
 	}
 	labels := map[string]string{
 		"app.kubernetes.io/name":       req.Name,
@@ -226,6 +260,11 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 		platformManagedLabel:           "true",
 		platformUserIDLabel:            p.userID(),
 		createdByLabel:                 p.userID(),
+	}
+	if teamNamespace {
+		labels[platformTeamIDLabel] = team.ID
+		labels[platformTeamSlugLabel] = team.Slug
+		labels[platformScopeLabel] = namespaceScopeTeam
 	}
 	dep := desiredDeployment(req.Name, namespace, image, req.Port, req.Replicas, labels)
 	applied, err := upsertDeployment(ctx, client, dep)
@@ -263,25 +302,65 @@ func (s *RuntimeServer) ensureUserNamespace(ctx context.Context, p principal) er
 	if s.k8sClients == nil || p.Namespace == "" {
 		return nil
 	}
+	labels := map[string]string{
+		platformManagedLabel:                 "true",
+		platformUserIDLabel:                  p.userID(),
+		platformScopeLabel:                   namespaceScopeUser,
+		"pod-security.kubernetes.io/enforce": "restricted",
+	}
+	return s.ensureManagedNamespace(ctx, p.Namespace, labels)
+}
+
+func (s *RuntimeServer) ensureTeamNamespace(ctx context.Context, team teamRecord) error {
+	if strings.TrimSpace(team.Namespace) == "" {
+		return errors.New("team namespace required")
+	}
+	labels := map[string]string{
+		platformManagedLabel:                 "true",
+		platformTeamIDLabel:                  strings.TrimSpace(team.ID),
+		platformTeamSlugLabel:                strings.TrimSpace(team.Slug),
+		platformScopeLabel:                   namespaceScopeTeam,
+		"pod-security.kubernetes.io/enforce": "restricted",
+	}
+	return s.ensureManagedNamespace(ctx, team.Namespace, labels)
+}
+
+func (s *RuntimeServer) ensureManagedNamespace(ctx context.Context, namespace string, labels map[string]string) error {
+	if s.k8sClients == nil || strings.TrimSpace(namespace) == "" {
+		return nil
+	}
 	base := s.k8sClients.Clientset
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: p.Namespace,
-		Labels: map[string]string{
-			platformManagedLabel:                 "true",
-			platformUserIDLabel:                  p.userID(),
-			"pod-security.kubernetes.io/enforce": "restricted",
-		},
+		Name:   namespace,
+		Labels: labels,
 	}}
 	if _, err := base.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
-	if err := ensureResourceQuota(ctx, base, p.Namespace); err != nil {
+	if err := ensureResourceQuota(ctx, base, namespace); err != nil {
 		return err
 	}
-	if err := ensureLimitRange(ctx, base, p.Namespace); err != nil {
+	if err := ensureLimitRange(ctx, base, namespace); err != nil {
 		return err
 	}
-	return ensureDefaultDenyNetworkPolicy(ctx, base, p.Namespace)
+	if err := ensureDefaultDenyNetworkPolicy(ctx, base, namespace); err != nil {
+		return err
+	}
+	return ensureWorkloadServiceAccount(ctx, base, namespace)
+}
+
+func ensureWorkloadServiceAccount(ctx context.Context, client kubernetes.Interface, namespace string) error {
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultWorkloadServiceAccount,
+			Namespace: namespace,
+		},
+		AutomountServiceAccountToken: boolPtr(false),
+	}
+	if _, err := client.CoreV1().ServiceAccounts(namespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }
 
 func ensureResourceQuota(ctx context.Context, client kubernetes.Interface, ns string) error {
@@ -369,6 +448,7 @@ func desiredDeployment(name, namespace, image string, port, replicas int32, labe
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{Labels: labels},
 			Spec: corev1.PodSpec{
+				ServiceAccountName:           defaultWorkloadServiceAccount,
 				AutomountServiceAccountToken: boolPtr(false),
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: boolPtr(true),
@@ -442,7 +522,7 @@ func upsertService(ctx context.Context, client kubernetes.Interface, svc *corev1
 	return client.CoreV1().Services(svc.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
 }
 
-func validateDeployImage(image, namespace, role string) error {
+func validateDeployImage(image, namespace, teamSlug, role string) error {
 	parts := strings.Split(image, "/")
 	if len(parts) < 2 {
 		return fmt.Errorf("image must include a registry/repository path")
@@ -453,8 +533,14 @@ func validateDeployImage(image, namespace, role string) error {
 			return fmt.Errorf("registry %q is not approved", host)
 		}
 	}
-	if role != roleAdmin && len(parts) >= 3 && parts[1] != namespace {
-		return fmt.Errorf("image repository must be scoped to namespace %q", namespace)
+	if role != roleAdmin && len(parts) >= 3 {
+		expected := namespace
+		if strings.TrimSpace(teamSlug) != "" {
+			expected = teamSlug
+		}
+		if parts[1] != expected {
+			return fmt.Errorf("image repository must be scoped to %q", expected)
+		}
 	}
 	return nil
 }

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -294,7 +294,7 @@ func main() {
 	mux.Handle("/api/user/registry-credentials/", server.auth(http.HandlerFunc(server.handleRegistryCredentialItem)))
 
 	// Initialize and register runtime server with Kubernetes support
-	runtimeServer, err := NewRuntimeServer(conn, dbName, apiKeys)
+	runtimeServer, err := NewRuntimeServer(conn, dbName, apiKeys, server.platform)
 	if err != nil {
 		server.runtimeInit = err.Error()
 		log.Printf("ERROR: runtime server initialization failed: %v", err)
@@ -306,6 +306,10 @@ func main() {
 		// Register all runtime endpoints with auth
 		mux.Handle("/api/dashboard/summary", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.handleDashboardSummary))))
 		mux.Handle("/api/runtime/servers", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeServers)))
+		mux.Handle("/api/runtime/teams", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeTeams)))
+		mux.Handle("/api/runtime/teams/", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeTeamItemPath)))
+		mux.Handle("/api/runtime/namespaces", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeNamespaces)))
+		mux.Handle("/api/runtime/namespaces/", server.auth(http.HandlerFunc(runtimeServer.handleRuntimeNamespaceItem)))
 		mux.Handle("/api/deployments", server.auth(http.HandlerFunc(runtimeServer.handleDeployments)))
 		mux.Handle("/api/deployments/", server.auth(http.HandlerFunc(runtimeServer.handleDeploymentItem)))
 		mux.Handle("/api/admin/namespaces", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleAdminNamespaces))))
@@ -919,13 +923,12 @@ func (s *apiServer) authenticateRequest(r *http.Request) (principal, bool, error
 		if err != nil {
 			return principal{}, false, err
 		}
-		return principal{
-			Role:      u.Role,
-			Subject:   u.ID,
-			Email:     u.Email,
-			Namespace: u.Namespace,
-			AuthType:  "oidc_jwt",
-		}, true, nil
+		p, err := s.platform.principalForUserID(r.Context(), u.ID)
+		if err != nil {
+			return principal{}, false, err
+		}
+		p.AuthType = "oidc_jwt"
+		return p, true, nil
 	}
 	return principal{
 		Role:     role,
@@ -961,18 +964,23 @@ func (s *apiServer) handleAuthMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	type authPrincipal struct {
-		Role      string `json:"role"`
-		Subject   string `json:"subject,omitempty"`
-		Email     string `json:"email,omitempty"`
-		Namespace string `json:"namespace,omitempty"`
+		Role              string          `json:"role"`
+		Subject           string          `json:"subject,omitempty"`
+		Email             string          `json:"email,omitempty"`
+		Namespace         string          `json:"namespace,omitempty"`
+		AllowedNamespaces []string        `json:"allowedNamespaces,omitempty"`
+		Teams             []principalTeam `json:"teams,omitempty"`
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"authenticated": true,
+		"authenticated":          true,
+		"sharedCatalogNamespace": sharedCatalogNamespace,
 		"principal": authPrincipal{
-			Role:      p.Role,
-			Subject:   p.Subject,
-			Email:     p.Email,
-			Namespace: p.Namespace,
+			Role:              p.Role,
+			Subject:           p.Subject,
+			Email:             p.Email,
+			Namespace:         p.Namespace,
+			AllowedNamespaces: p.AllowedNamespaces,
+			Teams:             p.Teams,
 		},
 	})
 }

--- a/services/api/migrations/001_platform_identity.sql
+++ b/services/api/migrations/001_platform_identity.sql
@@ -47,11 +47,22 @@ CREATE INDEX IF NOT EXISTS idx_registry_credentials_user_id ON registry_credenti
 
 CREATE TABLE IF NOT EXISTS namespaces (
   id uuid primary key,
-  user_id uuid not null references users(id) on delete cascade,
+  user_id uuid references users(id) on delete cascade,
+  team_id uuid,
   namespace text not null,
+  display_name text,
+  scope text not null default 'user',
   created_at timestamptz not null default now(),
   deleted_at timestamptz
 );
+ALTER TABLE namespaces ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE namespaces ADD COLUMN IF NOT EXISTS display_name text;
+ALTER TABLE namespaces ADD COLUMN IF NOT EXISTS scope text NOT NULL DEFAULT 'user';
+ALTER TABLE namespaces ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE namespaces
+  DROP CONSTRAINT IF EXISTS namespaces_scope_check;
+ALTER TABLE namespaces
+  ADD CONSTRAINT namespaces_scope_check CHECK (scope IN ('user', 'team'));
 
 ALTER TABLE IF EXISTS namespaces
   DROP CONSTRAINT IF EXISTS namespaces_namespace_key;
@@ -60,6 +71,32 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_namespaces_active
 ON namespaces(namespace)
 WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_namespaces_user_id ON namespaces(user_id);
+CREATE INDEX IF NOT EXISTS idx_namespaces_team_id ON namespaces(team_id);
+
+CREATE TABLE IF NOT EXISTS teams (
+  id uuid primary key,
+  slug text unique not null,
+  display_name text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_teams_slug_active ON teams(slug) WHERE deleted_at IS NULL;
+ALTER TABLE namespaces
+  DROP CONSTRAINT IF EXISTS namespaces_team_id_fkey;
+ALTER TABLE namespaces
+  ADD CONSTRAINT namespaces_team_id_fkey FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE;
+
+CREATE TABLE IF NOT EXISTS team_memberships (
+  id uuid primary key,
+  team_id uuid not null references teams(id) on delete cascade,
+  user_id uuid not null references users(id) on delete cascade,
+  role text not null check (role in ('owner', 'member')),
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_team_memberships_active ON team_memberships(team_id, user_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_team_memberships_user_id ON team_memberships(user_id);
 
 CREATE TABLE IF NOT EXISTS refresh_tokens (
   id uuid primary key,

--- a/services/api/platform_store.go
+++ b/services/api/platform_store.go
@@ -736,26 +736,53 @@ ORDER BY n.created_at DESC`)
 	defer rows.Close()
 	var out []map[string]any
 	for rows.Next() {
-		var id, userID, email, teamID, teamSlug, teamName, namespace, scope string
-		var createdAt time.Time
-		if err := rows.Scan(&id, &userID, &email, &teamID, &teamSlug, &teamName, &namespace, &scope, &createdAt); err != nil {
+		item, err := scanNamespaceRow(rows)
+		if err != nil {
 			return nil, err
 		}
-		out = append(out, map[string]any{
-			"id":         id,
-			"user_id":    userID,
-			"email":      email,
-			"team_id":    teamID,
-			"team_slug":  teamSlug,
-			"team_name":  teamName,
-			"scope":      scope,
-			"namespace":  namespace,
-			"created_at": createdAt,
-			"is_shared":  namespace == sharedCatalogNamespace,
-			"is_managed": strings.HasPrefix(namespace, teamNamespacePrefix),
-		})
+		out = append(out, item)
 	}
 	return out, rows.Err()
+}
+
+func (s *platformStore) GetNamespace(ctx context.Context, namespace string) (map[string]any, bool, error) {
+	namespace = strings.TrimSpace(namespace)
+	var id, userID, email, teamID, teamSlug, teamName, scope string
+	var createdAt time.Time
+	err := s.db.QueryRowContext(ctx, `
+SELECT
+  n.id,
+  COALESCE(n.user_id::text, ''),
+  COALESCE(u.email, ''),
+  COALESCE(n.team_id::text, ''),
+  COALESCE(t.slug, ''),
+  COALESCE(t.display_name, ''),
+  COALESCE(n.scope, 'user'),
+  n.created_at
+FROM namespaces n
+LEFT JOIN users u ON u.id = n.user_id
+LEFT JOIN teams t ON t.id = n.team_id
+WHERE n.deleted_at IS NULL AND n.namespace = $1
+LIMIT 1`, namespace).Scan(&id, &userID, &email, &teamID, &teamSlug, &teamName, &scope, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return map[string]any{
+		"id":         id,
+		"user_id":    userID,
+		"email":      email,
+		"team_id":    teamID,
+		"team_slug":  teamSlug,
+		"team_name":  teamName,
+		"scope":      scope,
+		"namespace":  namespace,
+		"created_at": createdAt,
+		"is_shared":  namespace == sharedCatalogNamespace,
+		"is_managed": strings.HasPrefix(namespace, teamNamespacePrefix),
+	}, true, nil
 }
 
 func (s *platformStore) CreateTeam(ctx context.Context, slug, name, createdByUserID string) (teamRecord, error) {
@@ -797,7 +824,7 @@ VALUES ($1, NULL, $2, $3, $4, $5)`, uuid.NewString(), teamID, namespace, name, n
 		if _, err = tx.ExecContext(ctx, `
 INSERT INTO team_memberships (id, team_id, user_id, role)
 VALUES ($1, $2, $3, $4)
-ON CONFLICT (team_id, user_id)
+ON CONFLICT (team_id, user_id) WHERE deleted_at IS NULL
 DO UPDATE SET role = EXCLUDED.role, deleted_at = NULL`, uuid.NewString(), teamID, createdByUserID, teamRoleOwner); err != nil {
 			return teamRecord{}, err
 		}
@@ -905,7 +932,7 @@ func (s *platformStore) UpsertTeamMembership(ctx context.Context, teamSlug, user
 	if _, err := s.db.ExecContext(ctx, `
 INSERT INTO team_memberships (id, team_id, user_id, role)
 VALUES ($1, $2, $3, $4)
-ON CONFLICT (team_id, user_id)
+ON CONFLICT (team_id, user_id) WHERE deleted_at IS NULL
 DO UPDATE SET role = EXCLUDED.role, deleted_at = NULL`, uuid.NewString(), team.ID, userID, role); err != nil {
 		return teamMembershipRecord{}, err
 	}
@@ -989,6 +1016,27 @@ func (s *platformStore) WriteAudit(ctx context.Context, ev auditEvent) {
 
 func normalizeTeamSlug(raw string) string {
 	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func scanNamespaceRow(rows *sql.Rows) (map[string]any, error) {
+	var id, userID, email, teamID, teamSlug, teamName, namespace, scope string
+	var createdAt time.Time
+	if err := rows.Scan(&id, &userID, &email, &teamID, &teamSlug, &teamName, &namespace, &scope, &createdAt); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"id":         id,
+		"user_id":    userID,
+		"email":      email,
+		"team_id":    teamID,
+		"team_slug":  teamSlug,
+		"team_name":  teamName,
+		"scope":      scope,
+		"namespace":  namespace,
+		"created_at": createdAt,
+		"is_shared":  namespace == sharedCatalogNamespace,
+		"is_managed": strings.HasPrefix(namespace, teamNamespacePrefix),
+	}, nil
 }
 
 func normalizeTeamMembershipRole(raw string) string {

--- a/services/api/platform_store.go
+++ b/services/api/platform_store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
 	"golang.org/x/crypto/bcrypt"
+	sentinelaccess "mcp-runtime/pkg/access"
 )
 
 const (
@@ -27,6 +28,15 @@ const (
 
 const oidcProviderPrefix = "oidc:"
 
+const (
+	sharedCatalogNamespace = "mcp-servers"
+	teamNamespacePrefix    = "mcp-team-"
+	teamRoleOwner          = "owner"
+	teamRoleMember         = "member"
+	namespaceScopeUser     = "user"
+	namespaceScopeTeam     = "team"
+)
+
 type platformStore struct {
 	db        *sql.DB
 	jwtSecret []byte
@@ -37,6 +47,24 @@ type platformUser struct {
 	Email     string `json:"email"`
 	Role      string `json:"role"`
 	Namespace string `json:"namespace"`
+}
+
+type teamRecord struct {
+	ID        string    `json:"id"`
+	Slug      string    `json:"slug"`
+	Name      string    `json:"name"`
+	Namespace string    `json:"namespace"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type teamMembershipRecord struct {
+	TeamID        string    `json:"team_id"`
+	TeamSlug      string    `json:"team_slug"`
+	TeamName      string    `json:"team_name"`
+	TeamNamespace string    `json:"team_namespace"`
+	UserID        string    `json:"user_id"`
+	Role          string    `json:"role"`
+	CreatedAt     time.Time `json:"created_at"`
 }
 
 type auditEvent struct {
@@ -452,14 +480,7 @@ func (s *platformStore) AuthenticateJWT(token string) (principal, bool) {
 	if subject == "" {
 		return principal{}, false
 	}
-
-	var p principal
-	err = s.db.QueryRow(`
-SELECT u.id, u.email, u.role, COALESCE(n.namespace, '')
-FROM users u
-LEFT JOIN namespaces n ON n.user_id = u.id AND n.deleted_at IS NULL
-WHERE u.id = $1 AND u.deleted_at IS NULL`, subject).
-		Scan(&p.Subject, &p.Email, &p.Role, &p.Namespace)
+	p, err := s.principalForUserID(context.Background(), subject)
 	if err != nil {
 		return principal{}, false
 	}
@@ -469,14 +490,13 @@ WHERE u.id = $1 AND u.deleted_at IS NULL`, subject).
 
 func (s *platformStore) AuthenticateUserAPIKey(ctx context.Context, rawKey string) (principal, bool, error) {
 	targetHash := hashAPIKey(rawKey)
-	var keyID, userID, email, role, namespace string
+	var keyID, userID string
 	err := s.db.QueryRowContext(ctx, `
-SELECT ak.id, ak.user_id, u.email, u.role, COALESCE(n.namespace, '')
+SELECT ak.id, ak.user_id
 FROM api_keys ak
 JOIN users u ON u.id = ak.user_id AND u.deleted_at IS NULL
-LEFT JOIN namespaces n ON n.user_id = u.id AND n.deleted_at IS NULL
 WHERE ak.key_hash = $1 AND ak.revoked = false`, targetHash).
-		Scan(&keyID, &userID, &email, &role, &namespace)
+		Scan(&keyID, &userID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return principal{}, false, nil
 	}
@@ -484,7 +504,108 @@ WHERE ak.key_hash = $1 AND ak.revoked = false`, targetHash).
 		return principal{}, false, err
 	}
 	_, _ = s.db.ExecContext(ctx, `UPDATE api_keys SET last_used_at = now() WHERE id = $1 AND (last_used_at IS NULL OR last_used_at < now() - interval '5 minutes')`, keyID)
-	return principal{Role: role, Subject: userID, Email: email, Namespace: namespace, AuthType: "user_api_key", APIKeyID: keyID}, true, nil
+	p, err := s.principalForUserID(ctx, userID)
+	if err != nil {
+		return principal{}, false, err
+	}
+	p.AuthType = "user_api_key"
+	p.APIKeyID = keyID
+	return p, true, nil
+}
+
+func (s *platformStore) principalForUserID(ctx context.Context, userID string) (principal, error) {
+	var p principal
+	err := s.db.QueryRowContext(ctx, `
+SELECT u.id, u.email, u.role, COALESCE(legacy.namespace, '')
+FROM users u
+LEFT JOIN LATERAL (
+  SELECT n.namespace
+  FROM namespaces n
+  WHERE n.user_id = u.id
+    AND n.deleted_at IS NULL
+    AND COALESCE(n.scope, 'user') = 'user'
+  ORDER BY n.created_at ASC
+  LIMIT 1
+) legacy ON true
+WHERE u.id = $1 AND u.deleted_at IS NULL`, userID).
+		Scan(&p.Subject, &p.Email, &p.Role, &p.Namespace)
+	if err != nil {
+		return principal{}, err
+	}
+	teams, err := s.listTeamMembershipsForUser(ctx, userID)
+	if err != nil {
+		return principal{}, err
+	}
+	legacyNamespace := p.Namespace
+	p.Teams = teams
+	for _, team := range teams {
+		if ns := strings.TrimSpace(team.Namespace); ns != "" {
+			p.Namespace = ns
+			break
+		}
+	}
+	p.AllowedNamespaces = dedupeNamespaces(append(collectAllowedNamespaces(legacyNamespace, teams), sharedCatalogNamespace))
+	if strings.TrimSpace(p.Namespace) == "" {
+		p.Namespace = strings.TrimSpace(legacyNamespace)
+	}
+	return p, nil
+}
+
+func collectAllowedNamespaces(legacyNamespace string, teams []principalTeam) []string {
+	namespaces := make([]string, 0, len(teams)+1)
+	if ns := strings.TrimSpace(legacyNamespace); ns != "" {
+		namespaces = append(namespaces, ns)
+	}
+	for _, team := range teams {
+		if ns := strings.TrimSpace(team.Namespace); ns != "" {
+			namespaces = append(namespaces, ns)
+		}
+	}
+	return namespaces
+}
+
+func dedupeNamespaces(namespaces []string) []string {
+	if len(namespaces) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(namespaces))
+	out := make([]string, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		namespace = strings.TrimSpace(namespace)
+		if namespace == "" {
+			continue
+		}
+		if _, ok := seen[namespace]; ok {
+			continue
+		}
+		seen[namespace] = struct{}{}
+		out = append(out, namespace)
+	}
+	return out
+}
+
+func (s *platformStore) listTeamMembershipsForUser(ctx context.Context, userID string) ([]principalTeam, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT t.id, t.slug, t.display_name, COALESCE(n.namespace, ''), tm.role
+FROM team_memberships tm
+JOIN teams t ON t.id = tm.team_id AND t.deleted_at IS NULL
+LEFT JOIN namespaces n ON n.team_id = t.id AND n.deleted_at IS NULL AND COALESCE(n.scope, 'team') = 'team'
+WHERE tm.user_id = $1 AND tm.deleted_at IS NULL
+ORDER BY t.slug ASC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	teams := make([]principalTeam, 0)
+	for rows.Next() {
+		var team principalTeam
+		if err := rows.Scan(&team.ID, &team.Slug, &team.Name, &team.Namespace, &team.Role); err != nil {
+			return nil, err
+		}
+		teams = append(teams, team)
+	}
+	return teams, rows.Err()
 }
 
 func (s *platformStore) ListUserAPIKeys(ctx context.Context, userID string) ([]userAPIKeySummary, error) {
@@ -593,21 +714,232 @@ RETURNING id, name, prefix, created_at, revoked, revoked_at`, userID, id).
 }
 
 func (s *platformStore) ListNamespaces(ctx context.Context) ([]map[string]any, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT n.id, n.user_id, u.email, n.namespace, n.created_at FROM namespaces n JOIN users u ON u.id = n.user_id WHERE n.deleted_at IS NULL ORDER BY n.created_at DESC`)
+	rows, err := s.db.QueryContext(ctx, `
+SELECT
+  n.id,
+  COALESCE(n.user_id::text, ''),
+  COALESCE(u.email, ''),
+  COALESCE(n.team_id::text, ''),
+  COALESCE(t.slug, ''),
+  COALESCE(t.display_name, ''),
+  n.namespace,
+  COALESCE(n.scope, 'user'),
+  n.created_at
+FROM namespaces n
+LEFT JOIN users u ON u.id = n.user_id
+LEFT JOIN teams t ON t.id = n.team_id
+WHERE n.deleted_at IS NULL
+ORDER BY n.created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	var out []map[string]any
 	for rows.Next() {
-		var id, userID, email, namespace string
+		var id, userID, email, teamID, teamSlug, teamName, namespace, scope string
 		var createdAt time.Time
-		if err := rows.Scan(&id, &userID, &email, &namespace, &createdAt); err != nil {
+		if err := rows.Scan(&id, &userID, &email, &teamID, &teamSlug, &teamName, &namespace, &scope, &createdAt); err != nil {
 			return nil, err
 		}
-		out = append(out, map[string]any{"id": id, "user_id": userID, "email": email, "namespace": namespace, "created_at": createdAt})
+		out = append(out, map[string]any{
+			"id":         id,
+			"user_id":    userID,
+			"email":      email,
+			"team_id":    teamID,
+			"team_slug":  teamSlug,
+			"team_name":  teamName,
+			"scope":      scope,
+			"namespace":  namespace,
+			"created_at": createdAt,
+			"is_shared":  namespace == sharedCatalogNamespace,
+			"is_managed": strings.HasPrefix(namespace, teamNamespacePrefix),
+		})
 	}
 	return out, rows.Err()
+}
+
+func (s *platformStore) CreateTeam(ctx context.Context, slug, name, createdByUserID string) (teamRecord, error) {
+	slug = normalizeTeamSlug(slug)
+	if err := validateTeamSlug(slug); err != nil {
+		return teamRecord{}, err
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = slug
+	}
+	namespace := teamNamespacePrefix + slug
+	if err := validateTeamNamespace(namespace); err != nil {
+		return teamRecord{}, err
+	}
+	teamID := uuid.NewString()
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return teamRecord{}, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err = tx.ExecContext(ctx, `
+INSERT INTO teams (id, slug, display_name, created_by)
+VALUES ($1, $2, $3, NULLIF($4, '')::uuid)`, teamID, slug, name, strings.TrimSpace(createdByUserID)); err != nil {
+		return teamRecord{}, err
+	}
+	if _, err = tx.ExecContext(ctx, `
+INSERT INTO namespaces (id, user_id, team_id, namespace, display_name, scope)
+VALUES ($1, NULL, $2, $3, $4, $5)`, uuid.NewString(), teamID, namespace, name, namespaceScopeTeam); err != nil {
+		return teamRecord{}, err
+	}
+	if strings.TrimSpace(createdByUserID) != "" {
+		if _, err = tx.ExecContext(ctx, `
+INSERT INTO team_memberships (id, team_id, user_id, role)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (team_id, user_id)
+DO UPDATE SET role = EXCLUDED.role, deleted_at = NULL`, uuid.NewString(), teamID, createdByUserID, teamRoleOwner); err != nil {
+			return teamRecord{}, err
+		}
+	}
+	if err = tx.Commit(); err != nil {
+		return teamRecord{}, err
+	}
+
+	return teamRecord{
+		ID:        teamID,
+		Slug:      slug,
+		Name:      name,
+		Namespace: namespace,
+		CreatedAt: time.Now().UTC(),
+	}, nil
+}
+
+func (s *platformStore) ListTeams(ctx context.Context) ([]teamRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT t.id, t.slug, t.display_name, COALESCE(n.namespace, ''), t.created_at
+FROM teams t
+LEFT JOIN namespaces n ON n.team_id = t.id AND n.deleted_at IS NULL AND COALESCE(n.scope, 'team') = 'team'
+WHERE t.deleted_at IS NULL
+ORDER BY t.slug ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]teamRecord, 0)
+	for rows.Next() {
+		var team teamRecord
+		if err := rows.Scan(&team.ID, &team.Slug, &team.Name, &team.Namespace, &team.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, team)
+	}
+	return out, rows.Err()
+}
+
+func (s *platformStore) ListUserTeams(ctx context.Context, userID string) ([]teamMembershipRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT t.id, t.slug, t.display_name, COALESCE(n.namespace, ''), tm.user_id::text, tm.role, tm.created_at
+FROM team_memberships tm
+JOIN teams t ON t.id = tm.team_id AND t.deleted_at IS NULL
+LEFT JOIN namespaces n ON n.team_id = t.id AND n.deleted_at IS NULL AND COALESCE(n.scope, 'team') = 'team'
+WHERE tm.user_id = $1 AND tm.deleted_at IS NULL
+ORDER BY t.slug ASC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]teamMembershipRecord, 0)
+	for rows.Next() {
+		var membership teamMembershipRecord
+		if err := rows.Scan(&membership.TeamID, &membership.TeamSlug, &membership.TeamName, &membership.TeamNamespace, &membership.UserID, &membership.Role, &membership.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, membership)
+	}
+	return out, rows.Err()
+}
+
+func (s *platformStore) GetTeamBySlug(ctx context.Context, slug string) (teamRecord, bool, error) {
+	slug = normalizeTeamSlug(slug)
+	var team teamRecord
+	err := s.db.QueryRowContext(ctx, `
+SELECT t.id, t.slug, t.display_name, COALESCE(n.namespace, ''), t.created_at
+FROM teams t
+LEFT JOIN namespaces n ON n.team_id = t.id AND n.deleted_at IS NULL AND COALESCE(n.scope, 'team') = 'team'
+WHERE t.slug = $1 AND t.deleted_at IS NULL`, slug).
+		Scan(&team.ID, &team.Slug, &team.Name, &team.Namespace, &team.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return teamRecord{}, false, nil
+	}
+	if err != nil {
+		return teamRecord{}, false, err
+	}
+	return team, true, nil
+}
+
+func (s *platformStore) UpsertTeamMembership(ctx context.Context, teamSlug, userID, role string) (teamMembershipRecord, error) {
+	teamSlug = normalizeTeamSlug(teamSlug)
+	userID = strings.TrimSpace(userID)
+	role = normalizeTeamMembershipRole(role)
+	if userID == "" {
+		return teamMembershipRecord{}, errors.New("userID is required")
+	}
+	if role == "" {
+		return teamMembershipRecord{}, errors.New("membership role is required")
+	}
+	team, ok, err := s.GetTeamBySlug(ctx, teamSlug)
+	if err != nil {
+		return teamMembershipRecord{}, err
+	}
+	if !ok {
+		return teamMembershipRecord{}, sql.ErrNoRows
+	}
+	if _, exists, err := s.GetUser(ctx, userID); err != nil {
+		return teamMembershipRecord{}, err
+	} else if !exists {
+		return teamMembershipRecord{}, sql.ErrNoRows
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO team_memberships (id, team_id, user_id, role)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (team_id, user_id)
+DO UPDATE SET role = EXCLUDED.role, deleted_at = NULL`, uuid.NewString(), team.ID, userID, role); err != nil {
+		return teamMembershipRecord{}, err
+	}
+	return teamMembershipRecord{
+		TeamID:        team.ID,
+		TeamSlug:      team.Slug,
+		TeamName:      team.Name,
+		TeamNamespace: team.Namespace,
+		UserID:        userID,
+		Role:          role,
+		CreatedAt:     time.Now().UTC(),
+	}, nil
+}
+
+func (s *platformStore) DeleteTeamMembership(ctx context.Context, teamSlug, userID string) error {
+	team, ok, err := s.GetTeamBySlug(ctx, teamSlug)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return sql.ErrNoRows
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE team_memberships SET deleted_at = now() WHERE team_id = $1 AND user_id = $2 AND deleted_at IS NULL`, team.ID, strings.TrimSpace(userID))
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (s *platformStore) ListAuditLogs(ctx context.Context, limit int) ([]platformAuditLog, error) {
@@ -653,6 +985,49 @@ func (s *platformStore) WriteAudit(ctx context.Context, ev auditEvent) {
 	}
 	_, _ = s.db.ExecContext(ctx, `INSERT INTO audit_logs (user_id,action,resource,namespace,status,message,actor_ip,request_id) VALUES (NULLIF($1,'')::uuid,$2,$3,$4,$5,$6,$7,$8)`,
 		ev.UserID, ev.Action, ev.Resource, ev.Namespace, ev.Status, ev.Message, ev.ActorIP, ev.RequestID)
+}
+
+func normalizeTeamSlug(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func normalizeTeamMembershipRole(raw string) string {
+	role := strings.ToLower(strings.TrimSpace(raw))
+	switch role {
+	case teamRoleOwner, teamRoleMember:
+		return role
+	default:
+		return ""
+	}
+}
+
+func validateTeamSlug(slug string) error {
+	if slug == "" {
+		return errors.New("team slug is required")
+	}
+	if err := sentinelaccess.ValidateResourceName("team", slug); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateTeamNamespace(namespace string) error {
+	if namespace == "" {
+		return errors.New("namespace required")
+	}
+	if strings.TrimSpace(namespace) == sharedCatalogNamespace {
+		return errors.New("shared catalog namespace is reserved")
+	}
+	reserved := []string{"default", "kube-system", "kube-public", "kube-node-lease", "mcp-runtime", "mcp-sentinel", "registry", "traefik"}
+	for _, disallowed := range reserved {
+		if namespace == disallowed {
+			return fmt.Errorf("namespace %q is reserved", namespace)
+		}
+	}
+	if err := sentinelaccess.ValidateResourceName("namespace", namespace); err != nil {
+		return err
+	}
+	return nil
 }
 
 func validEmail(email string) bool {
@@ -707,15 +1082,50 @@ CREATE TABLE IF NOT EXISTS registry_credentials (
 CREATE INDEX IF NOT EXISTS idx_registry_credentials_user_id ON registry_credentials(user_id);
 CREATE TABLE IF NOT EXISTS namespaces (
   id uuid primary key,
-  user_id uuid not null references users(id) on delete cascade,
+  user_id uuid references users(id) on delete cascade,
+  team_id uuid,
   namespace text not null,
+  display_name text,
+  scope text not null default 'user',
   created_at timestamptz not null default now(),
   deleted_at timestamptz
 );
+ALTER TABLE namespaces ADD COLUMN IF NOT EXISTS team_id uuid;
+ALTER TABLE namespaces ADD COLUMN IF NOT EXISTS display_name text;
+ALTER TABLE namespaces ADD COLUMN IF NOT EXISTS scope text NOT NULL DEFAULT 'user';
+ALTER TABLE namespaces ALTER COLUMN user_id DROP NOT NULL;
+ALTER TABLE namespaces
+  DROP CONSTRAINT IF EXISTS namespaces_scope_check;
+ALTER TABLE namespaces
+  ADD CONSTRAINT namespaces_scope_check CHECK (scope IN ('user', 'team'));
 CREATE INDEX IF NOT EXISTS idx_namespaces_user_id ON namespaces(user_id);
+CREATE INDEX IF NOT EXISTS idx_namespaces_team_id ON namespaces(team_id);
 ALTER TABLE IF EXISTS namespaces
   DROP CONSTRAINT IF EXISTS namespaces_namespace_key;
 CREATE UNIQUE INDEX IF NOT EXISTS uq_namespaces_active ON namespaces(namespace) WHERE deleted_at IS NULL;
+CREATE TABLE IF NOT EXISTS teams (
+  id uuid primary key,
+  slug text unique not null,
+  display_name text not null,
+  created_by uuid references users(id),
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_teams_slug_active ON teams(slug) WHERE deleted_at IS NULL;
+ALTER TABLE namespaces
+  DROP CONSTRAINT IF EXISTS namespaces_team_id_fkey;
+ALTER TABLE namespaces
+  ADD CONSTRAINT namespaces_team_id_fkey FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE;
+CREATE TABLE IF NOT EXISTS team_memberships (
+  id uuid primary key,
+  team_id uuid not null references teams(id) on delete cascade,
+  user_id uuid not null references users(id) on delete cascade,
+  role text not null check (role in ('owner', 'member')),
+  created_at timestamptz not null default now(),
+  deleted_at timestamptz
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_team_memberships_active ON team_memberships(team_id, user_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_team_memberships_user_id ON team_memberships(user_id);
 CREATE TABLE IF NOT EXISTS refresh_tokens (
   id uuid primary key,
   user_id uuid not null references users(id) on delete cascade,

--- a/services/api/runtime.go
+++ b/services/api/runtime.go
@@ -279,16 +279,14 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "shared catalog namespace is read-only for team users"})
 		return
 	}
-	if approved := approvedRegistries(); len(approved) > 0 {
-		parts := strings.Split(req.Spec.Image, "/")
-		if len(parts) < 2 {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "image must include a registry/repository path"})
-			return
-		}
-		if _, ok := approved[parts[0]]; !ok {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("registry %q is not approved", parts[0])})
-			return
-		}
+	team, isTeamNamespace := p.teamForNamespace(namespace)
+	teamSlug := ""
+	if isTeamNamespace {
+		teamSlug = strings.TrimSpace(team.Slug)
+	}
+	if err := validateDeployImage(req.Spec.Image, namespace, teamSlug, p.Role); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
 	}
 
 	req.Namespace = namespace

--- a/services/api/runtime.go
+++ b/services/api/runtime.go
@@ -15,6 +15,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
@@ -53,19 +54,27 @@ type accessSessionRequest struct {
 	PolicyVersion  string                         `json:"policyVersion"`
 }
 
+type runtimeServerApplyRequest struct {
+	Name      string                    `json:"name"`
+	Namespace string                    `json:"namespace,omitempty"`
+	Labels    map[string]string         `json:"labels,omitempty"`
+	Spec      mcpv1alpha1.MCPServerSpec `json:"spec"`
+}
+
 // RuntimeServer extends apiServer with Kubernetes and enhanced ClickHouse capabilities.
 type RuntimeServer struct {
 	db          *chpkg.Client
 	clickhouse  clickhouse.Conn
 	dbName      string
 	apiKeys     map[string]struct{}
+	platform    *platformStore
 	k8sClients  *k8sclient.Clients
 	accessMgr   *sentinelaccess.Manager
 	sentinelMgr *sentinel.Manager
 }
 
 // NewRuntimeServer creates a runtime server with Kubernetes access.
-func NewRuntimeServer(db clickhouse.Conn, dbName string, apiKeys map[string]struct{}) (*RuntimeServer, error) {
+func NewRuntimeServer(db clickhouse.Conn, dbName string, apiKeys map[string]struct{}, platform *platformStore) (*RuntimeServer, error) {
 	// Create ClickHouse client wrapper
 	chClient := &chpkg.Client{
 		Conn:   db,
@@ -93,6 +102,7 @@ func NewRuntimeServer(db clickhouse.Conn, dbName string, apiKeys map[string]stru
 		clickhouse:  db,
 		dbName:      dbName,
 		apiKeys:     apiKeys,
+		platform:    platform,
 		k8sClients:  k8sClients,
 		accessMgr:   accessMgr,
 		sentinelMgr: sentinelMgr,
@@ -141,6 +151,18 @@ func (s *RuntimeServer) handleDashboardSummary(w http.ResponseWriter, r *http.Re
 
 // handleRuntimeServers returns MCP server deployments.
 func (s *RuntimeServer) handleRuntimeServers(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleRuntimeServerList(w, r)
+	case http.MethodPost:
+		s.handleRuntimeServerApply(w, r)
+	default:
+		w.Header().Set("allow", "GET, POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+	}
+}
+
+func (s *RuntimeServer) handleRuntimeServerList(w http.ResponseWriter, r *http.Request) {
 	if s.k8sClients == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
 		return
@@ -151,21 +173,19 @@ func (s *RuntimeServer) handleRuntimeServers(w http.ResponseWriter, r *http.Requ
 
 	namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	if p, ok := principalFromContext(r.Context()); ok && p.Role != roleAdmin {
-		switch {
-		case namespace == "":
-			// Non-admin users should still see the shared MCP catalog by default.
-			namespace = "mcp-servers"
-		case namespace == "mcp-servers":
-			// Allow explicit shared catalog lookup.
-		case p.Namespace != "" && namespace == p.Namespace:
-			// Allow user's private namespace lookup.
-		default:
+		if namespace == "" {
+			namespace = strings.TrimSpace(p.Namespace)
+			if namespace == "" {
+				namespace = sharedCatalogNamespace
+			}
+		}
+		if !p.hasNamespace(namespace) {
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
 			return
 		}
 	}
 	if namespace == "" {
-		namespace = "mcp-servers"
+		namespace = sharedCatalogNamespace
 	}
 
 	serverObjects, err := s.k8sClients.Dynamic.Resource(mcpServerGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
@@ -221,6 +241,127 @@ func (s *RuntimeServer) handleRuntimeServers(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{"servers": servers})
+}
+
+func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.Request) {
+	if s.k8sClients == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		return
+	}
+	p, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req runtimeServerApplyRequest
+	r.Body = http.MaxBytesReader(w, r.Body, accessApplyMaxBytes)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	req.Namespace = strings.TrimSpace(req.Namespace)
+	req.Spec.Image = strings.TrimSpace(req.Spec.Image)
+	if req.Name == "" || req.Spec.Image == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and spec.image are required"})
+		return
+	}
+	if req.Namespace == "" {
+		req.Namespace = strings.TrimSpace(p.Namespace)
+	}
+	namespace, err := s.scopedNamespaceForPrincipal(r.Context(), req.Namespace)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+	if p.Role != roleAdmin && namespace == sharedCatalogNamespace {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "shared catalog namespace is read-only for team users"})
+		return
+	}
+	if approved := approvedRegistries(); len(approved) > 0 {
+		parts := strings.Split(req.Spec.Image, "/")
+		if len(parts) < 2 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "image must include a registry/repository path"})
+			return
+		}
+		if _, ok := approved[parts[0]]; !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("registry %q is not approved", parts[0])})
+			return
+		}
+	}
+
+	req.Namespace = namespace
+	if req.Spec.PublicPathPrefix == "" {
+		req.Spec.PublicPathPrefix = req.Name
+	}
+	if req.Spec.IngressPath == "" {
+		req.Spec.IngressPath = "/" + req.Spec.PublicPathPrefix + "/mcp"
+	}
+
+	labels := map[string]string{
+		"app.kubernetes.io/managed-by": "mcp-runtime",
+	}
+	for key, value := range req.Labels {
+		labels[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+
+	server := &mcpv1alpha1.MCPServer{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcpv1alpha1.GroupVersion.String(),
+			Kind:       "MCPServer",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: req.Spec,
+	}
+
+	payload, err := apiruntime.DefaultUnstructuredConverter.ToUnstructured(server)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to encode server spec"})
+		return
+	}
+	resource := &unstructured.Unstructured{Object: payload}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+	current, err := s.k8sClients.Dynamic.Resource(mcpServerGVR).Namespace(namespace).Get(ctx, req.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		applied, createErr := s.k8sClients.Dynamic.Resource(mcpServerGVR).Namespace(namespace).Create(ctx, resource, metav1.CreateOptions{})
+		if createErr != nil {
+			code, msg := k8sclient.HTTPStatusFromK8sError(createErr)
+			writeJSON(w, code, map[string]string{"error": msg})
+			return
+		}
+		var out mcpv1alpha1.MCPServer
+		if convertErr := apiruntime.DefaultUnstructuredConverter.FromUnstructured(applied.Object, &out); convertErr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to decode created server"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"server": serverInfoFromMCPServer(out, serverDeploymentStatus{}, r)})
+		return
+	}
+	if err != nil {
+		code, msg := k8sclient.HTTPStatusFromK8sError(err)
+		writeJSON(w, code, map[string]string{"error": msg})
+		return
+	}
+	resource.SetResourceVersion(current.GetResourceVersion())
+	applied, err := s.k8sClients.Dynamic.Resource(mcpServerGVR).Namespace(namespace).Update(ctx, resource, metav1.UpdateOptions{})
+	if err != nil {
+		code, msg := k8sclient.HTTPStatusFromK8sError(err)
+		writeJSON(w, code, map[string]string{"error": msg})
+		return
+	}
+	var out mcpv1alpha1.MCPServer
+	if convertErr := apiruntime.DefaultUnstructuredConverter.FromUnstructured(applied.Object, &out); convertErr != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to decode updated server"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"server": serverInfoFromMCPServer(out, serverDeploymentStatus{}, r)})
 }
 
 type serverInfo struct {
@@ -440,6 +581,9 @@ func (s *RuntimeServer) handleRuntimeGrantApply(w http.ResponseWriter, r *http.R
 		return
 	}
 	req.Namespace = scopedNamespace
+	if strings.TrimSpace(req.ServerRef.Namespace) == "" {
+		req.ServerRef.Namespace = req.Namespace
+	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
@@ -551,6 +695,9 @@ func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http
 		return
 	}
 	req.Namespace = scopedNamespace
+	if strings.TrimSpace(req.ServerRef.Namespace) == "" {
+		req.ServerRef.Namespace = req.Namespace
+	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
@@ -1082,14 +1229,16 @@ func (s *RuntimeServer) scopedNamespaceForPrincipal(ctx context.Context, request
 	if !ok || p.Role == roleAdmin {
 		return requested, nil
 	}
-	subjectNamespace := strings.TrimSpace(p.Namespace)
-	if subjectNamespace == "" {
+	if requested == "" {
+		if preferred := strings.TrimSpace(p.Namespace); preferred != "" {
+			return preferred, nil
+		}
+		if p.hasNamespace(sharedCatalogNamespace) {
+			return sharedCatalogNamespace, nil
+		}
 		return "", errPrincipalIdentityRequired
 	}
-	if requested == "" {
-		return subjectNamespace, nil
-	}
-	if requested != subjectNamespace {
+	if !p.hasNamespace(requested) {
 		return "", errors.New("forbidden namespace")
 	}
 	return requested, nil

--- a/services/api/runtime_teams.go
+++ b/services/api/runtime_teams.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func (s *RuntimeServer) handleRuntimeTeams(w http.ResponseWriter, r *http.Request) {
+	if s.platform == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		return
+	}
+	p, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		s.handleRuntimeTeamList(w, r, p)
+	case http.MethodPost:
+		if p.Role != roleAdmin {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			return
+		}
+		s.handleRuntimeTeamCreate(w, r, p)
+	default:
+		w.Header().Set("allow", "GET, POST")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+	}
+}
+
+func (s *RuntimeServer) handleRuntimeTeamItemPath(w http.ResponseWriter, r *http.Request) {
+	if s.platform == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		return
+	}
+	p, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/runtime/teams/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid path"})
+		return
+	}
+	teamSlug := normalizeTeamSlug(parts[0])
+
+	switch {
+	case len(parts) == 1 && r.Method == http.MethodGet:
+		s.handleRuntimeTeamGet(w, r, p, teamSlug)
+		return
+	case len(parts) == 2 && parts[1] == "members" && r.Method == http.MethodPost:
+		s.handleRuntimeTeamMemberUpsert(w, r, p, teamSlug)
+		return
+	case len(parts) == 3 && parts[1] == "members" && r.Method == http.MethodDelete:
+		s.handleRuntimeTeamMemberDelete(w, r, p, teamSlug, strings.TrimSpace(parts[2]))
+		return
+	default:
+		w.Header().Set("allow", "GET, POST, DELETE")
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+	}
+}
+
+func (s *RuntimeServer) handleRuntimeNamespaces(w http.ResponseWriter, r *http.Request) {
+	if s.platform == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return
+	}
+	p, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	if p.Role == roleAdmin {
+		namespaces, err := s.platform.ListNamespaces(ctx)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list namespaces"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"namespaces": namespaces})
+		return
+	}
+
+	entries := make([]map[string]any, 0, len(p.AllowedNamespaces))
+	for _, namespace := range p.AllowedNamespaces {
+		namespace = strings.TrimSpace(namespace)
+		if namespace == "" {
+			continue
+		}
+		entry := map[string]any{
+			"namespace": namespace,
+			"is_shared": namespace == sharedCatalogNamespace,
+		}
+		for _, team := range p.Teams {
+			if strings.TrimSpace(team.Namespace) == namespace {
+				entry["team_id"] = team.ID
+				entry["team_slug"] = team.Slug
+				entry["team_name"] = team.Name
+				entry["team_role"] = team.Role
+				entry["scope"] = namespaceScopeTeam
+			}
+		}
+		if _, ok := entry["scope"]; !ok {
+			entry["scope"] = namespaceScopeUser
+		}
+		entries = append(entries, entry)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"namespaces": entries})
+}
+
+func (s *RuntimeServer) handleRuntimeNamespaceItem(w http.ResponseWriter, r *http.Request) {
+	if s.platform == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return
+	}
+	p, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	namespace := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/api/runtime/namespaces/"))
+	namespace = strings.Trim(namespace, "/")
+	if namespace == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace required"})
+		return
+	}
+
+	if p.Role != roleAdmin && !p.hasNamespace(namespace) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	namespaces, err := s.platform.ListNamespaces(ctx)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list namespaces"})
+		return
+	}
+	for _, item := range namespaces {
+		if strings.TrimSpace(asString(item["namespace"])) == namespace {
+			writeJSON(w, http.StatusOK, map[string]any{"namespace": item})
+			return
+		}
+	}
+	if namespace == sharedCatalogNamespace {
+		writeJSON(w, http.StatusOK, map[string]any{"namespace": map[string]any{
+			"namespace": sharedCatalogNamespace,
+			"scope":     "shared",
+			"is_shared": true,
+		}})
+		return
+	}
+	writeJSON(w, http.StatusNotFound, map[string]string{"error": "namespace not found"})
+}
+
+func (s *RuntimeServer) handleRuntimeTeamList(w http.ResponseWriter, r *http.Request, p principal) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	if p.Role == roleAdmin {
+		teams, err := s.platform.ListTeams(ctx)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list teams"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"teams": teams})
+		return
+	}
+	teams, err := s.platform.ListUserTeams(ctx, p.userID())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list teams"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"teams": teams})
+}
+
+func (s *RuntimeServer) handleRuntimeTeamGet(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	team, ok, err := s.platform.GetTeamBySlug(ctx, teamSlug)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch team"})
+		return
+	}
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "team not found"})
+		return
+	}
+	if p.Role != roleAdmin && p.teamRole(teamSlug) == "" {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"team": team})
+}
+
+func (s *RuntimeServer) handleRuntimeTeamCreate(w http.ResponseWriter, r *http.Request, p principal) {
+	var req struct {
+		Slug string `json:"slug"`
+		Name string `json:"name"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 8*1024)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+
+	team, err := s.platform.CreateTeam(ctx, req.Slug, req.Name, p.userID())
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "duplicate") || strings.Contains(strings.ToLower(err.Error()), "unique") {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "team already exists"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if err := s.ensureTeamNamespace(ctx, team); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to provision team namespace"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"team": team})
+}
+
+func (s *RuntimeServer) handleRuntimeTeamMemberUpsert(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
+	if p.Role != roleAdmin && p.teamRole(teamSlug) != teamRoleOwner {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	var req struct {
+		UserID string `json:"userID"`
+		Role   string `json:"role"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 8*1024)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	membership, err := s.platform.UpsertTeamMembership(ctx, teamSlug, req.UserID, req.Role)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "team or user not found"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"membership": membership})
+}
+
+func (s *RuntimeServer) handleRuntimeTeamMemberDelete(w http.ResponseWriter, r *http.Request, p principal, teamSlug, userID string) {
+	if p.Role != roleAdmin && p.teamRole(teamSlug) != teamRoleOwner {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	if err := s.platform.DeleteTeamMembership(ctx, teamSlug, userID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "membership not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete membership"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"success": true,
+		"team":    teamSlug,
+		"userID":  userID,
+	})
+}
+
+func asString(v any) string {
+	switch typed := v.(type) {
+	case string:
+		return typed
+	default:
+		return ""
+	}
+}

--- a/services/api/runtime_teams.go
+++ b/services/api/runtime_teams.go
@@ -153,16 +153,14 @@ func (s *RuntimeServer) handleRuntimeNamespaceItem(w http.ResponseWriter, r *htt
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
-	namespaces, err := s.platform.ListNamespaces(ctx)
+	item, ok, err := s.platform.GetNamespace(ctx, namespace)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list namespaces"})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch namespace"})
 		return
 	}
-	for _, item := range namespaces {
-		if strings.TrimSpace(asString(item["namespace"])) == namespace {
-			writeJSON(w, http.StatusOK, map[string]any{"namespace": item})
-			return
-		}
+	if ok {
+		writeJSON(w, http.StatusOK, map[string]any{"namespace": item})
+		return
 	}
 	if namespace == sharedCatalogNamespace {
 		writeJSON(w, http.StatusOK, map[string]any{"namespace": map[string]any{
@@ -193,7 +191,17 @@ func (s *RuntimeServer) handleRuntimeTeamList(w http.ResponseWriter, r *http.Req
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list teams"})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"teams": teams})
+	out := make([]teamRecord, 0, len(teams))
+	for _, membership := range teams {
+		out = append(out, teamRecord{
+			ID:        membership.TeamID,
+			Slug:      membership.TeamSlug,
+			Name:      membership.TeamName,
+			Namespace: membership.TeamNamespace,
+			CreatedAt: membership.CreatedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"teams": out})
 }
 
 func (s *RuntimeServer) handleRuntimeTeamGet(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {

--- a/services/api/runtime_test.go
+++ b/services/api/runtime_test.go
@@ -281,7 +281,7 @@ func accessJSONServerURL(t *testing.T, info serverInfo, name string) string {
 	return url
 }
 
-func TestRuntimeServersNonAdminDefaultsToSharedNamespace(t *testing.T) {
+func TestRuntimeServersNonAdminDefaultsToPrincipalNamespace(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("AddToScheme: %v", err)
@@ -316,6 +316,10 @@ func TestRuntimeServersNonAdminDefaultsToSharedNamespace(t *testing.T) {
 		Role:      roleUser,
 		Subject:   "user-1",
 		Namespace: "user-1",
+		AllowedNamespaces: []string{
+			"user-1",
+			sharedCatalogNamespace,
+		},
 	}))
 	recorder := httptest.NewRecorder()
 	server.handleRuntimeServers(recorder, request)
@@ -329,8 +333,8 @@ func TestRuntimeServersNonAdminDefaultsToSharedNamespace(t *testing.T) {
 	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if len(payload.Servers) != 1 || payload.Servers[0].Name != "shared-server" {
-		t.Fatalf("servers = %#v, want only shared-server", payload.Servers)
+	if len(payload.Servers) != 1 || payload.Servers[0].Name != "private-server" {
+		t.Fatalf("servers = %#v, want only private-server", payload.Servers)
 	}
 }
 
@@ -346,11 +350,43 @@ func TestRuntimeServersNonAdminRejectsOtherNamespace(t *testing.T) {
 		Role:      roleUser,
 		Subject:   "user-1",
 		Namespace: "user-1",
+		AllowedNamespaces: []string{
+			"user-1",
+			sharedCatalogNamespace,
+		},
 	}))
 	recorder := httptest.NewRecorder()
 	server.handleRuntimeServers(recorder, request)
 	if recorder.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRuntimeServerApplyNonAdminRejectsSharedCatalogNamespace(t *testing.T) {
+	server := &RuntimeServer{
+		k8sClients: &k8sclient.Clients{
+			Dynamic:   dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+			Clientset: kubernetesfake.NewSimpleClientset(),
+		},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/runtime/servers", bytes.NewReader([]byte(`{
+		"name": "demo",
+		"namespace": "mcp-servers",
+		"spec": {"image":"registry.example.com/core/demo"}
+	}`)))
+	request = request.WithContext(context.WithValue(request.Context(), principalContextKey{}, principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-core",
+		AllowedNamespaces: []string{
+			"mcp-team-core",
+			sharedCatalogNamespace,
+		},
+	}))
+	recorder := httptest.NewRecorder()
+	server.handleRuntimeServers(recorder, request)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
 	}
 }
 
@@ -377,7 +413,16 @@ func TestScopedNamespaceForPrincipal(t *testing.T) {
 
 func TestRuntimeGrantApplyNonAdminDefaultsToPrincipalNamespace(t *testing.T) {
 	ctx := context.Background()
-	accessMgr := newTestAccessManager(t)
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	accessMgr := sentinelaccess.NewManager(dynamicfake.NewSimpleDynamicClient(scheme, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "user-1",
+		},
+	}), nil)
 	server := &RuntimeServer{accessMgr: accessMgr}
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodPost, "/api/runtime/grants", bytes.NewReader([]byte(`{
@@ -390,6 +435,10 @@ func TestRuntimeGrantApplyNonAdminDefaultsToPrincipalNamespace(t *testing.T) {
 		Role:      roleUser,
 		Subject:   "user-1",
 		Namespace: "user-1",
+		AllowedNamespaces: []string{
+			"user-1",
+			sharedCatalogNamespace,
+		},
 	}))
 	server.handleRuntimeGrantApply(recorder, request)
 	if recorder.Code != http.StatusOK {

--- a/services/api/team_validation_test.go
+++ b/services/api/team_validation_test.go
@@ -1,0 +1,58 @@
+package main
+
+import "testing"
+
+func TestValidateTeamSlug(t *testing.T) {
+	cases := []struct {
+		name    string
+		slug    string
+		wantErr bool
+	}{
+		{name: "valid", slug: "platform-core", wantErr: false},
+		{name: "empty", slug: "", wantErr: true},
+		{name: "invalid characters", slug: "core/team", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTeamSlug(tc.slug)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateTeamSlug(%q) error = nil, want error", tc.slug)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateTeamSlug(%q) error = %v, want nil", tc.slug, err)
+			}
+		})
+	}
+}
+
+func TestValidateTeamNamespaceReserved(t *testing.T) {
+	cases := []struct {
+		name      string
+		namespace string
+		wantErr   bool
+	}{
+		{name: "team namespace", namespace: "mcp-team-core", wantErr: false},
+		{name: "shared reserved", namespace: sharedCatalogNamespace, wantErr: true},
+		{name: "kube reserved", namespace: "kube-system", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTeamNamespace(tc.namespace)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateTeamNamespace(%q) error = nil, want error", tc.namespace)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateTeamNamespace(%q) error = %v, want nil", tc.namespace, err)
+			}
+		})
+	}
+}
+
+func TestValidateDeployImageScope(t *testing.T) {
+	if err := validateDeployImage("registry.example.com/core/demo:latest", "mcp-team-core", "core", roleUser); err != nil {
+		t.Fatalf("validateDeployImage() error = %v, want nil", err)
+	}
+	if err := validateDeployImage("registry.example.com/other/demo:latest", "mcp-team-core", "core", roleUser); err == nil {
+		t.Fatal("expected image scope validation error for non-admin")
+	}
+}

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -16,6 +16,8 @@ let userAPIKeyClearTimer = null;
 let serverSearchQuery = "";
 let serverStatusFilter = "all";
 let selectedOperationsServerKey = "";
+let namespaceScopes = [];
+let selectedNamespace = defaults.namespace || "mcp-servers";
 
 // API Helper
 async function fetchJSON(path, options = {}) {
@@ -48,6 +50,71 @@ function unauthorizedError() {
 
 function isUnauthorizedError(err) {
   return err?.name === "UnauthorizedError";
+}
+
+function activeScopeNamespace() {
+  return (selectedNamespace || defaults.namespace || "mcp-servers").trim();
+}
+
+function scopedPath(path) {
+  const namespace = activeScopeNamespace();
+  if (!namespace) return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}namespace=${encodeURIComponent(namespace)}`;
+}
+
+function namespaceScopeLabel(item) {
+  if (item?.is_shared) {
+    return `shared / ${item.namespace}`;
+  }
+  if (item?.team_slug) {
+    return `team:${item.team_slug} / ${item.namespace}`;
+  }
+  return item?.namespace || "-";
+}
+
+function syncScopeSelector() {
+  const select = document.getElementById("scope-namespace");
+  if (!select) return;
+  select.innerHTML = "";
+  const scopes = Array.isArray(namespaceScopes) && namespaceScopes.length
+    ? namespaceScopes
+    : [{ namespace: defaults.namespace || "mcp-servers", is_shared: true }];
+  scopes.forEach((item) => {
+    const option = document.createElement("option");
+    option.value = item.namespace || "";
+    option.textContent = namespaceScopeLabel(item);
+    select.appendChild(option);
+  });
+  const hasSelected = scopes.some((item) => (item.namespace || "") === selectedNamespace);
+  if (!hasSelected) {
+    selectedNamespace = scopes[0]?.namespace || defaults.namespace || "mcp-servers";
+  }
+  select.value = selectedNamespace;
+  setFieldValue("grant-namespace", activeScopeNamespace());
+  setFieldValue("session-namespace", activeScopeNamespace());
+}
+
+async function loadNamespaceScopes() {
+  if (!authenticated) {
+    namespaceScopes = [{ namespace: "mcp-servers", scope: "shared", is_shared: true }];
+    selectedNamespace = "mcp-servers";
+    syncScopeSelector();
+    return;
+  }
+  try {
+    const data = await fetchJSON("/runtime/namespaces");
+    namespaceScopes = Array.isArray(data.namespaces) ? data.namespaces.filter((item) => item?.namespace) : [];
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load namespaces:", err);
+    namespaceScopes = [];
+  }
+  const teamNamespaces = namespaceScopes.filter((item) => item.scope === "team").map((item) => item.namespace);
+  if (teamNamespaces.length && !teamNamespaces.includes(selectedNamespace)) {
+    selectedNamespace = teamNamespaces[0];
+  }
+  syncScopeSelector();
 }
 
 async function copyTextToClipboard(text, successMessage = "Copied") {
@@ -575,9 +642,11 @@ async function initAuth() {
   }
 
   if (authenticated) {
+    await loadNamespaceScopes();
     loadActiveTab();
     startAutoRefresh();
   } else {
+    await loadNamespaceScopes();
     activateTab("servers");
     loadServers();
   }
@@ -614,6 +683,7 @@ async function handleAuthSubmit(event) {
     if (passwordInput) passwordInput.value = "";
     hideAuthModal();
     setAuthenticated(true);
+    await loadNamespaceScopes();
     loadActiveTab();
     startAutoRefresh();
   } catch (err) {
@@ -664,6 +734,7 @@ async function handleGoogleSignIn(response) {
     authPrincipal = data?.principal || null;
     hideAuthModal();
     setAuthenticated(true);
+    await loadNamespaceScopes();
     loadActiveTab();
     startAutoRefresh();
   } catch (err) {
@@ -717,6 +788,9 @@ async function logout() {
   stopAutoRefresh();
   authPrincipal = null;
   setAuthenticated(false);
+  namespaceScopes = [{ namespace: "mcp-servers", scope: "shared", is_shared: true }];
+  selectedNamespace = "mcp-servers";
+  syncScopeSelector();
   resetDashboard();
   resetGovernance();
   resetUserAPIKeys();
@@ -818,7 +892,7 @@ function resetGovernance() {
 
 async function loadServers() {
   try {
-    const data = await fetchJSON("/runtime/servers");
+    const data = await fetchJSON(scopedPath("/runtime/servers"));
     serversCache = Array.isArray(data.servers) ? data.servers : [];
     renderServers();
   } catch (err) {
@@ -1110,6 +1184,11 @@ function initDashboard() {
   document.getElementById("refresh-servers")?.addEventListener("click", () => {
     loadServers();
   });
+  document.getElementById("scope-namespace")?.addEventListener("change", (event) => {
+    selectedNamespace = (event.target.value || "").trim();
+    syncScopeSelector();
+    loadActiveTab();
+  });
   document.getElementById("server-search")?.addEventListener("input", (event) => {
     serverSearchQuery = event.target.value || "";
     renderServers();
@@ -1184,7 +1263,7 @@ function stopAutoRefresh() {
 // Governance - Grants
 async function loadGrants() {
   try {
-    const data = await fetchJSON("/runtime/grants");
+    const data = await fetchJSON(scopedPath("/runtime/grants"));
     grantsCache = Array.isArray(data.grants) ? data.grants : [];
     renderGovernanceSummary();
     renderGrants();
@@ -1239,7 +1318,7 @@ function renderGrants() {
   filtered.forEach((grant) => {
     const status = grant.disabled ? "Disabled" : "Active";
     const statusClass = grant.disabled ? "badge-muted" : "badge-success";
-    const namespace = grant.namespace || defaults.namespace;
+    const namespace = grant.namespace || activeScopeNamespace();
     const serverNamespace = grant.serverRef?.namespace || namespace;
 
     const row = document.createElement("tr");
@@ -1313,7 +1392,7 @@ async function applyGrant(event) {
   try {
     const payload = {
       name,
-      namespace: fieldValue("grant-namespace") || defaults.namespace,
+      namespace: fieldValue("grant-namespace") || activeScopeNamespace(),
       serverRef: {
         name: server,
         namespace: fieldValue("grant-server-namespace"),
@@ -1330,7 +1409,7 @@ async function applyGrant(event) {
     });
     showToast(`Grant "${payload.name}" applied successfully`);
     document.getElementById("grant-form")?.reset();
-    setFieldValue("grant-namespace", defaults.namespace);
+    setFieldValue("grant-namespace", activeScopeNamespace());
     setFieldValue("grant-policy-version", defaults.policyVersion);
     document.getElementById("grant-form")?.classList.add("hidden");
     loadGrants();
@@ -1375,7 +1454,7 @@ function parseToolRules(text) {
 // Governance - Sessions
 async function loadSessions() {
   try {
-    const data = await fetchJSON("/runtime/sessions");
+    const data = await fetchJSON(scopedPath("/runtime/sessions"));
     sessionsCache = Array.isArray(data.sessions) ? data.sessions : [];
     renderGovernanceSummary();
     renderSessions();
@@ -1418,7 +1497,7 @@ function renderSessions() {
   filtered.forEach((session) => {
     const status = session.revoked ? "Revoked" : "Active";
     const statusClass = session.revoked ? "badge-error" : "badge-success";
-    const namespace = session.namespace || defaults.namespace;
+    const namespace = session.namespace || activeScopeNamespace();
     const serverNamespace = session.serverRef?.namespace || namespace;
 
     const row = document.createElement("tr");
@@ -1492,7 +1571,7 @@ async function applySession(event) {
   try {
     const payload = {
       name,
-      namespace: fieldValue("session-namespace") || defaults.namespace,
+      namespace: fieldValue("session-namespace") || activeScopeNamespace(),
       serverRef: {
         name: server,
         namespace: fieldValue("session-server-namespace"),
@@ -1512,7 +1591,7 @@ async function applySession(event) {
     });
     showToast(`Session "${payload.name}" applied successfully`);
     document.getElementById("session-form")?.reset();
-    setFieldValue("session-namespace", defaults.namespace);
+    setFieldValue("session-namespace", activeScopeNamespace());
     setFieldValue("session-policy-version", defaults.policyVersion);
     document.getElementById("session-form")?.classList.add("hidden");
     loadSessions();
@@ -1569,9 +1648,9 @@ function updateSessionExpiresUTCHint() {
 }
 
 function initGovernance() {
-  setFieldValue("grant-namespace", defaults.namespace);
+  setFieldValue("grant-namespace", activeScopeNamespace());
   setFieldValue("grant-policy-version", defaults.policyVersion);
-  setFieldValue("session-namespace", defaults.namespace);
+  setFieldValue("session-namespace", activeScopeNamespace());
   setFieldValue("session-policy-version", defaults.policyVersion);
 
   document
@@ -1744,7 +1823,7 @@ function setOperationLoadingState() {
 
 async function loadOperationServers() {
   try {
-    const data = await fetchJSON("/runtime/servers");
+    const data = await fetchJSON(scopedPath("/runtime/servers"));
     operationsServersCache = Array.isArray(data.servers) ? data.servers : [];
     const selectedStillExists = operationsServersCache.some(
       (server) => operationServerKey(server) === selectedOperationsServerKey
@@ -2030,7 +2109,7 @@ async function loadPlatformServerHealth() {
     tbody.innerHTML = '<tr><td colspan="4" class="empty">Loading MCP server health...</td></tr>';
   }
   try {
-    const data = await fetchJSON("/runtime/servers");
+    const data = await fetchJSON(scopedPath("/runtime/servers"));
     const servers = Array.isArray(data.servers) ? data.servers : [];
     renderPlatformServerHealth(servers);
   } catch (err) {

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -127,6 +127,7 @@
               <button data-server-status="attention" type="button">Issues</button>
             </div>
             <div class="server-catalog-controls">
+              <select id="scope-namespace" aria-label="Active namespace scope"></select>
               <input
                 type="search"
                 id="server-search"

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -1006,7 +1006,8 @@ tr:hover td {
   justify-content: flex-end;
 }
 
-.server-catalog-controls input {
+.server-catalog-controls input,
+.server-catalog-controls select {
   min-width: 0;
   width: min(100%, 420px);
 }
@@ -1397,7 +1398,8 @@ tr:hover td {
     justify-content: flex-start;
   }
 
-  .server-catalog-controls input {
+  .server-catalog-controls input,
+  .server-catalog-controls select {
     width: 100%;
   }
 

--- a/test/golden/cli/testdata/mcp-runtime_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_help.golden
@@ -20,6 +20,7 @@ Available Commands:
   server      Manage MCP servers
   setup       Setup the complete MCP platform
   status      Show platform status
+  team        Manage internal platform teams
 
 Flags:
       --debug     Enable debug mode with structured error logging

--- a/test/golden/cli/testdata/mcp-runtime_server_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_server_help.golden
@@ -15,6 +15,7 @@ Available Commands:
   build       Build MCP server images (push via `registry push`)
   create      Create an MCP server
   delete      Delete an MCP server
+  deploy      Deploy an MCP server through the platform API
   export      Export an MCP server manifest
   get         Get MCP server details
   list        List MCP servers

--- a/test/golden/cli/testdata/mcp-runtime_server_list_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_server_list_help.golden
@@ -5,7 +5,8 @@ Usage:
 
 Flags:
   -h, --help               help for list
-      --namespace string   Namespace to list servers from (default "mcp-servers")
+      --namespace string   Namespace to list servers from
+      --team string        Team slug to resolve namespace from via the platform API
 
 Global Flags:
       --debug      Enable debug mode with structured error logging


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces team-scoped internal multi-tenancy, enhancing the platform's API and CLI for managing resources within defined organizational boundaries.

Key changes include:

*   **Team-Scoped Multi-Tenancy Implementation**:
    *   Introduced new database tables (`teams`, `team_memberships`) and updated the `namespaces` table to support team ownership and scope.
    *   The `principal` authorization object now includes `AllowedNamespaces` and `Teams` information, enabling fine-grained access control.
    *   New API endpoints for managing teams:
        *   `GET /api/runtime/teams`: Lists all teams for admins, or user's memberships for non-admins.
        *   `POST /api/runtime/teams`: Allows admins to create new teams and associated namespaces.
        *   `GET /api/runtime/teams/{team}`: Retrieves metadata for a specific team (accessible by admins or team members).
        *   `POST /api/runtime/teams/{team}/members`: Upserts team memberships (admin or team owner).
        *   `DELETE /api/runtime/teams/{team}/members/{userID}`: Removes team memberships (admin or team owner).
    *   New API endpoints for managing namespaces:
        *   `GET /api/runtime/namespaces`: Lists allowed namespaces and shared catalog metadata for the caller's scope.
        *   `GET /api/runtime/namespaces/{namespace}`: Retrieves metadata for a specific namespace when authorized.
    *   Runtime write paths (e.g., creating servers, grants, sessions) now enforce namespace ownership through team membership for non-admin users and reject writes to the shared `mcp-servers` catalog namespace.
    *   Image validation for server deployments now checks if the image repository is scoped to the user's team slug for non-admin users.

*   **Enhanced `MCPServer` Management**:
    *   The `/api/runtime/servers` endpoint now supports `POST` requests for creating and updating `MCPServer` resources through the platform API, with team-scoped authorization.
    *   `MCPServer` deployments are configured to use a dedicated `mcp-workload` service account and disable automounting of service account tokens for improved security.
    *   Kubernetes RBAC rules for the API server are updated to allow `create`, `update`, `patch`, and `delete` verbs on `MCPServer` resources, and `create` on `ServiceAccount` resources.

*   **CLI Updates**:
    *   A new top-level `mcp-runtime team` command is added, with subcommands `list` and `create` for managing teams via the platform API.
    *   The `mcp-runtime server` command now includes a `deploy` subcommand for deploying `MCPServer` resources through the platform API, supporting arguments for name, namespace/team, image, replicas, and ports.
    *   The `mcp-runtime server list` command now accepts a `--team` flag to filter servers by team-associated namespaces.
    *   `mcp-runtime server list` now defaults to the user's preferred namespace or the shared catalog namespace when no namespace or team is specified.

*   **User Interface (UI) Enhancements**:
    *   The web UI now includes a namespace/scope selector, allowing users to switch between their allowed namespaces (user-owned, team-owned, or shared catalog) for viewing and managing resources.
    *   The UI dynamically loads and displays available namespaces based on the authenticated user's permissions.

*   **Improved Error Reporting**:
    *   `kubectl` command failures during bootstrap now provide more detailed and user-friendly error messages, including hints for common connection issues.

*   **CI/CD Workflow**:
    *   The GitHub Actions CI workflow is updated to use `concurrency` settings, ensuring that only one workflow run for a given pull request is in progress at a time, canceling older runs.
<!-- kody-pr-summary:end -->