### PR TITLE
[codex] Add MCP server descriptions

### DIFF
--- a/api/v1alpha1/deepcopy_test.go
+++ b/api/v1alpha1/deepcopy_test.go
@@ -217,6 +217,7 @@ func TestResourceRequirementsDeepCopyWithNilPointers(t *testing.T) {
 func TestMCPServerSpecDeepCopy(t *testing.T) {
 	replicas := int32(3)
 	original := MCPServerSpec{
+		Description:            "Test server for deepcopy coverage.",
 		Image:                  "test-image",
 		ImageTag:               "v1.0.0",
 		RegistryOverride:       "registry.example.com",
@@ -315,6 +316,9 @@ func assertSpecSimpleFields(t *testing.T, copied, original *MCPServerSpec) {
 	t.Helper()
 	if copied == nil || original == nil {
 		t.Fatal("MCPServerSpec is nil")
+	}
+	if copied.Description != original.Description {
+		t.Errorf("Description = %q, want %q", copied.Description, original.Description)
 	}
 	if copied.Image != original.Image {
 		t.Errorf("Image = %q, want %q", copied.Image, original.Image)

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -50,6 +50,9 @@ const (
 // MCPServerSpec defines the desired state of MCPServer.
 // +kubebuilder:object:generate=true
 type MCPServerSpec struct {
+	// Description is a human-readable summary of what the MCP server provides.
+	Description string `json:"description,omitempty"`
+
 	// Image is the container image for the MCP server.
 	Image string `json:"image"`
 

--- a/config/crd/bases/mcpruntime.org_mcpservers.yaml
+++ b/config/crd/bases/mcpruntime.org_mcpservers.yaml
@@ -111,6 +111,10 @@ spec:
                   tokenHeader:
                     type: string
                 type: object
+              description:
+                description: Description is a human-readable summary of what the MCP
+                  server provides.
+                type: string
               envVars:
                 description: EnvVars are literal environment variables to pass to
                   the container.

--- a/docs/api.md
+++ b/docs/api.md
@@ -71,6 +71,7 @@ metadata:
   name: payments
   namespace: mcp-servers
 spec:
+  description: Payments MCP server for invoice lookup and refund workflows.
   image: registry.example.com/payments-mcp
   port: 8088
   publicPathPrefix: payments
@@ -94,8 +95,10 @@ spec:
     idleTimeout: 1h
   tools:
     - name: list_invoices
+      description: List invoices for a customer account.
       requiredTrust: low
     - name: refund_invoice
+      description: Issue a refund for an invoice.
       requiredTrust: high
   analytics:
     enabled: true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -248,6 +248,7 @@ cat > /tmp/go-example-mcp.yaml <<'EOF'
 version: v1
 servers:
   - name: go-example-mcp
+    description: Go MCP example server with smoke and text transformation tools.
     route: /go-example-mcp/mcp
     publicPathPrefix: go-example-mcp
     port: 8088
@@ -257,8 +258,10 @@ servers:
         value: /go-example-mcp/mcp
     tools:
       - name: add
+        description: Add two numbers.
         requiredTrust: low
       - name: upper
+        description: Uppercase the provided message.
         requiredTrust: medium
     auth:
       mode: header

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -795,6 +795,9 @@ func (in *MCPServerList) DeepCopyObject() runtime.Object
 <a id="api-types-type-mcpserverspec-struct"></a>
 ```text
 type MCPServerSpec struct {
+	// Description is a human-readable summary of what the MCP server provides.
+	Description string `json:"description,omitempty"`
+
 	// Image is the container image for the MCP server.
 	Image string `json:"image"`
 
@@ -1639,6 +1642,9 @@ type SecretKeyRef struct {
 type ServerMetadata struct {
 	// Name is the unique name of the MCP server.
 	Name string `yaml:"name" json:"name"`
+
+	// Description is a human-readable summary of what the MCP server provides.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 
 	// Image is the container image for the server.
 	Image string `yaml:"image" json:"image"`
@@ -4100,12 +4106,13 @@ func (c *PlatformClient) RecordImagePublish(ctx context.Context, record ImagePub
 <a id="cli-platform-api-type-serverlistitem-struct"></a>
 ```text
 type ServerListItem struct {
-	Name      string            `json:"name"`
-	Namespace string            `json:"namespace"`
-	Ready     string            `json:"ready"`
-	Status    string            `json:"status"`
-	Labels    map[string]string `json:"labels"`
-	Age       string            `json:"age"`
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Description string            `json:"description,omitempty"`
+	Ready       string            `json:"ready"`
+	Status      string            `json:"status"`
+	Labels      map[string]string `json:"labels"`
+	Age         string            `json:"age"`
 }
     ServerListItem is one row from the platform API runtime servers list.
 

--- a/docs/internals/pkg-metadata.md
+++ b/docs/internals/pkg-metadata.md
@@ -25,6 +25,7 @@ servers:
 `ServerMetadata` mirrors the parts of `MCPServerSpec` that contributors commonly
 author by hand:
 
+- server description
 - image and tag
 - route, ingress host, and public path prefix
 - container port and replicas

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -10,7 +10,7 @@ This guide covers the user-facing path for getting an MCP server into MCP Runtim
 
 Use this guide after [Getting started](getting-started.md) once the platform stack is already installed.
 
-## Choose a description format
+## Choose an authoring format
 
 You can describe a server in two ways:
 
@@ -32,6 +32,7 @@ metadata:
   name: payments
   namespace: mcp-servers
 spec:
+  description: Payments MCP server for invoice lookup and refund workflows.
   image: registry.example.com/payments
   imageTag: v1.0.0
   port: 8088
@@ -48,6 +49,8 @@ spec:
   The server name inside the platform. This is also the default public route prefix when you do not override it.
 - `metadata.namespace`
   Usually `mcp-servers`.
+- `spec.description`
+  A short platform-facing summary shown in the server catalog.
 - `spec.image`
   The image repository to run.
 - `spec.imageTag`
@@ -67,7 +70,8 @@ spec:
 - Add `spec.servicePort` when you want a Service port other than `80`.
 - Add `spec.envVars` or `spec.secretEnvVars` for runtime configuration.
 - Add `spec.imagePullSecrets` if your registry requires explicit pull credentials.
-- Add `spec.tools`, `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you want stricter governance or more delivery control.
+- Add `spec.tools` with tool descriptions and trust levels so the platform catalog mirrors the tool summaries clients see from `tools/list`.
+- Add `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you want stricter governance or more delivery control.
 
 Apply the manifest:
 
@@ -86,6 +90,7 @@ Example:
 version: v1
 servers:
   - name: payments
+    description: Payments MCP server for invoice lookup and refund workflows.
     image: registry.example.com/payments
     imageTag: v1.0.0
     route: /payments
@@ -98,6 +103,8 @@ servers:
 
 - `name`
   The server name.
+- `description`
+  A short platform-facing summary shown in the server catalog.
 - `image`
   The image repository.
 - `imageTag`
@@ -110,6 +117,8 @@ servers:
   The desired replica count.
 - `namespace`
   The target namespace.
+- `tools`
+  Tool inventory for the platform catalog and policy authoring. Include each tool's description when the MCP server SDK exposes one through `tools/list`.
 
 ### Metadata defaults
 

--- a/examples/go-mcp-server/.mcp/servers.yaml
+++ b/examples/go-mcp-server/.mcp/servers.yaml
@@ -1,6 +1,7 @@
 version: v1
 servers:
   - name: go-example-mcp
+    description: Go MCP example server with smoke, text transformation, prompt, and resource examples.
     route: /go-example-mcp/mcp
     publicPathPrefix: go-example-mcp
     port: 8088
@@ -10,14 +11,20 @@ servers:
         value: /go-example-mcp/mcp
     tools:
       - name: aaa-ping
+        description: Return a simple pong response.
         requiredTrust: low
       - name: echo
+        description: Echo back the provided message.
         requiredTrust: low
       - name: add
+        description: Add two numbers.
         requiredTrust: low
       - name: upper
+        description: Uppercase the provided message.
         requiredTrust: medium
       - name: lower
+        description: Lowercase the provided message.
         requiredTrust: low
       - name: slugify
+        description: Convert the provided message into a URL slug.
         requiredTrust: low

--- a/examples/mcpserver-path-based.yaml
+++ b/examples/mcpserver-path-based.yaml
@@ -4,6 +4,7 @@ metadata:
   name: go-example-mcp
   namespace: mcp-servers
 spec:
+  description: Go MCP example server with smoke, text transformation, prompt, and resource examples.
   image: your-registry.local/go-mcp-server
   imageTag: latest
   port: 8088
@@ -15,3 +16,22 @@ spec:
   envVars:
     - name: MCP_PATH
       value: /go-example-mcp/mcp
+  tools:
+    - name: aaa-ping
+      description: Return a simple pong response.
+      requiredTrust: low
+    - name: echo
+      description: Echo back the provided message.
+      requiredTrust: low
+    - name: add
+      description: Add two numbers.
+      requiredTrust: low
+    - name: upper
+      description: Uppercase the provided message.
+      requiredTrust: medium
+    - name: lower
+      description: Lowercase the provided message.
+      requiredTrust: low
+    - name: slugify
+      description: Convert the provided message into a URL slug.
+      requiredTrust: low

--- a/examples/python-mcp-server/.mcp/servers.yaml
+++ b/examples/python-mcp-server/.mcp/servers.yaml
@@ -1,6 +1,7 @@
 version: v1
 servers:
   - name: python-example-mcp
+    description: Python MCP example server with simple echo and string reversal tools.
     route: /python-example-mcp/mcp
     publicPathPrefix: python-example-mcp
     port: 8088
@@ -10,6 +11,8 @@ servers:
         value: /python-example-mcp/mcp
     tools:
       - name: echo
+        description: Echo the provided message.
         requiredTrust: low
       - name: reverse
+        description: Reverse the provided message.
         requiredTrust: low

--- a/examples/rust-mcp-server/.mcp/servers.yaml
+++ b/examples/rust-mcp-server/.mcp/servers.yaml
@@ -1,6 +1,7 @@
 version: v1
 servers:
   - name: rust-example-mcp
+    description: Rust MCP example server with repeat and word-count tools.
     route: /rust-example-mcp/mcp
     publicPathPrefix: rust-example-mcp
     port: 8088
@@ -10,6 +11,8 @@ servers:
         value: /rust-example-mcp/mcp
     tools:
       - name: repeat
+        description: Repeat the provided message a number of times.
         requiredTrust: low
       - name: word_count
+        description: Count the words in the provided message.
         requiredTrust: low

--- a/internal/cli/platformapi/client.go
+++ b/internal/cli/platformapi/client.go
@@ -456,12 +456,13 @@ func httpAPIError(status int, body []byte) error {
 
 // ServerListItem is one row from the platform API runtime servers list.
 type ServerListItem struct {
-	Name      string            `json:"name"`
-	Namespace string            `json:"namespace"`
-	Ready     string            `json:"ready"`
-	Status    string            `json:"status"`
-	Labels    map[string]string `json:"labels"`
-	Age       string            `json:"age"`
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Description string            `json:"description,omitempty"`
+	Ready       string            `json:"ready"`
+	Status      string            `json:"status"`
+	Labels      map[string]string `json:"labels"`
+	Age         string            `json:"age"`
 }
 
 type serverListResponse struct {

--- a/pkg/metadata/crd_generator.go
+++ b/pkg/metadata/crd_generator.go
@@ -24,10 +24,11 @@ func GenerateCRD(server *ServerMetadata, outputPath string) error {
 			Namespace: server.Namespace,
 		},
 		Spec: mcpv1alpha1.MCPServerSpec{
-			Image:    server.Image,
-			ImageTag: server.ImageTag,
-			Port:     server.Port,
-			Replicas: server.Replicas,
+			Description: server.Description,
+			Image:       server.Image,
+			ImageTag:    server.ImageTag,
+			Port:        server.Port,
+			Replicas:    server.Replicas,
 		},
 	}
 

--- a/pkg/metadata/crd_generator_test.go
+++ b/pkg/metadata/crd_generator_test.go
@@ -17,6 +17,7 @@ func TestGenerateCRD(t *testing.T) {
 		replicas := int32(2)
 		server := &ServerMetadata{
 			Name:             "test-server",
+			Description:      "Test server for CRD generation.",
 			Image:            "my-image",
 			ImageTag:         "v1.0.0",
 			Route:            "/test/mcp",
@@ -44,6 +45,7 @@ func TestGenerateCRD(t *testing.T) {
 		assertContains(t, content, "kind: MCPServer")
 		assertContains(t, content, "name: test-server")
 		assertContains(t, content, "namespace: custom-ns")
+		assertContains(t, content, "description: Test server for CRD generation.")
 		assertContains(t, content, "image: my-image")
 		assertContains(t, content, "imageTag: v1.0.0")
 		assertContains(t, content, "port: 9000")
@@ -148,7 +150,7 @@ func TestGenerateCRD(t *testing.T) {
 				HeaderName: "X-MCP-Agent-Session",
 			},
 			Tools: []ToolConfig{
-				{Name: "delete_user", RequiredTrust: TrustLevel("high")},
+				{Name: "delete_user", Description: "Delete a user from the backing system.", RequiredTrust: TrustLevel("high")},
 			},
 			SecretEnvVars: []SecretEnvVar{
 				{
@@ -214,6 +216,7 @@ func TestGenerateCRD(t *testing.T) {
 		}
 		tool := assertMapItem(t, tools[0], "tools[0]")
 		assertMapStringValue(t, tool, "name", "delete_user")
+		assertMapStringValue(t, tool, "description", "Delete a user from the backing system.")
 		assertMapStringValue(t, tool, "requiredTrust", "high")
 
 		secretEnvVars := assertSliceValue(t, spec, "secretEnvVars")

--- a/pkg/metadata/loader_test.go
+++ b/pkg/metadata/loader_test.go
@@ -35,13 +35,14 @@ func TestLoadFromFile(t *testing.T) {
 						Namespace: "mcp-servers",
 					},
 					{
-						Name:      "custom-server",
-						Image:     "custom/image",
-						ImageTag:  "v1",
-						Route:     "/custom-route",
-						Port:      9090,
-						Replicas:  int32Ptr(3),
-						Namespace: "custom-namespace",
+						Name:        "custom-server",
+						Description: "Example server for testing metadata loading.",
+						Image:       "custom/image",
+						ImageTag:    "v1",
+						Route:       "/custom-route",
+						Port:        9090,
+						Replicas:    int32Ptr(3),
+						Namespace:   "custom-namespace",
 						Gateway: &GatewayConfig{
 							Enabled:     true,
 							Image:       "example.com/mcp-proxy:latest",
@@ -70,8 +71,8 @@ func TestLoadFromFile(t *testing.T) {
 							UpstreamTokenHeader: "Authorization",
 						},
 						Tools: []ToolConfig{
-							{Name: "list_tools", RequiredTrust: TrustLevel("low")},
-							{Name: "delete_user", RequiredTrust: TrustLevel("high")},
+							{Name: "list_tools", Description: "List tools exposed by the server.", RequiredTrust: TrustLevel("low")},
+							{Name: "delete_user", Description: "Delete a user from the backing system.", RequiredTrust: TrustLevel("high")},
 						},
 						SecretEnvVars: []SecretEnvVar{
 							{
@@ -138,6 +139,9 @@ func TestLoadFromFile(t *testing.T) {
 				want := test.want.Servers[i]
 				if got.Name != want.Name {
 					t.Errorf("server[%d].Name = %q, want %q", i, got.Name, want.Name)
+				}
+				if got.Description != want.Description {
+					t.Errorf("server[%d].Description = %q, want %q", i, got.Description, want.Description)
 				}
 				if got.Image != want.Image {
 					t.Errorf("server[%d].Image = %q, want %q", i, got.Image, want.Image)

--- a/pkg/metadata/schema.go
+++ b/pkg/metadata/schema.go
@@ -48,6 +48,9 @@ type ServerMetadata struct {
 	// Name is the unique name of the MCP server.
 	Name string `yaml:"name" json:"name"`
 
+	// Description is a human-readable summary of what the MCP server provides.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+
 	// Image is the container image for the server.
 	Image string `yaml:"image" json:"image"`
 

--- a/pkg/metadata/testdata/valid.yaml
+++ b/pkg/metadata/testdata/valid.yaml
@@ -2,6 +2,7 @@ version: v1
 servers:
   - name: test-server
   - name: custom-server
+    description: Example server for testing metadata loading.
     image: custom/image
     imageTag: v1
     route: custom-route
@@ -19,8 +20,10 @@ servers:
       required: true
     tools:
       - name: list_tools
+        description: List tools exposed by the server.
         requiredTrust: low
       - name: delete_user
+        description: Delete a user from the backing system.
         requiredTrust: high
     analytics:
       enabled: true

--- a/services/api/runtime.go
+++ b/services/api/runtime.go
@@ -364,18 +364,19 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 }
 
 type serverInfo struct {
-	Name       string                      `json:"name"`
-	Namespace  string                      `json:"namespace"`
-	Ready      string                      `json:"ready"`
-	Status     string                      `json:"status"`
-	Labels     map[string]string           `json:"labels,omitempty"`
-	Age        string                      `json:"age"`
-	Endpoint   string                      `json:"endpoint,omitempty"`
-	Tools      []mcpv1alpha1.ToolConfig    `json:"tools,omitempty"`
-	Prompts    []mcpv1alpha1.InventoryItem `json:"prompts"`
-	Resources  []mcpv1alpha1.InventoryItem `json:"resources"`
-	Tasks      []mcpv1alpha1.InventoryItem `json:"tasks"`
-	AccessJSON map[string]any              `json:"access_json,omitempty"`
+	Name        string                      `json:"name"`
+	Namespace   string                      `json:"namespace"`
+	Description string                      `json:"description,omitempty"`
+	Ready       string                      `json:"ready"`
+	Status      string                      `json:"status"`
+	Labels      map[string]string           `json:"labels,omitempty"`
+	Age         string                      `json:"age"`
+	Endpoint    string                      `json:"endpoint,omitempty"`
+	Tools       []mcpv1alpha1.ToolConfig    `json:"tools,omitempty"`
+	Prompts     []mcpv1alpha1.InventoryItem `json:"prompts"`
+	Resources   []mcpv1alpha1.InventoryItem `json:"resources"`
+	Tasks       []mcpv1alpha1.InventoryItem `json:"tasks"`
+	AccessJSON  map[string]any              `json:"access_json,omitempty"`
 }
 
 type serverDeploymentStatus struct {
@@ -407,17 +408,18 @@ func serverInfoFromMCPServer(mcpServer mcpv1alpha1.MCPServer, deploymentStatus s
 	endpoint := publicMCPEndpoint(mcpServer)
 	connectEndpoint := publicMCPConnectEndpoint(endpoint, r)
 	info := serverInfo{
-		Name:      mcpServer.Name,
-		Namespace: mcpServer.Namespace,
-		Ready:     deploymentStatus.Ready,
-		Status:    deploymentStatus.Status,
-		Labels:    mcpServer.Labels,
-		Age:       mcpServer.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
-		Endpoint:  endpoint,
-		Tools:     mcpServer.Spec.Tools,
-		Prompts:   inventoryItemsOrEmpty(mcpServer.Spec.Prompts),
-		Resources: inventoryItemsOrEmpty(mcpServer.Spec.MCPResources),
-		Tasks:     inventoryItemsOrEmpty(mcpServer.Spec.Tasks),
+		Name:        mcpServer.Name,
+		Namespace:   mcpServer.Namespace,
+		Description: mcpServer.Spec.Description,
+		Ready:       deploymentStatus.Ready,
+		Status:      deploymentStatus.Status,
+		Labels:      mcpServer.Labels,
+		Age:         mcpServer.CreationTimestamp.Format("2006-01-02T15:04:05Z"),
+		Endpoint:    endpoint,
+		Tools:       mcpServer.Spec.Tools,
+		Prompts:     inventoryItemsOrEmpty(mcpServer.Spec.Prompts),
+		Resources:   inventoryItemsOrEmpty(mcpServer.Spec.MCPResources),
+		Tasks:       inventoryItemsOrEmpty(mcpServer.Spec.Tasks),
 	}
 	if connectEndpoint != "" {
 		info.AccessJSON = map[string]any{

--- a/services/api/runtime_test.go
+++ b/services/api/runtime_test.go
@@ -143,6 +143,7 @@ func TestRuntimeServersIncludesMCPServerInventory(t *testing.T) {
 			CreationTimestamp: metav1.Now(),
 		},
 		Spec: mcpv1alpha1.MCPServerSpec{
+			Description:      "Demo server for basic arithmetic and text tools.",
 			Image:            "demo:latest",
 			PublicPathPrefix: "demo-one",
 			Tools: []mcpv1alpha1.ToolConfig{
@@ -185,6 +186,9 @@ func TestRuntimeServersIncludesMCPServerInventory(t *testing.T) {
 	got := payload.Servers[0]
 	if got.Name != "demo-one" || len(got.Tools) != 1 || got.Tools[0].Name != "add" {
 		t.Fatalf("server inventory = %#v", got)
+	}
+	if got.Description != "Demo server for basic arithmetic and text tools." {
+		t.Fatalf("description = %q", got.Description)
 	}
 	if len(got.Prompts) != 1 || got.Prompts[0].Name != "summarize" {
 		t.Fatalf("prompts = %#v", got.Prompts)

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -1135,16 +1135,24 @@ function setText(id, value) {
 }
 
 function renderInventoryBlock(label, items, itemRenderer) {
-  const block = document.createElement("div");
+  const block = document.createElement("details");
   block.className = "inventory-block";
-  const heading = document.createElement("h4");
-  heading.textContent = label;
-  block.appendChild(heading);
+  const summary = document.createElement("summary");
+  summary.className = "inventory-section-summary";
+  summary.innerHTML = `
+    <span>${escapeHtml(label)}</span>
+    <small>${formatNumber(items.length)}</small>
+  `;
+  block.appendChild(summary);
+
+  const body = document.createElement("div");
+  body.className = "inventory-section-body";
   if (!items.length) {
     const empty = document.createElement("p");
     empty.className = "inventory-empty";
     empty.textContent = "None";
-    block.appendChild(empty);
+    body.appendChild(empty);
+    block.appendChild(body);
     return block;
   }
   const list = document.createElement("ul");
@@ -1153,27 +1161,57 @@ function renderInventoryBlock(label, items, itemRenderer) {
     li.innerHTML = itemRenderer(item);
     list.appendChild(li);
   });
-  block.appendChild(list);
+  body.appendChild(list);
+  block.appendChild(body);
   return block;
 }
 
 function renderToolItem(tool) {
-  const trust = tool.requiredTrust ? ` <span class="trust-chip">${escapeHtml(tool.requiredTrust)}</span>` : "";
-  const desc = tool.description ? `<small>${escapeHtml(tool.description)}</small>` : "";
-  return `<strong>${escapeHtml(tool.name || "-")}</strong>${trust}${desc}`;
+  const trust = tool.requiredTrust ? `<span class="trust-chip">${escapeHtml(tool.requiredTrust)}</span>` : "";
+  const labels = renderInventoryLabels(tool.labels);
+  return renderExpandableInventoryItem({
+    name: tool.name || "-",
+    summaryMeta: trust,
+    description: tool.description,
+    labels,
+  });
 }
 
 function renderInventoryItem(item) {
   if (typeof item === "string") {
-    return `<strong>${escapeHtml(item || "-")}</strong>`;
+    return renderExpandableInventoryItem({ name: item || "-" });
   }
-  const name = item?.name || "-";
-  const desc = item?.description ? `<small>${escapeHtml(item.description)}</small>` : "";
-  const labels = item?.labels && typeof item.labels === "object" ? Object.entries(item.labels) : [];
-  const labelsText = labels.length
-    ? `<small>${escapeHtml(labels.map(([k, v]) => `${k}=${v}`).join(", "))}</small>`
-    : "";
-  return `<strong>${escapeHtml(name)}</strong>${desc}${labelsText}`;
+  return renderExpandableInventoryItem({
+    name: item?.name || "-",
+    description: item?.description,
+    labels: renderInventoryLabels(item?.labels),
+  });
+}
+
+function renderExpandableInventoryItem({ name, summaryMeta = "", description = "", labels = "" }) {
+  const details = description
+    ? `<p>${escapeHtml(description)}</p>`
+    : '<p class="muted-text">No description</p>';
+  const labelRows = labels ? `<div class="inventory-label-list">${labels}</div>` : "";
+  return `
+    <details class="inventory-item">
+      <summary>
+        <strong>${escapeHtml(name || "-")}</strong>
+        ${summaryMeta}
+      </summary>
+      <div class="inventory-item-body">
+        ${details}
+        ${labelRows}
+      </div>
+    </details>
+  `;
+}
+
+function renderInventoryLabels(labels) {
+  if (!labels || typeof labels !== "object") return "";
+  return Object.entries(labels)
+    .map(([key, value]) => `<span>${escapeHtml(key)}=${escapeHtml(value)}</span>`)
+    .join("");
 }
 
 function initDashboard() {

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -976,6 +976,7 @@ function serverSearchText(server) {
   const values = [
     server.name,
     server.namespace,
+    server.description,
     server.status,
     server.ready,
     server.endpoint,
@@ -1010,12 +1011,16 @@ function renderServerCatalogSummary() {
 function renderServerHero(server) {
   const hero = document.createElement("div");
   hero.className = "server-card-hero";
+  const description = server.description
+    ? `<p class="server-description">${escapeHtml(server.description)}</p>`
+    : "";
   hero.innerHTML = `
     <div class="server-identity">
       <span class="server-avatar" aria-hidden="true">${escapeHtml(serverInitials(server.name))}</span>
       <div class="server-title-stack">
         <h3>${escapeHtml(server.name || "-")}</h3>
         <p>${escapeHtml(server.namespace || "-")}</p>
+        ${description}
       </div>
     </div>
     <div class="server-status-stack">
@@ -2032,6 +2037,9 @@ function renderSelectedOperationServer() {
   const labels = server.labels && typeof server.labels === "object"
     ? Object.entries(server.labels)
     : [];
+  const description = server.description
+    ? `<p class="server-description">${escapeHtml(server.description)}</p>`
+    : "";
   detail.innerHTML = `
     <div class="server-inspector-head">
       <div class="server-identity">
@@ -2039,6 +2047,7 @@ function renderSelectedOperationServer() {
         <div class="server-title-stack">
           <h3>${escapeHtml(server.name || "-")}</h3>
           <p>${escapeHtml(server.namespace || "-")}</p>
+          ${description}
         </div>
       </div>
       <span class="badge ${serverBadgeClass(server.status)}">${escapeHtml(server.status || "Unknown")}</span>

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -1154,6 +1154,7 @@ tr:hover td {
 
 .server-description {
   color: var(--text);
+  font-size: 13px;
   line-height: 1.35;
   max-width: 56ch;
 }

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -1123,6 +1123,8 @@ tr:hover td {
 }
 
 .server-title-stack {
+  display: grid;
+  gap: 4px;
   min-width: 0;
 }
 
@@ -1148,6 +1150,12 @@ tr:hover td {
   color: var(--muted);
   font-size: 13px;
   overflow-wrap: anywhere;
+}
+
+.server-description {
+  color: var(--text);
+  line-height: 1.35;
+  max-width: 56ch;
 }
 
 .server-status-stack {

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -1232,20 +1232,73 @@ tr:hover td {
 }
 
 .server-inventory-grid {
+  align-items: start;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
 }
 
 .inventory-block {
+  background: rgba(247, 245, 239, 0.04);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 8px;
   min-width: 0;
+  overflow: hidden;
 }
 
-.inventory-block h4 {
+.inventory-section-summary {
+  align-items: center;
   color: var(--accent);
+  cursor: pointer;
+  display: flex;
   font-size: 13px;
-  margin-bottom: 6px;
+  font-weight: 700;
+  gap: 10px;
+  justify-content: space-between;
+  list-style: none;
+  min-height: 42px;
+  padding: 10px 12px;
   text-transform: uppercase;
+}
+
+.inventory-section-summary::-webkit-details-marker,
+.inventory-item summary::-webkit-details-marker {
+  display: none;
+}
+
+.inventory-section-summary::before,
+.inventory-item summary::before {
+  color: var(--muted);
+  content: ">";
+  flex: 0 0 auto;
+  font-size: 12px;
+  transform: rotate(0deg);
+  transition: transform 0.16s ease;
+}
+
+.inventory-block[open] > .inventory-section-summary::before,
+.inventory-item[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.inventory-section-summary span:first-child {
+  margin-right: auto;
+}
+
+.inventory-section-summary small {
+  background: rgba(242, 184, 75, 0.12);
+  border: 1px solid rgba(242, 184, 75, 0.24);
+  border-radius: 999px;
+  color: var(--accent);
+  font-size: 11px;
+  min-width: 28px;
+  padding: 3px 8px;
+  text-align: center;
+}
+
+.inventory-section-body {
+  border-top: 1px solid rgba(247, 245, 239, 0.08);
+  padding: 10px;
 }
 
 .inventory-block ul {
@@ -1257,16 +1310,12 @@ tr:hover td {
 }
 
 .inventory-block li {
-  align-items: center;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(247, 245, 239, 0.06);
   border-radius: 6px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  justify-content: space-between;
   min-height: 40px;
-  padding: 8px 10px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .inventory-block span {
@@ -1274,17 +1323,54 @@ tr:hover td {
   font-size: 12px;
 }
 
-.inventory-block small,
+.inventory-item summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  list-style: none;
+  min-height: 40px;
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.inventory-item summary strong {
+  margin-right: auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.inventory-item-body {
+  border-top: 1px solid rgba(247, 245, 239, 0.06);
+  display: grid;
+  gap: 8px;
+  padding: 0 10px 10px 30px;
+}
+
+.inventory-item-body p,
 .inventory-empty {
   color: var(--muted);
   font-size: 12px;
+  line-height: 1.4;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.inventory-label-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.inventory-label-list span {
+  background: rgba(247, 245, 239, 0.06);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  border-radius: 999px;
+  padding: 3px 7px;
 }
 
 .inventory-empty {
-  background: rgba(247, 245, 239, 0.04);
-  border: 1px dashed rgba(247, 245, 239, 0.12);
-  border-radius: 6px;
-  margin: 0;
   min-height: 40px;
   padding: 10px;
 }


### PR DESCRIPTION
## Summary

- Add optional MCP server descriptions to the API type, generated CRD, `.mcp` metadata schema, and metadata-to-CRD generation.
- Return server descriptions from the platform runtime API and show them in the dashboard catalog, server detail view, and search index.
- Populate example MCP servers and docs with server/tool descriptions so `tools/list` descriptions are visible in the platform.
- Make the server inventory UI collapsible: Tools, Prompts, Resources, and Tasks are expandable sections, and each tool/prompt/resource/task row expands independently for descriptions and labels.

## Verification

- `go test ./api/v1alpha1 ./pkg/metadata ./internal/cli/platformapi -count=1`
- `go test ./internal/cli/pipeline ./internal/cli/server -run 'TestPipeline|TestBuild' -count=1`
- `(cd services/api && go test -race -count=1 ./...)`
- `(cd services/ui && go test -race -count=1 ./...)`
- `node --check services/ui/static/app.js`
- `git diff --check`
- Pre-commit hooks on both commits: Gitleaks, go fmt, staticcheck, go vet, root race unit tests, generated-file drift.
- Verified in a Kind contributor test-mode cluster following `docs/getting-started.md#3-contributor-test-mode-cluster`: applied the updated CRD, rolled branch images for operator/API/UI, deployed `go-example-mcp`, confirmed API server/tool descriptions, direct MCP `tools/list` descriptions, and dashboard rendering.
- Rebuilt and rolled the dashboard image after the expandable inventory change, then inspected the live UI in a browser at desktop and mobile widths. Desktop geometry confirmed all four inventory sections start closed at `44px`; after opening Tools and the first tool, Prompts/Resources/Tasks remain collapsed at `44px`. Mobile inspection confirmed no horizontal overflow.

## Notes

- Browser verification still shows the pre-existing Google Fonts CSP block and favicon 404 noise; they are unrelated to this PR.