### PR TITLE
Multi-tenancy verification: docs, doctor RBAC drift check, and e2e scenario

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -550,6 +550,10 @@ namespace. Use `/api/dashboard/summary`, `/api/events`, or
 uses `/api/analytics/usage` for its MCP server, human/agent, tool, and decision
 rollups.
 
+To exercise tenant isolation between two `MCPServer` resources and per-subject
+grant enforcement on the same cluster, see
+[Sentinel → Verifying multi-tenancy](sentinel.md#verifying-multi-tenancy).
+
 ## 4. Install the platform stack
 
 ```bash

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -261,6 +261,45 @@ refund_invoice:allow:high
 
 CLI parity: `mcp-runtime access grant` and `mcp-runtime access session` cover the same CRUD flows. CRs are the source of truth — the UI is a convenience layer.
 
+## Verifying multi-tenancy
+
+Each `MCPServer` is its own tenant: the operator renders a per-server policy ConfigMap (`<server>-gateway-policy`) holding only the grants and sessions whose `serverRef` points at that server, and the `mcp-gateway` sidecar evaluates traffic against that policy alone. To verify isolation end-to-end, deploy two gateway-enabled servers in `mcp-servers` and grant disjoint subjects on each.
+
+Apply two `MCPServer` resources (same image is fine, different `metadata.name` and `publicPathPrefix`) with `gateway.enabled: true`, `auth.mode: header`, `policy.mode: allow-list`, and `session.required: true`. Then apply two grant + session pairs:
+
+```yaml
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAccessGrant
+metadata: {name: alice-tenant-a, namespace: mcp-servers}
+spec:
+  serverRef: {name: tenant-a-mcp}
+  subject:   {humanID: alice, agentID: alice-agent}
+  maxTrust: high
+  toolRules: [{name: add, decision: allow, requiredTrust: low}]
+---
+# bob-tenant-b mirrors the above with serverRef tenant-b-mcp and a different toolRule
+```
+
+Confirm each server's policy contains only its own subject:
+
+```bash
+mcp-runtime server policy inspect tenant-a-mcp --namespace mcp-servers   # alice only
+mcp-runtime server policy inspect tenant-b-mcp --namespace mcp-servers   # bob only
+```
+
+Drive the cross-tenant matrix using the configured identity headers (`X-MCP-Human-ID`, `X-MCP-Agent-ID`, `X-MCP-Agent-Session`). The expected outcomes distinguish the two deny modes:
+
+| Subject | Tenant | Tool | Outcome |
+|---|---|---|---|
+| alice | A | grant-listed tool | **200** allow |
+| alice | A | other tool | **403** — known subject, tool not in grant |
+| alice | B | any | **401** — gateway has no session/grant for alice on B |
+| bob | B | grant-listed tool | **200** allow |
+| bob | A | any | **401** |
+| no headers / unknown session | any | any | **401** (`reason: session_not_found`) |
+
+The 401-vs-403 split is the multi-tenancy signal: cross-tenant traffic is rejected at session lookup before tool evaluation; same-tenant unallowed tools are rejected by allow-list policy. Audit confirms it: `/api/events/filter?server=<name>` returns events scoped to that server only, and cross-tenant attempts appear as denies on the *targeted* server with the source subject preserved — never on the other tenant.
+
 ## Manifests
 
 | Group | Files |

--- a/internal/cli/cluster/doctor_impl.go
+++ b/internal/cli/cluster/doctor_impl.go
@@ -580,18 +580,23 @@ func checkOperatorRecentReconcileErrors(kubectl core.KubectlRunner) DoctorCheck 
 	}
 }
 
-// operatorClusterRoleResources is the minimum set of core/k8s resources the
-// deployed operator ClusterRole must allow (verbs at least get;list;watch) for
-// the controller-runtime informer cache to sync. A drift here typically means
-// the cluster was set up against an older config/rbac/role.yaml and never
+type operatorClusterRoleResource struct {
+	Resource string
+	APIGroup string
+}
+
+// operatorClusterRoleResources is the minimum set of resource/API group pairs
+// the deployed operator ClusterRole must allow (verbs at least get;list;watch)
+// for the controller-runtime informer cache to sync. A drift here typically
+// means the cluster was set up against an older config/rbac/role.yaml and never
 // re-ran setup; the symptom is silent: MCPServer creates land in etcd but the
 // operator never reconciles them.
-var operatorClusterRoleResources = []string{
-	"serviceaccounts",
-	"configmaps",
-	"services",
-	"deployments",
-	"ingresses",
+var operatorClusterRoleResources = []operatorClusterRoleResource{
+	{Resource: "serviceaccounts", APIGroup: ""},
+	{Resource: "configmaps", APIGroup: ""},
+	{Resource: "services", APIGroup: ""},
+	{Resource: "deployments", APIGroup: "apps"},
+	{Resource: "ingresses", APIGroup: "networking.k8s.io"},
 }
 
 func checkOperatorClusterRoleRules(kubectl core.KubectlRunner) DoctorCheck {
@@ -619,43 +624,21 @@ func checkOperatorClusterRoleRules(kubectl core.KubectlRunner) DoctorCheck {
 	}
 
 	required := []string{"get", "list", "watch"}
-	hasVerbs := func(verbs []string) bool {
-		set := map[string]bool{}
-		for _, v := range verbs {
-			set[v] = true
-		}
-		if set["*"] {
-			return true
-		}
-		for _, r := range required {
-			if !set[r] {
-				return false
-			}
-		}
-		return true
-	}
 
 	var missing []string
 	for _, want := range operatorClusterRoleResources {
-		ok := false
+		verbs := map[string]bool{}
 		for _, rule := range role.Rules {
-			covered := false
-			for _, res := range rule.Resources {
-				if res == want || res == "*" {
-					covered = true
-					break
-				}
-			}
-			if !covered {
+			if !operatorClusterRoleRuleIncludes(rule.APIGroups, want.APIGroup) ||
+				!operatorClusterRoleRuleIncludes(rule.Resources, want.Resource) {
 				continue
 			}
-			if hasVerbs(rule.Verbs) {
-				ok = true
-				break
+			for _, verb := range rule.Verbs {
+				verbs[verb] = true
 			}
 		}
-		if !ok {
-			missing = append(missing, want)
+		if !operatorClusterRoleHasRequiredVerbs(verbs, required) {
+			missing = append(missing, operatorClusterRoleResourceLabel(want))
 		}
 	}
 
@@ -672,6 +655,34 @@ func checkOperatorClusterRoleRules(kubectl core.KubectlRunner) DoctorCheck {
 		OK:     true,
 		Detail: fmt.Sprintf("get/list/watch present for %d expected resources", len(operatorClusterRoleResources)),
 	}
+}
+
+func operatorClusterRoleRuleIncludes(values []string, want string) bool {
+	for _, got := range values {
+		if got == want || got == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func operatorClusterRoleHasRequiredVerbs(verbs map[string]bool, required []string) bool {
+	if verbs["*"] {
+		return true
+	}
+	for _, verb := range required {
+		if !verbs[verb] {
+			return false
+		}
+	}
+	return true
+}
+
+func operatorClusterRoleResourceLabel(resource operatorClusterRoleResource) string {
+	if resource.APIGroup == "" {
+		return resource.Resource
+	}
+	return resource.Resource + "." + resource.APIGroup
 }
 
 func checkTraefikIngressClass(kubectl core.KubectlRunner) DoctorCheck {

--- a/internal/cli/cluster/doctor_impl.go
+++ b/internal/cli/cluster/doctor_impl.go
@@ -199,6 +199,7 @@ func doctorCheckSpecs(kubectl core.KubectlRunner, distro Distribution) []doctorC
 		{Name: "MCPServer CRD", Detail: "checking that the MCPServer API type is installed", Run: func() DoctorCheck { return checkMCPServerCRD(kubectl) }},
 		{Name: "operator readiness", Detail: "reading ready and desired replicas for the operator deployment", Run: func() DoctorCheck { return checkOperatorReady(kubectl) }},
 		{Name: "operator reconcile errors (last 10m)", Detail: "scanning recent operator logs for reconcile failure patterns", Run: func() DoctorCheck { return checkOperatorRecentReconcileErrors(kubectl) }},
+		{Name: "operator ClusterRole rules", Detail: "verifying mcp-runtime-operator-role grants get/list/watch on the resources the informer cache needs", Run: func() DoctorCheck { return checkOperatorClusterRoleRules(kubectl) }},
 		{Name: "traefik ingressClass", Detail: "checking that the traefik IngressClass exists", Run: func() DoctorCheck { return checkTraefikIngressClass(kubectl) }},
 		{Name: "traefik deployment readiness", Detail: "reading ready and desired replicas for Traefik", Run: func() DoctorCheck { return checkTraefikDeploymentReady(kubectl, distro) }},
 		{Name: "traefik web entrypoint", Detail: "checking the Traefik Service ports for the web entrypoint", Run: func() DoctorCheck { return checkTraefikWebEntrypoint(kubectl, distro) }},
@@ -576,6 +577,100 @@ func checkOperatorRecentReconcileErrors(kubectl core.KubectlRunner) DoctorCheck 
 		Name:   "operator reconcile errors (last 10m)",
 		OK:     true,
 		Detail: "no reconcile error patterns detected",
+	}
+}
+
+// operatorClusterRoleResources is the minimum set of core/k8s resources the
+// deployed operator ClusterRole must allow (verbs at least get;list;watch) for
+// the controller-runtime informer cache to sync. A drift here typically means
+// the cluster was set up against an older config/rbac/role.yaml and never
+// re-ran setup; the symptom is silent: MCPServer creates land in etcd but the
+// operator never reconciles them.
+var operatorClusterRoleResources = []string{
+	"serviceaccounts",
+	"configmaps",
+	"services",
+	"deployments",
+	"ingresses",
+}
+
+func checkOperatorClusterRoleRules(kubectl core.KubectlRunner) DoctorCheck {
+	const name = "operator ClusterRole rules"
+	const remedy = "re-run `./bin/mcp-runtime setup` (or `kubectl apply -k config/rbac/`) to reapply config/rbac/role.yaml; the controller-runtime informer cache will not sync without these"
+
+	cmd, err := kubectl.CommandArgs([]string{"get", "clusterrole", "mcp-runtime-operator-role", "-o", "json"})
+	if err != nil {
+		return DoctorCheck{Name: name, OK: false, Detail: fmt.Sprintf("kubectl error: %v", err), Remedy: remedy}
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return DoctorCheck{Name: name, OK: false, Detail: fmt.Sprintf("ClusterRole mcp-runtime-operator-role not readable: %v", err), Remedy: remedy}
+	}
+
+	var role struct {
+		Rules []struct {
+			APIGroups []string `json:"apiGroups"`
+			Resources []string `json:"resources"`
+			Verbs     []string `json:"verbs"`
+		} `json:"rules"`
+	}
+	if err := json.Unmarshal(out, &role); err != nil {
+		return DoctorCheck{Name: name, OK: false, Detail: fmt.Sprintf("could not parse ClusterRole JSON: %v", err), Remedy: remedy}
+	}
+
+	required := []string{"get", "list", "watch"}
+	hasVerbs := func(verbs []string) bool {
+		set := map[string]bool{}
+		for _, v := range verbs {
+			set[v] = true
+		}
+		if set["*"] {
+			return true
+		}
+		for _, r := range required {
+			if !set[r] {
+				return false
+			}
+		}
+		return true
+	}
+
+	var missing []string
+	for _, want := range operatorClusterRoleResources {
+		ok := false
+		for _, rule := range role.Rules {
+			covered := false
+			for _, res := range rule.Resources {
+				if res == want || res == "*" {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				continue
+			}
+			if hasVerbs(rule.Verbs) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			missing = append(missing, want)
+		}
+	}
+
+	if len(missing) > 0 {
+		return DoctorCheck{
+			Name:   name,
+			OK:     false,
+			Detail: fmt.Sprintf("ClusterRole mcp-runtime-operator-role missing get/list/watch on: %s", strings.Join(missing, ", ")),
+			Remedy: remedy,
+		}
+	}
+	return DoctorCheck{
+		Name:   name,
+		OK:     true,
+		Detail: fmt.Sprintf("get/list/watch present for %d expected resources", len(operatorClusterRoleResources)),
 	}
 }
 

--- a/internal/cli/cluster/doctor_impl_test.go
+++ b/internal/cli/cluster/doctor_impl_test.go
@@ -577,6 +577,10 @@ func TestRunDoctorAggregates(t *testing.T) {
 				return &core.MockCommand{OutputData: []byte("web:8000:32080\n")}
 			case contains(spec.Args, "jsonpath={.spec.ports[0].nodePort}"):
 				return &core.MockCommand{OutputData: []byte("32000")}
+			case contains(spec.Args, "get") && contains(spec.Args, "pod") && argContains(spec.Args, "imageID"):
+				return &core.MockCommand{OutputData: []byte("docker-pullable://registry.k8s.io/pause@sha256:test")}
+			case contains(spec.Args, "get") && contains(spec.Args, "pods") && argContains(spec.Args, "spec.nodeName"):
+				return &core.MockCommand{OutputData: []byte("node-a")}
 			case contains(spec.Args, "curl"):
 				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
 			}
@@ -614,6 +618,10 @@ func TestRunDoctorWithProgressReportsEachCheck(t *testing.T) {
 				return &core.MockCommand{OutputData: []byte("web:8000:32080\n")}
 			case contains(spec.Args, "jsonpath={.spec.ports[0].nodePort}"):
 				return &core.MockCommand{OutputData: []byte("32000")}
+			case contains(spec.Args, "get") && contains(spec.Args, "pod") && argContains(spec.Args, "imageID"):
+				return &core.MockCommand{OutputData: []byte("docker-pullable://registry.k8s.io/pause@sha256:test")}
+			case contains(spec.Args, "get") && contains(spec.Args, "pods") && argContains(spec.Args, "spec.nodeName"):
+				return &core.MockCommand{OutputData: []byte("node-a")}
 			case contains(spec.Args, "curl"):
 				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
 			}
@@ -943,6 +951,66 @@ func TestCheckOperatorRecentReconcileErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckOperatorClusterRoleRules(t *testing.T) {
+	t.Run("accepts split verbs with matching API groups", func(t *testing.T) {
+		check := checkOperatorClusterRoleRulesFromJSON(t, `{
+			"rules": [
+				{"apiGroups":[""],"resources":["serviceaccounts","configmaps","services"],"verbs":["get"]},
+				{"apiGroups":[""],"resources":["serviceaccounts","configmaps","services"],"verbs":["list"]},
+				{"apiGroups":[""],"resources":["serviceaccounts","configmaps","services"],"verbs":["watch"]},
+				{"apiGroups":["apps"],"resources":["deployments"],"verbs":["get","list"]},
+				{"apiGroups":["apps"],"resources":["deployments"],"verbs":["watch"]},
+				{"apiGroups":["networking.k8s.io"],"resources":["ingresses"],"verbs":["get"]},
+				{"apiGroups":["networking.k8s.io"],"resources":["ingresses"],"verbs":["list","watch"]}
+			]
+		}`)
+		if !check.OK {
+			t.Fatalf("expected OK for additive RBAC rules, got detail=%q", check.Detail)
+		}
+	})
+
+	t.Run("requires the expected API group", func(t *testing.T) {
+		check := checkOperatorClusterRoleRulesFromJSON(t, `{
+			"rules": [
+				{"apiGroups":[""],"resources":["serviceaccounts","configmaps","services"],"verbs":["get","list","watch"]},
+				{"apiGroups":["extensions"],"resources":["deployments","ingresses"],"verbs":["get","list","watch"]}
+			]
+		}`)
+		if check.OK {
+			t.Fatal("expected failure for permissions granted on the wrong API groups")
+		}
+		for _, want := range []string{"deployments.apps", "ingresses.networking.k8s.io"} {
+			if !strings.Contains(check.Detail, want) {
+				t.Fatalf("detail should mention %q, got %q", want, check.Detail)
+			}
+		}
+	})
+
+	t.Run("accepts wildcard grants", func(t *testing.T) {
+		check := checkOperatorClusterRoleRulesFromJSON(t, `{
+			"rules": [
+				{"apiGroups":["*"],"resources":["*"],"verbs":["*"]}
+			]
+		}`)
+		if !check.OK {
+			t.Fatalf("expected OK for wildcard RBAC rule, got detail=%q", check.Detail)
+		}
+	})
+}
+
+func checkOperatorClusterRoleRulesFromJSON(t *testing.T, body string) DoctorCheck {
+	t.Helper()
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			if !contains(spec.Args, "mcp-runtime-operator-role") {
+				t.Fatalf("unexpected command args: %v", spec.Args)
+			}
+			return &core.MockCommand{OutputData: []byte(body)}
+		},
+	}
+	return checkOperatorClusterRoleRules(core.NewTestKubectlClient(mock))
 }
 
 func TestCheckMCPServerReconcileSmoke(t *testing.T) {

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -1375,6 +1375,7 @@ func deployOperatorManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap.
 		}
 		return wrappedErr
 	}
+	core.Info("Reapplied operator ClusterRole mcp-runtime-operator-role from config/rbac/role.yaml; run `mcp-runtime cluster doctor` if MCPServer creates ever appear unreconciled")
 
 	// Step 3: Apply manager deployment with structured image replacement
 	core.Info("Applying operator deployment")

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # - verify audit events plus trace/log backends
 #
 # Set E2E_SCENARIOS to a comma-separated subset for local debugging.
-# Supported values: all, smoke-auth, governance, trust, oauth, observability.
+# Supported values: all, smoke-auth, governance, trust, oauth, observability, multitenancy.
 # observability requires the full traffic suite: smoke-auth, governance, trust, oauth.
 #
 # For repeated local debugging, set E2E_CACHE_MODE=1. Cache mode implies
@@ -213,11 +213,11 @@ validate_scenarios() {
   local scenario
   for scenario in "${E2E_SCENARIO_LIST[@]}"; do
     case "${scenario}" in
-      all|smoke-auth|governance|trust|oauth|observability)
+      all|smoke-auth|governance|trust|oauth|observability|multitenancy)
         ;;
       *)
         echo "unsupported E2E scenario: ${scenario}" >&2
-        echo "supported values: all, smoke-auth, governance, trust, oauth, observability" >&2
+        echo "supported values: all, smoke-auth, governance, trust, oauth, observability, multitenancy" >&2
         exit 1
         ;;
     esac
@@ -4300,6 +4300,235 @@ print("-" * (width + 8))
 for key, value in rows:
     print(f"{key:{width}}  {value}")
 PY
+fi
+
+if scenario_selected "multitenancy"; then
+  # Multi-tenancy isolation: deploy two gateway-enabled MCPServers in mcp-servers
+  # that reuse the policy-mcp-server image already in the kind registry, grant
+  # alice on tenant-a and bob on tenant-b, then assert the cross-tenant deny
+  # matrix:
+  #   - allowed tool on own tenant   -> 200
+  #   - same-tenant disallowed tool  -> 403 (subject known, tool not in grant)
+  #   - cross-tenant request         -> 401 (no session/grant for subject on that server)
+  echo "[multitenancy] preparing two-tenant isolation probe"
+
+  MT_NS="mcp-servers"
+  MT_TENANT_A="mt-tenant-a"
+  MT_TENANT_B="mt-tenant-b"
+  MT_HUMAN_A="alice"
+  MT_AGENT_A="alice-agent"
+  MT_SESSION_A="alice-session"
+  MT_HUMAN_B="bob"
+  MT_AGENT_B="bob-agent"
+  MT_SESSION_B="bob-session"
+  MT_IMAGE_REPO="registry.registry.svc.cluster.local:5000/library/${SERVER_NAME}"
+  MT_IMAGE_TAG="latest"
+
+  mt_apply_tenant() {
+    local name="$1" prefix="$2"
+    cat <<EOF | kubectl apply -f -
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPServer
+metadata:
+  name: ${name}
+  namespace: ${MT_NS}
+spec:
+  description: Multi-tenancy verification tenant ${name}.
+  image: ${MT_IMAGE_REPO}
+  imageTag: ${MT_IMAGE_TAG}
+  port: 8088
+  servicePort: 80
+  publicPathPrefix: ${prefix}
+  ingressPath: /${prefix}/mcp
+  envVars:
+    - name: MCP_PATH
+      value: /${prefix}/mcp
+  tools:
+    - name: add
+      description: Add two numbers.
+      requiredTrust: low
+    - name: upper
+      description: Uppercase the provided message.
+      requiredTrust: medium
+  auth:
+    mode: header
+    humanIDHeader: X-MCP-Human-ID
+    agentIDHeader: X-MCP-Agent-ID
+    sessionIDHeader: X-MCP-Agent-Session
+  policy:
+    mode: allow-list
+    defaultDecision: deny
+    policyVersion: v1
+  session:
+    required: true
+  gateway:
+    enabled: true
+EOF
+  }
+
+  mt_apply_tenant "${MT_TENANT_A}" "mt-tenant-a"
+  mt_apply_tenant "${MT_TENANT_B}" "mt-tenant-b"
+
+  echo "[multitenancy] waiting for tenant rollouts"
+  wait_for_deployment_exists "${MT_NS}" "${MT_TENANT_A}"
+  wait_for_deployment_exists "${MT_NS}" "${MT_TENANT_B}"
+  kubectl rollout status "deploy/${MT_TENANT_A}" -n "${MT_NS}" --timeout=180s
+  kubectl rollout status "deploy/${MT_TENANT_B}" -n "${MT_NS}" --timeout=180s
+  wait_for_named_server_ready "${MT_TENANT_A}" "${MT_NS}" 60
+  wait_for_named_server_ready "${MT_TENANT_B}" "${MT_NS}" 60
+
+  echo "[multitenancy] applying alice (tenant-a / add) and bob (tenant-b / upper) grants and sessions"
+  cat <<EOF | kubectl apply -f -
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAccessGrant
+metadata: {name: alice-${MT_TENANT_A}, namespace: ${MT_NS}}
+spec:
+  serverRef: {name: ${MT_TENANT_A}}
+  subject:   {humanID: ${MT_HUMAN_A}, agentID: ${MT_AGENT_A}}
+  maxTrust: high
+  policyVersion: v1
+  toolRules:
+    - {name: add, decision: allow, requiredTrust: low}
+---
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAgentSession
+metadata: {name: ${MT_SESSION_A}, namespace: ${MT_NS}}
+spec:
+  serverRef: {name: ${MT_TENANT_A}}
+  subject:   {humanID: ${MT_HUMAN_A}, agentID: ${MT_AGENT_A}}
+  consentedTrust: high
+  policyVersion: v1
+---
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAccessGrant
+metadata: {name: bob-${MT_TENANT_B}, namespace: ${MT_NS}}
+spec:
+  serverRef: {name: ${MT_TENANT_B}}
+  subject:   {humanID: ${MT_HUMAN_B}, agentID: ${MT_AGENT_B}}
+  maxTrust: high
+  policyVersion: v1
+  toolRules:
+    - {name: upper, decision: allow, requiredTrust: medium}
+---
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAgentSession
+metadata: {name: ${MT_SESSION_B}, namespace: ${MT_NS}}
+spec:
+  serverRef: {name: ${MT_TENANT_B}}
+  subject:   {humanID: ${MT_HUMAN_B}, agentID: ${MT_AGENT_B}}
+  consentedTrust: high
+  policyVersion: v1
+EOF
+
+  echo "[multitenancy] waiting for per-tenant policy materialization"
+  mt_wait_for_session_in_policy() {
+    local server="$1" session="$2" tries=60 i policy_json
+    for i in $(seq 1 "${tries}"); do
+      policy_json="$(kubectl get configmap "${server}-gateway-policy" -n "${MT_NS}" -o "jsonpath={.data.policy\.json}" 2>/dev/null || true)"
+      if [[ -n "${policy_json}" ]] && printf '%s' "${policy_json}" | grep -q "\"name\": \"${session}\""; then
+        return 0
+      fi
+      sleep 2
+    done
+    echo "[multitenancy] timed out waiting for session ${session} in ${server}-gateway-policy" >&2
+    kubectl get configmap "${server}-gateway-policy" -n "${MT_NS}" -o yaml || true
+    return 1
+  }
+  mt_wait_for_session_in_policy "${MT_TENANT_A}" "${MT_SESSION_A}"
+  mt_wait_for_session_in_policy "${MT_TENANT_B}" "${MT_SESSION_B}"
+  # Sidecar polls the rendered policy file; let it observe the new sessions
+  # before issuing the matrix.
+  sleep 6
+
+  echo "[multitenancy] running cross-tenant deny matrix"
+  MT_BASE_A="http://localhost:${TRAEFIK_PORT}/mt-tenant-a/mcp"
+  MT_BASE_B="http://localhost:${TRAEFIK_PORT}/mt-tenant-b/mcp"
+  MT_REPORT="${WORKDIR}/multitenancy-matrix.json"
+
+  MT_BASE_A="${MT_BASE_A}" \
+  MT_BASE_B="${MT_BASE_B}" \
+  MT_PROTO="${MCP_PROTOCOL_VERSION}" \
+  MT_HUMAN_A="${MT_HUMAN_A}" MT_AGENT_A="${MT_AGENT_A}" MT_SESSION_A="${MT_SESSION_A}" \
+  MT_HUMAN_B="${MT_HUMAN_B}" MT_AGENT_B="${MT_AGENT_B}" MT_SESSION_B="${MT_SESSION_B}" \
+  MT_REPORT="${MT_REPORT}" \
+  python3 <<'PY'
+import json, os, subprocess, sys, tempfile
+
+PROTO = os.environ["MT_PROTO"]
+A = os.environ["MT_BASE_A"]
+B = os.environ["MT_BASE_B"]
+report = []
+
+def post(base, body, human, agent, sess, mcp_session=""):
+    with tempfile.TemporaryDirectory() as td:
+        payload = os.path.join(td, "p.json"); headers = os.path.join(td, "h.txt"); bodyf = os.path.join(td, "b.txt")
+        with open(payload, "w") as fh: json.dump(body, fh)
+        cmd = [
+            "curl", "-sS", "--max-time", "20", "-D", headers, "-o", bodyf, "-w", "%{http_code}",
+            "-X", "POST",
+            "-H", "content-type: application/json",
+            "-H", "accept: application/json, text/event-stream",
+            "-H", f"Mcp-Protocol-Version: {PROTO}",
+        ]
+        if human:   cmd += ["-H", f"X-MCP-Human-ID: {human}"]
+        if agent:   cmd += ["-H", f"X-MCP-Agent-ID: {agent}"]
+        if sess:    cmd += ["-H", f"X-MCP-Agent-Session: {sess}"]
+        if mcp_session: cmd += ["-H", f"Mcp-Session-Id: {mcp_session}"]
+        cmd += ["--data-binary", f"@{payload}", base]
+        proc = subprocess.run(cmd, text=True, capture_output=True, check=False)
+        try: status = int(proc.stdout.strip().splitlines()[-1])
+        except Exception: status = 0
+        with open(headers) as fh: h = fh.read()
+        next_sess = ""
+        for line in h.splitlines():
+            k, sep, v = line.partition(":")
+            if sep and k.lower() == "mcp-session-id":
+                next_sess = v.strip()
+        return status, next_sess
+
+def call(label, base, human, agent, sess, tool, expect_status):
+    init_status, mcp_sess = post(base, {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}, human, agent, sess)
+    if init_status != 200:
+        # Cross-tenant or unknown-session requests are rejected at initialize;
+        # that is the gateway behavior we want to assert.
+        ok = (init_status == expect_status)
+        report.append({"case": label, "expect": expect_status, "got_at": "initialize", "got": init_status, "ok": ok})
+        return
+    post(base, {"jsonrpc":"2.0","method":"notifications/initialized"}, human, agent, sess, mcp_sess)
+    args = {"a": 2, "b": 3} if tool == "add" else {"message": "hello"}
+    call_status, _ = post(base, {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":tool,"arguments":args}}, human, agent, sess, mcp_sess)
+    ok = (call_status == expect_status)
+    report.append({"case": label, "expect": expect_status, "got_at": "tools/call", "got": call_status, "ok": ok})
+
+H_A = (os.environ["MT_HUMAN_A"], os.environ["MT_AGENT_A"], os.environ["MT_SESSION_A"])
+H_B = (os.environ["MT_HUMAN_B"], os.environ["MT_AGENT_B"], os.environ["MT_SESSION_B"])
+
+call("alice -> tenant-a / add (allow)",     A, *H_A, "add",   200)
+call("alice -> tenant-a / upper (deny)",    A, *H_A, "upper", 403)
+call("alice -> tenant-b / add (cross)",     B, *H_A, "add",   401)
+call("bob   -> tenant-b / upper (allow)",   B, *H_B, "upper", 200)
+call("bob   -> tenant-b / add (deny)",      B, *H_B, "add",   403)
+call("bob   -> tenant-a / upper (cross)",   A, *H_B, "upper", 401)
+call("no-headers -> tenant-a (deny)",       A, "", "", "",    "add", 401)
+call("bogus-session -> tenant-a (deny)",    A, os.environ["MT_HUMAN_A"], os.environ["MT_AGENT_A"], "bogus-session", "add", 401)
+
+with open(os.environ["MT_REPORT"], "w") as fh:
+    json.dump(report, fh, indent=2)
+
+failed = [r for r in report if not r["ok"]]
+for r in report:
+    mark = "PASS" if r["ok"] else "FAIL"
+    print(f"  [{mark}] {r['case']:<42}  expect={r['expect']}  got={r['got']} ({r['got_at']})")
+sys.exit(1 if failed else 0)
+PY
+
+  echo "[multitenancy] cleaning up tenant resources"
+  kubectl delete mcpaccessgrant "alice-${MT_TENANT_A}" "bob-${MT_TENANT_B}" -n "${MT_NS}" --ignore-not-found --wait=false >/dev/null
+  kubectl delete mcpagentsession "${MT_SESSION_A}" "${MT_SESSION_B}" -n "${MT_NS}" --ignore-not-found --wait=false >/dev/null
+  ./bin/mcp-runtime server --use-kube delete "${MT_TENANT_A}" --namespace "${MT_NS}" >/dev/null
+  ./bin/mcp-runtime server --use-kube delete "${MT_TENANT_B}" --namespace "${MT_NS}" >/dev/null
+  kubectl wait --for=delete "mcpserver/${MT_TENANT_A}" -n "${MT_NS}" --timeout=60s || true
+  kubectl wait --for=delete "mcpserver/${MT_TENANT_B}" -n "${MT_NS}" --timeout=60s || true
 fi
 
 echo "[cli] checking sentinel restart command"

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -107,6 +107,14 @@ RUST_EXAMPLE_SERVER_ROUTE="${RUST_EXAMPLE_SERVER_ROUTE:-/${RUST_EXAMPLE_SERVER_N
 GO_EXAMPLE_SERVER_NAME="${GO_EXAMPLE_SERVER_NAME:-go-example-mcp}"
 GO_EXAMPLE_SERVER_HOST="${GO_EXAMPLE_SERVER_HOST:-${PLATFORM_HOST}}"
 GO_EXAMPLE_SERVER_ROUTE="${GO_EXAMPLE_SERVER_ROUTE:-/${GO_EXAMPLE_SERVER_NAME}/mcp}"
+MT_TENANT_A="${MT_TENANT_A:-mt-tenant-a}"
+MT_TENANT_B="${MT_TENANT_B:-mt-tenant-b}"
+MT_HUMAN_A="${MT_HUMAN_A:-alice}"
+MT_AGENT_A="${MT_AGENT_A:-alice-agent}"
+MT_SESSION_A="${MT_SESSION_A:-alice-session}"
+MT_HUMAN_B="${MT_HUMAN_B:-bob}"
+MT_AGENT_B="${MT_AGENT_B:-bob-agent}"
+MT_SESSION_B="${MT_SESSION_B:-bob-session}"
 HUMAN_ID="${HUMAN_ID:-user-123}"
 AGENT_ID="${AGENT_ID:-ops-agent}"
 SESSION_ID="${SESSION_ID:-sess-ops-agent}"
@@ -290,12 +298,59 @@ wait_port() {
   local tries="${2:-60}"
   local i
   for i in $(seq 1 "${tries}"); do
-    if (echo >/dev/tcp/127.0.0.1/"${port}") >/dev/null 2>&1; then
+    if port_is_listening "${port}"; then
       return 0
     fi
     sleep 1
   done
   echo "timed out waiting for localhost:${port}" >&2
+  return 1
+}
+
+port_is_listening() {
+  local port="$1"
+  (echo >/dev/tcp/127.0.0.1/"${port}") >/dev/null 2>&1
+}
+
+require_port_available() {
+  local port="$1"
+  local label="$2"
+
+  if port_is_listening "${port}"; then
+    echo "[error] localhost:${port} is already in use before starting ${label}" >&2
+    echo "[error] stop the existing listener or override the matching E2E port environment variable" >&2
+    return 1
+  fi
+}
+
+wait_managed_port() {
+  local port="$1"
+  local pid="$2"
+  local log_file="$3"
+  local label="$4"
+  local tries="${5:-60}"
+  local i
+
+  for i in $(seq 1 "${tries}"); do
+    if ! kill -0 "${pid}" >/dev/null 2>&1; then
+      echo "[error] ${label} exited before localhost:${port} became available" >&2
+      if [[ -s "${log_file}" ]]; then
+        echo "[debug] ${label} log:" >&2
+        cat "${log_file}" >&2 || true
+      fi
+      return 1
+    fi
+    if port_is_listening "${port}"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "timed out waiting for ${label} on localhost:${port}" >&2
+  if [[ -s "${log_file}" ]]; then
+    echo "[debug] ${label} log:" >&2
+    cat "${log_file}" >&2 || true
+  fi
   return 1
 }
 
@@ -387,9 +442,12 @@ port_forward_bg() {
   local local_port="$3"
   local remote_port="$4"
   local log_file="$5"
+  local label="port-forward ${namespace}/svc/${service}"
 
+  require_port_available "${local_port}" "${label}"
   kubectl port-forward -n "${namespace}" "svc/${service}" "${local_port}:${remote_port}" >"${log_file}" 2>&1 &
   PIDS+=("$!")
+  wait_managed_port "${local_port}" "$!" "${log_file}" "${label}"
 }
 
 port_forward_resource_bg() {
@@ -398,23 +456,29 @@ port_forward_resource_bg() {
   local local_port="$3"
   local remote_port="$4"
   local log_file="$5"
+  local label="port-forward ${namespace}/${resource}"
 
+  require_port_available "${local_port}" "${label}"
   kubectl port-forward -n "${namespace}" "${resource}" "${local_port}:${remote_port}" >"${log_file}" 2>&1 &
   PIDS+=("$!")
+  wait_managed_port "${local_port}" "$!" "${log_file}" "${label}"
 }
 
 start_header_proxy_bg() {
   local local_port="$1"
   local upstream_origin="$2"
   local log_file="$3"
+  local label="header proxy ${local_port} -> ${upstream_origin}"
   shift 3
 
+  require_port_available "${local_port}" "${label}"
   python3 "${PROJECT_ROOT}/test/e2e/mcp_header_proxy.py" \
     --listen-host 127.0.0.1 \
     --listen-port "${local_port}" \
     --upstream-origin "${upstream_origin}" \
     "$@" >"${log_file}" 2>&1 &
   PIDS+=("$!")
+  wait_managed_port "${local_port}" "$!" "${log_file}" "${label}"
 }
 
 build_headers_json() {
@@ -2027,16 +2091,22 @@ if cache_mode_enabled; then
     "${SERVER_NAME}-grant" \
     "${SERVER_NAME}-e2e-api-grant" \
     "${OAUTH_SERVER_NAME}-grant" \
+    "alice-${MT_TENANT_A}" \
+    "bob-${MT_TENANT_B}" \
     --ignore-not-found --wait=true >/dev/null
   kubectl delete mcpagentsession -n mcp-servers \
     "${SESSION_ID}" \
     "${SERVER_NAME}-e2e-api-session" \
+    "${MT_SESSION_A}" \
+    "${MT_SESSION_B}" \
     --ignore-not-found --wait=true >/dev/null
   echo "[cache] removing previous policy/OAuth test workloads before cluster doctor"
-  kubectl delete mcpserver -n mcp-servers "${SERVER_NAME}" "${OAUTH_SERVER_NAME}" --ignore-not-found --wait=true >/dev/null
-  kubectl delete deployment -n mcp-servers "${SERVER_NAME}" "${OAUTH_SERVER_NAME}" --ignore-not-found --wait=true >/dev/null
+  kubectl delete mcpserver -n mcp-servers "${SERVER_NAME}" "${OAUTH_SERVER_NAME}" "${MT_TENANT_A}" "${MT_TENANT_B}" --ignore-not-found --wait=true >/dev/null
+  kubectl delete deployment -n mcp-servers "${SERVER_NAME}" "${OAUTH_SERVER_NAME}" "${MT_TENANT_A}" "${MT_TENANT_B}" --ignore-not-found --wait=true >/dev/null
   kubectl delete pod -n mcp-servers -l "app=${SERVER_NAME}" --ignore-not-found --wait=false >/dev/null
   kubectl delete pod -n mcp-servers -l "app=${OAUTH_SERVER_NAME}" --ignore-not-found --wait=false >/dev/null
+  kubectl delete pod -n mcp-servers -l "app=${MT_TENANT_A}" --ignore-not-found --wait=false >/dev/null
+  kubectl delete pod -n mcp-servers -l "app=${MT_TENANT_B}" --ignore-not-found --wait=false >/dev/null
   echo "[cache] deleting stale pending mcp-servers pods before cluster doctor"
   kubectl delete pod -n mcp-servers --field-selector=status.phase=Pending --ignore-not-found --wait=false >/dev/null
   echo "[cache] restarting operator before cluster doctor to avoid stale retained reconcile logs"
@@ -2059,12 +2129,13 @@ run_cli_allowing_cert_prereq_failure cluster-cert-wait ./bin/mcp-runtime cluster
 ./bin/mcp-runtime sentinel status
 ./bin/mcp-runtime sentinel events >"${WORKDIR}/sentinel-events.txt"
 ./bin/mcp-runtime sentinel logs api --tail 20 >"${WORKDIR}/sentinel-api-logs.txt"
+require_port_available "${CLI_SENTINEL_API_PORT}" "sentinel CLI port-forward"
 ./bin/mcp-runtime sentinel port-forward api \
   --port "${CLI_SENTINEL_API_PORT}" \
   --address 127.0.0.1 >"${WORKDIR}/sentinel-cli-port-forward.log" 2>&1 &
 _cli_pf_pid="$!"
 PIDS+=("${_cli_pf_pid}")
-wait_port "${CLI_SENTINEL_API_PORT}" 30
+wait_managed_port "${CLI_SENTINEL_API_PORT}" "${_cli_pf_pid}" "${WORKDIR}/sentinel-cli-port-forward.log" "sentinel CLI port-forward" 30
 kill "${_cli_pf_pid}" >/dev/null 2>&1 || true
 wait "${_cli_pf_pid}" 2>/dev/null || true
 
@@ -4313,16 +4384,8 @@ if scenario_selected "multitenancy"; then
   echo "[multitenancy] preparing two-tenant isolation probe"
 
   MT_NS="mcp-servers"
-  MT_TENANT_A="mt-tenant-a"
-  MT_TENANT_B="mt-tenant-b"
-  MT_HUMAN_A="alice"
-  MT_AGENT_A="alice-agent"
-  MT_SESSION_A="alice-session"
-  MT_HUMAN_B="bob"
-  MT_AGENT_B="bob-agent"
-  MT_SESSION_B="bob-session"
-  MT_IMAGE_REPO="registry.registry.svc.cluster.local:5000/library/${SERVER_NAME}"
-  MT_IMAGE_TAG="latest"
+  MT_IMAGE_REPO="${SERVER_IMAGE%:*}"
+  MT_IMAGE_TAG="${SERVER_IMAGE##*:}"
 
   mt_apply_tenant() {
     local name="$1" prefix="$2"
@@ -4366,8 +4429,8 @@ spec:
 EOF
   }
 
-  mt_apply_tenant "${MT_TENANT_A}" "mt-tenant-a"
-  mt_apply_tenant "${MT_TENANT_B}" "mt-tenant-b"
+  mt_apply_tenant "${MT_TENANT_A}" "${MT_TENANT_A}"
+  mt_apply_tenant "${MT_TENANT_B}" "${MT_TENANT_B}"
 
   echo "[multitenancy] waiting for tenant rollouts"
   wait_for_deployment_exists "${MT_NS}" "${MT_TENANT_A}"
@@ -4436,13 +4499,13 @@ EOF
   }
   mt_wait_for_session_in_policy "${MT_TENANT_A}" "${MT_SESSION_A}"
   mt_wait_for_session_in_policy "${MT_TENANT_B}" "${MT_SESSION_B}"
-  # Sidecar polls the rendered policy file; let it observe the new sessions
-  # before issuing the matrix.
-  sleep 6
+  # The sidecar reloads from a ConfigMap volume, which can lag behind the
+  # rendered ConfigMap. The matrix below retries each expected decision until
+  # the sidecar observes the updated policy.
 
   echo "[multitenancy] running cross-tenant deny matrix"
-  MT_BASE_A="http://localhost:${TRAEFIK_PORT}/mt-tenant-a/mcp"
-  MT_BASE_B="http://localhost:${TRAEFIK_PORT}/mt-tenant-b/mcp"
+  MT_BASE_A="http://localhost:${TRAEFIK_PORT}/${MT_TENANT_A}/mcp"
+  MT_BASE_B="http://localhost:${TRAEFIK_PORT}/${MT_TENANT_B}/mcp"
   MT_REPORT="${WORKDIR}/multitenancy-matrix.json"
 
   MT_BASE_A="${MT_BASE_A}" \
@@ -4452,7 +4515,7 @@ EOF
   MT_HUMAN_B="${MT_HUMAN_B}" MT_AGENT_B="${MT_AGENT_B}" MT_SESSION_B="${MT_SESSION_B}" \
   MT_REPORT="${MT_REPORT}" \
   python3 <<'PY'
-import json, os, subprocess, sys, tempfile
+import json, os, subprocess, sys, tempfile, time
 
 PROTO = os.environ["MT_PROTO"]
 A = os.environ["MT_BASE_A"]
@@ -4484,21 +4547,56 @@ def post(base, body, human, agent, sess, mcp_session=""):
             k, sep, v = line.partition(":")
             if sep and k.lower() == "mcp-session-id":
                 next_sess = v.strip()
-        return status, next_sess
+        with open(bodyf) as fh: response_body = fh.read()
+        return status, next_sess, response_body, proc.stderr
 
-def call(label, base, human, agent, sess, tool, expect_status):
-    init_status, mcp_sess = post(base, {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}, human, agent, sess)
+def run_call(label, base, human, agent, sess, tool, expect_status):
+    init_status, mcp_sess, init_body, init_stderr = post(base, {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}, human, agent, sess)
     if init_status != 200:
         # Cross-tenant or unknown-session requests are rejected at initialize;
         # that is the gateway behavior we want to assert.
-        ok = (init_status == expect_status)
-        report.append({"case": label, "expect": expect_status, "got_at": "initialize", "got": init_status, "ok": ok})
-        return
-    post(base, {"jsonrpc":"2.0","method":"notifications/initialized"}, human, agent, sess, mcp_sess)
+        return {
+            "case": label,
+            "expect": expect_status,
+            "got_at": "initialize",
+            "got": init_status,
+            "body": init_body,
+            "stderr": init_stderr,
+            "ok": init_status == expect_status,
+        }
+    notify_status, _, notify_body, notify_stderr = post(base, {"jsonrpc":"2.0","method":"notifications/initialized"}, human, agent, sess, mcp_sess)
+    if notify_status not in (200, 202):
+        return {
+            "case": label,
+            "expect": expect_status,
+            "got_at": "notifications/initialized",
+            "got": notify_status,
+            "body": notify_body,
+            "stderr": notify_stderr,
+            "ok": notify_status == expect_status,
+        }
     args = {"a": 2, "b": 3} if tool == "add" else {"message": "hello"}
-    call_status, _ = post(base, {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":tool,"arguments":args}}, human, agent, sess, mcp_sess)
-    ok = (call_status == expect_status)
-    report.append({"case": label, "expect": expect_status, "got_at": "tools/call", "got": call_status, "ok": ok})
+    call_status, _, call_body, call_stderr = post(base, {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":tool,"arguments":args}}, human, agent, sess, mcp_sess)
+    return {
+        "case": label,
+        "expect": expect_status,
+        "got_at": "tools/call",
+        "got": call_status,
+        "body": call_body,
+        "stderr": call_stderr,
+        "ok": call_status == expect_status,
+    }
+
+def call(label, base, human, agent, sess, tool, expect_status, retries=90, delay=2):
+    last = {}
+    for attempt in range(1, retries + 1):
+        last = run_call(label, base, human, agent, sess, tool, expect_status)
+        last["attempts"] = attempt
+        if last["ok"]:
+            report.append(last)
+            return
+        time.sleep(delay)
+    report.append(last)
 
 H_A = (os.environ["MT_HUMAN_A"], os.environ["MT_AGENT_A"], os.environ["MT_SESSION_A"])
 H_B = (os.environ["MT_HUMAN_B"], os.environ["MT_AGENT_B"], os.environ["MT_SESSION_B"])
@@ -4518,7 +4616,12 @@ with open(os.environ["MT_REPORT"], "w") as fh:
 failed = [r for r in report if not r["ok"]]
 for r in report:
     mark = "PASS" if r["ok"] else "FAIL"
-    print(f"  [{mark}] {r['case']:<42}  expect={r['expect']}  got={r['got']} ({r['got_at']})")
+    detail = ""
+    if not r["ok"]:
+        body = " ".join(str(r.get("body", "")).split())
+        if body:
+            detail = f" body={body[:160]}"
+    print(f"  [{mark}] {r['case']:<42}  expect={r['expect']}  got={r['got']} ({r['got_at']}, attempts={r.get('attempts', 1)}){detail}")
 sys.exit(1 if failed else 0)
 PY
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces enhancements for multi-tenancy verification, encompassing documentation, a new CLI diagnostic check, and an end-to-end test scenario.

Key changes include:
- **Multi-tenancy Verification Documentation:** Added a new section to the `sentinel.md` documentation, linked from `getting-started.md`, detailing how to verify tenant isolation. This guide explains that each `MCPServer` acts as a distinct tenant and provides a step-by-step scenario to deploy two gateway-enabled servers with disjoint subject grants and sessions. It outlines the expected HTTP response codes (200, 401, 403) for various cross-tenant and same-tenant requests, clarifying the distinction between cross-tenant rejection (401) and same-tenant unallowed tool rejection (403).
- **Operator RBAC Drift Check:** Implemented a new `mcp-runtime cluster doctor` check that verifies the `mcp-runtime-operator-role` ClusterRole has the necessary `get/list/watch` permissions on core Kubernetes resources (e.g., `serviceaccounts`, `configmaps`, `deployments`). This check helps diagnose issues where the operator's informer cache might fail to sync due to outdated RBAC configurations, providing a clear remedy.
- **E2E Multi-tenancy Scenario:** Added a new end-to-end test scenario (`multitenancy`) to `kind.sh`. This test programmatically deploys two `MCPServer` instances, configures specific `MCPAccessGrant` and `MCPAgentSession` resources for different subjects on each server, and then executes a comprehensive matrix of API calls to assert correct tenant isolation and per-subject grant enforcement, validating the expected 200, 401, and 403 responses.
- **CLI Setup Guidance:** Enhanced the `mcp-runtime setup` command to include an informational message after reapplying the operator ClusterRole, advising users to use `mcp-runtime cluster doctor` if `MCPServer` resources appear unreconciled.
<!-- kody-pr-summary:end -->