### PR TITLE
[codex] Add governed agent adapters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ If instructions conflict, prefer **this repo** (`README`, CRDs, `v1alpha1` types
 | Area | Path | Notes |
 |------|------|--------|
 | User-facing CLI | `cmd/mcp-runtime/`, `internal/cli/root/`, `internal/cli/<command>/`, `internal/cli/core/` | Entrypoint, foldered Cobra command routing, command-owned behavior for `setup`, `status`, `registry`, `server`, `access`, …, and shared CLI kernel code |
+| Agent adapters | `cmd/mcp-runtime-agent-proxy/`, `cmd/mcp-runtime-mcp-shim/`, `internal/agentadapter/` | Optional HTTP and stdio adapter binaries that inject issued governance identity/session headers while leaving grant/session creation and enforcement to the platform |
 | Operator (controller) | `cmd/operator/`, `internal/operator/` | `MCPServer` reconciliation, ingress, gateway wiring |
 | API & CRD types | `api/v1alpha1/` | Source of truth for object shapes; CRD YAML in `config/crd/bases/` |
 | Access and policy (shared) | `pkg/access/`, `pkg/policy/` | Grant/session CRUD helpers plus rendered gateway policy contracts and evaluation semantics used by operator and proxy |
@@ -33,6 +34,7 @@ Use **Go** from `go.mod` (see `go version` / toolchain). From the repo root:
 gofmt -s -l .   # if empty, OK; else run: gofmt -s -w .
 
 go build -o bin/mcp-runtime ./cmd/mcp-runtime
+make build-adapters
 
 # Fast feedback (matches most of CI for the main module)
 go test ./... -count=1 -race
@@ -51,6 +53,7 @@ envtest assets and set `KUBEBUILDER_ASSETS`.
 **Targeted tests** (prefer these while iterating; full `./...` can be slow):
 
 - `go test ./internal/operator/... ./internal/cli/... -race -count=1`
+- `go test ./internal/agentadapter -count=1` (agent-side HTTP proxy and stdio shim behavior)
 - `go test ./test/golden/... -count=1` (CLI help snapshots; update `test/golden/cli/testdata/*.golden` when you change Cobra help text on purpose)
 - `go test ./test/integration/...` (needs `KUBEBUILDER_ASSETS`; see `Makefile.operator` and CI for envtest setup)
 - `E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh` for repeated local Kind e2e debugging without recreating the cluster or rebuilding cached images. The e2e traffic path uses deterministic curl-based MCP requests; omit cache mode for CI-equivalent fresh runs.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test clean deps deps-go deps-check deps-install dev fmt lint coverage build-all build-unix install help \
+.PHONY: all build build-adapters test clean deps deps-go deps-check deps-install dev fmt lint coverage build-all build-unix install help \
 	operator-build operator-run operator-docker-build operator-docker-push \
 	operator-test operator-deploy operator-undeploy operator-install operator-uninstall \
 	operator-manifests operator-generate operator-coverage \
@@ -27,6 +27,12 @@ build: ## Build CLI binary for current platform.
 	@echo "Building $(BINARY_NAME) CLI..."
 	@mkdir -p $(BUILD_DIR)
 	go build -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/mcp-runtime
+
+build-adapters: ## Build optional agent-side MCP adapter binaries.
+	@echo "Building agent adapter binaries..."
+	@mkdir -p $(BUILD_DIR)
+	go build -o $(BUILD_DIR)/mcp-runtime-agent-proxy ./cmd/mcp-runtime-agent-proxy
+	go build -o $(BUILD_DIR)/mcp-runtime-mcp-shim ./cmd/mcp-runtime-mcp-shim
 
 build-all: ## Build CLI for all Unix platforms (macOS and Linux, ARM64 and AMD64).
 	@echo "Building for all Unix platforms..."

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The public platform at `platform.mcpruntime.org` is a live preview of the deploy
 ## What ships
 
 - `mcp-runtime` CLI for `setup`, `status`, `registry`, `server`, `pipeline`, `cluster`, `access`, and `sentinel`
+- Optional `mcp-runtime-agent-proxy` and `mcp-runtime-mcp-shim` adapters for governed HTTP and stdio agent integrations
 - Platform UI for browsing MCP servers, viewing platform state, and operating the stack through a web interface
 - `MCPServer`, `MCPAccessGrant`, and `MCPAgentSession` CRDs
 - Kubernetes operator for `Deployment`, `Service`, `Ingress`, and policy materialization
@@ -101,6 +102,7 @@ Notes:
 ```bash
 gofmt -s -l .
 go build -o bin/mcp-runtime ./cmd/mcp-runtime
+make build-adapters
 go test ./... -count=1 -race
 go vet ./...
 ```

--- a/cmd/mcp-runtime-agent-proxy/main.go
+++ b/cmd/mcp-runtime-agent-proxy/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"mcp-runtime/internal/agentadapter"
+)
+
+func main() {
+	cfg, err := agentadapter.LoadProxyConfigFromEnv()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	fmt.Fprintf(os.Stderr, "mcp-runtime-agent-proxy listening on %s -> %s\n", cfg.ListenAddr, cfg.RuntimeURL.String())
+	if err := agentadapter.RunHTTPProxy(ctx, cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/mcp-runtime-mcp-shim/main.go
+++ b/cmd/mcp-runtime-mcp-shim/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"mcp-runtime/internal/agentadapter"
+)
+
+func main() {
+	cfg, err := agentadapter.LoadShimConfigFromEnv()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := agentadapter.RunStdioShim(ctx, cfg, agentadapter.StdioOptions{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ human workflows.
     <li>Registry-backed image build, push, and deploy flow</li>
     <li>Sentinel gateway policy, grants, consented sessions, audit, and analytics</li>
     <li>Governance controls for tool access, trust levels, session revocation, and policy versioning</li>
+    <li>Optional HTTP and stdio agent adapters for governed framework integrations</li>
     <li>Compliance-oriented event records for who called what, when, against which server, and whether it was allowed or denied</li>
     <li>Ingress routing for path-based MCP endpoints</li>
     <li>CLI for setup, status, registry, access, Sentinel, and servers</li>
@@ -118,6 +119,12 @@ DNS, ingress, TLS, and k3s configuration, start with
   <span class="docs-card-kicker">Ship</span>
   <strong>Publish an MCP server</strong>
   <span>Write a manifest or `.mcp` metadata, push an image, deploy it, and verify what the platform creates.</span>
+</a>
+
+<a class="docs-card" href="agent-adapters/">
+  <span class="docs-card-kicker">Connect</span>
+  <strong>Wire agent frameworks</strong>
+  <span>Use HTTP and stdio adapters to present issued identity/session values without moving enforcement out of the gateway.</span>
 </a>
 </div>
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -45,6 +45,9 @@ Set these values for both adapters:
 | `MCP_RUNTIME_HOST_HEADER` | no | Optional upstream `Host` header for host-based ingress. |
 | `MCP_RUNTIME_LISTEN_ADDR` | proxy only | Local proxy listen address. Defaults to `127.0.0.1:8099`. |
 | `MCP_RUNTIME_PROTOCOL_VERSION` | shim only | MCP protocol header for stdio-to-HTTP calls. Defaults to `2025-06-18`; an `initialize.params.protocolVersion` value overrides it for that shim process. |
+| `MCP_RUNTIME_SET_XFF` | proxy only | Set to `false`, `0`, `no`, or `off` to suppress proxy-generated `X-Forwarded-*` headers. Defaults to enabled. |
+| `MCP_RUNTIME_REQUEST_TIMEOUT` | shim only | Optional Go duration such as `300s` for stdio-to-HTTP requests. Defaults to unbounded so long-running tools are not cut off. |
+| `MCP_RUNTIME_LOG_LEVEL` | no | Set to `info` to log runtime 4xx denials to stderr with status, reason, method, and tool name. Defaults to silent. |
 
 The adapters inject these governance headers on every forwarded request:
 
@@ -59,6 +62,11 @@ headers such as `Mcp-Protocol-Version`, `Mcp-Session-Id`, `content-type`, and
 `accept` are preserved for HTTP proxy traffic. The stdio shim stores the
 runtime `Mcp-Session-Id` returned by `initialize` and sends it on later HTTP
 requests.
+
+The HTTP proxy streams `text/event-stream` responses through as they arrive and
+returns JSON-RPC error envelopes for upstream connection failures. That keeps
+agent clients on the MCP response shape instead of receiving a generic HTML
+`502 Bad Gateway` body.
 
 ## Admin Flow
 
@@ -171,6 +179,9 @@ http://127.0.0.1:8099/mcp
 The proxy forwards to the exact `MCP_RUNTIME_URL` route. The local request path
 is accepted for client compatibility; it is not appended to the upstream route.
 Query strings from the configured URL and client request are merged.
+By default the proxy adds `X-Forwarded-For`, `X-Forwarded-Host`, and
+`X-Forwarded-Proto`; set `MCP_RUNTIME_SET_XFF=false` when the local loopback
+address only adds audit noise.
 
 This shape works for LangChain, LlamaIndex, CrewAI, custom Python/Go/Node
 services, or any other MCP-aware runtime that can connect to a Streamable HTTP
@@ -201,6 +212,17 @@ The shim reads newline-delimited JSON-RPC messages from stdin, posts them to
 the platform, such as `trust_too_low`, are returned to stdio clients as JSON-RPC
 errors so the client sees the governed failure instead of a silent transport
 drop.
+
+For Streamable HTTP event-stream responses, the shim writes each valid JSON-RPC
+`data:` frame to stdout as it arrives and keeps reading stdin while the upstream
+stream remains open. That lets server-to-client requests and progress messages
+flow through without waiting for the runtime to close the HTTP response.
+
+The shim exits on process context cancellation even when stdin is idle.
+`initialize` is forwarded synchronously so the runtime session ID is captured
+before later requests. Leave `MCP_RUNTIME_REQUEST_TIMEOUT` unset for unbounded
+tool calls, or set it to a duration when a demo or local integration should
+fail fast if the runtime stops responding.
 
 ## Expected Outcomes
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -1,0 +1,206 @@
+# Agent Adapters
+
+MCP Runtime includes two optional agent-side adapters for frameworks and IDEs
+that need help attaching governed identity to MCP traffic:
+
+- `mcp-runtime-agent-proxy` exposes a local Streamable HTTP MCP endpoint and
+  forwards requests to an MCP Runtime route.
+- `mcp-runtime-mcp-shim` exposes a stdio MCP server process and forwards each
+  JSON-RPC message to the same MCP Runtime HTTP route.
+
+Both adapters only present issued identity values. They do not create grants,
+create sessions, evaluate policy, or bypass the gateway. Platform admins still
+grant access through `MCPAccessGrant` and `MCPAgentSession`; the gateway remains
+the enforcement point.
+
+## Build
+
+```bash
+make build-adapters
+```
+
+The binaries are written to:
+
+```text
+bin/mcp-runtime-agent-proxy
+bin/mcp-runtime-mcp-shim
+```
+
+## Configuration
+
+Set these values for both adapters:
+
+| Environment variable | Required | Purpose |
+|---|---:|---|
+| `MCP_RUNTIME_URL` | yes | Absolute Streamable HTTP MCP route, such as `http://localhost:18080/go-example-mcp/mcp`. |
+| `MCP_RUNTIME_HUMAN_ID` | yes | Human identity issued by the platform/admin flow. |
+| `MCP_RUNTIME_AGENT_ID` | yes | Agent identity issued by the platform/admin flow. |
+| `MCP_RUNTIME_SESSION_ID` | yes | `MCPAgentSession` name/value to present in `X-MCP-Agent-Session`. |
+| `MCP_RUNTIME_HOST_HEADER` | no | Optional upstream `Host` header for host-based ingress. |
+| `MCP_RUNTIME_LISTEN_ADDR` | proxy only | Local proxy listen address. Defaults to `127.0.0.1:8099`. |
+| `MCP_RUNTIME_PROTOCOL_VERSION` | shim only | MCP protocol header for stdio-to-HTTP calls. Defaults to `2025-06-18`; an `initialize.params.protocolVersion` value overrides it for that shim process. |
+
+The adapters inject these governance headers on every forwarded request:
+
+```text
+X-MCP-Human-ID: <MCP_RUNTIME_HUMAN_ID>
+X-MCP-Agent-ID: <MCP_RUNTIME_AGENT_ID>
+X-MCP-Agent-Session: <MCP_RUNTIME_SESSION_ID>
+```
+
+Incoming spoofed values for those three headers are overwritten. MCP protocol
+headers such as `Mcp-Protocol-Version`, `Mcp-Session-Id`, `content-type`, and
+`accept` are preserved for HTTP proxy traffic. The stdio shim stores the
+runtime `Mcp-Session-Id` returned by `initialize` and sends it on later HTTP
+requests.
+
+## Admin Flow
+
+Apply grants and sessions before giving an adapter config to an agent builder:
+
+```bash
+./bin/mcp-runtime access grant apply --file grant.yaml
+./bin/mcp-runtime access session apply --file session.yaml
+./bin/mcp-runtime server policy inspect go-example-mcp --namespace mcp-servers
+```
+
+Minimal example:
+
+```yaml
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAccessGrant
+metadata:
+  name: ticket-triage-agent
+  namespace: mcp-servers
+spec:
+  serverRef:
+    name: go-example-mcp
+  subject:
+    humanID: support-lead
+    agentID: ticket-triage-agent
+  maxTrust: high
+  allowedSideEffects:
+    - read
+  policyVersion: v1
+  toolRules:
+    - name: add
+      decision: allow
+      requiredTrust: low
+    - name: upper
+      decision: allow
+      requiredTrust: low
+---
+apiVersion: mcpruntime.org/v1alpha1
+kind: MCPAgentSession
+metadata:
+  name: sess-ticket-triage-agent
+  namespace: mcp-servers
+spec:
+  serverRef:
+    name: go-example-mcp
+  subject:
+    humanID: support-lead
+    agentID: ticket-triage-agent
+  consentedTrust: high
+  policyVersion: v1
+```
+
+## Direct HTTP Clients
+
+Use direct HTTP when the framework supports Streamable HTTP MCP and custom
+request headers. For example, the OpenAI Agents SDK exposes
+`MCPServerStreamableHttp` with `params.url` and `params.headers` for local or
+remote Streamable HTTP MCP servers.
+
+```python
+import asyncio
+import os
+
+from agents import Agent, Runner
+from agents.mcp import MCPServerStreamableHttp
+
+async def main() -> None:
+    async with MCPServerStreamableHttp(
+        name="go-example-mcp",
+        params={
+            "url": os.environ["MCP_RUNTIME_URL"],
+            "headers": {
+                "X-MCP-Human-ID": os.environ["MCP_RUNTIME_HUMAN_ID"],
+                "X-MCP-Agent-ID": os.environ["MCP_RUNTIME_AGENT_ID"],
+                "X-MCP-Agent-Session": os.environ["MCP_RUNTIME_SESSION_ID"],
+            },
+        },
+    ) as server:
+        agent = Agent(
+            name="Governed Agent",
+            instructions="Use MCP tools when they help.",
+            mcp_servers=[server],
+        )
+        result = await Runner.run(agent, "Add 2 and 3.")
+        print(result.final_output)
+
+asyncio.run(main())
+```
+
+## HTTP Proxy Adapter
+
+Use the proxy when a framework can speak Streamable HTTP MCP but cannot attach
+the governance headers itself.
+
+```bash
+export MCP_RUNTIME_URL=http://localhost:18080/go-example-mcp/mcp
+export MCP_RUNTIME_HUMAN_ID=support-lead
+export MCP_RUNTIME_AGENT_ID=ticket-triage-agent
+export MCP_RUNTIME_SESSION_ID=sess-ticket-triage-agent
+
+./bin/mcp-runtime-agent-proxy
+```
+
+Then point the framework's MCP HTTP URL at the local proxy:
+
+```text
+http://127.0.0.1:8099/mcp
+```
+
+The proxy forwards to the exact `MCP_RUNTIME_URL` route. The local request path
+is accepted for client compatibility; it is not appended to the upstream route.
+Query strings from the configured URL and client request are merged.
+
+This shape works for LangChain, LlamaIndex, CrewAI, custom Python/Go/Node
+services, or any other MCP-aware runtime that can connect to a Streamable HTTP
+MCP URL.
+
+## Stdio Shim
+
+Use the shim when an IDE or client only launches stdio MCP commands.
+
+```json
+{
+  "mcpServers": {
+    "go-example-mcp": {
+      "command": "/absolute/path/to/bin/mcp-runtime-mcp-shim",
+      "env": {
+        "MCP_RUNTIME_URL": "http://localhost:18080/go-example-mcp/mcp",
+        "MCP_RUNTIME_HUMAN_ID": "support-lead",
+        "MCP_RUNTIME_AGENT_ID": "ticket-triage-agent",
+        "MCP_RUNTIME_SESSION_ID": "sess-ticket-triage-agent"
+      }
+    }
+  }
+}
+```
+
+The shim reads newline-delimited JSON-RPC messages from stdin, posts them to
+`MCP_RUNTIME_URL`, and writes JSON-RPC responses to stdout. HTTP denials from
+the platform, such as `trust_too_low`, are returned to stdio clients as JSON-RPC
+errors so the client sees the governed failure instead of a silent transport
+drop.
+
+## Expected Outcomes
+
+- A low-trust allowed tool call succeeds when the grant, session, and tool rule
+  permit it.
+- If the active session consents to less trust than the tool requires, the
+  runtime returns a denial such as `trust_too_low`.
+- Removing, disabling, or revoking the platform-side grant/session blocks calls
+  without changing adapter configuration.

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -13,6 +13,12 @@ create sessions, evaluate policy, or bypass the gateway. Platform admins still
 grant access through `MCPAccessGrant` and `MCPAgentSession`; the gateway remains
 the enforcement point.
 
+The adapter surface is intentionally limited to stdio and Streamable HTTP, the
+two standard MCP transports. There is no separate legacy HTTP+SSE adapter. When
+the docs or code mention `text/event-stream`, that is only because Streamable
+HTTP allows a server to return a JSON response or an event-stream response for
+the same request, and clients are expected to handle both response shapes.
+
 ## Build
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -529,6 +529,12 @@ The bundled Go example server also exposes `upper`, `lower`, `echo`, and
 `slugify`, and each of those tools expects a `message` field in `arguments`
 instead of `input` or `text`.
 
+For agent frameworks or IDEs that cannot attach the governance headers directly,
+build the optional adapters with `make build-adapters` and follow
+[Agent Adapters](agent-adapters.md). The same grant/session values from
+`/tmp/go-example-access.yaml` become `MCP_RUNTIME_HUMAN_ID`,
+`MCP_RUNTIME_AGENT_ID`, and `MCP_RUNTIME_SESSION_ID` for the adapter process.
+
 ```bash
 ./bin/mcp-runtime sentinel status
 ./bin/mcp-runtime sentinel events

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -534,6 +534,8 @@ build the optional adapters with `make build-adapters` and follow
 [Agent Adapters](agent-adapters.md). The same grant/session values from
 `/tmp/go-example-access.yaml` become `MCP_RUNTIME_HUMAN_ID`,
 `MCP_RUNTIME_AGENT_ID`, and `MCP_RUNTIME_SESSION_ID` for the adapter process.
+Set `MCP_RUNTIME_LOG_LEVEL=info` while debugging governed-agent demos when you
+want adapter stderr to show runtime denials such as `trust_too_low`.
 
 ```bash
 ./bin/mcp-runtime sentinel status

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -44,6 +44,7 @@ flowchart LR
 | CLI implementation | [`internal-cli.md`](internal-cli.md) | Covers the `internal/cli/root` routing layer plus setup, bootstrap, registry, server, access, status, sentinel, auth, and pipeline behavior. |
 | Kubernetes API types | [`api-types.md`](api-types.md) | Defines the public CRD shapes consumed by users, tests, and the operator. |
 | Generated Go reference | [`go-package-reference.md`](go-package-reference.md) | Captures `go doc` output for the main contributor-facing packages. |
+| Agent adapters | `internal/agentadapter/`, `cmd/mcp-runtime-agent-proxy/`, `cmd/mcp-runtime-mcp-shim/` | Shared HTTP proxy and stdio shim behavior for forwarding agent MCP traffic with issued governance headers. |
 | Operator | [`cmd-operator.md`](cmd-operator.md) | Explains manager startup and reconciliation from desired state to Kubernetes resources. |
 | Control-plane helpers | `pkg/controlplane/` | Shared MCPServer Kubernetes operations and status projection used outside HTTP/CLI glue. |
 | Shared policy and events | `pkg/policy/`, `pkg/events/`, `pkg/clickhouse/` | Gateway policy contracts/evaluation plus Sentinel event envelopes and ClickHouse query/insert helpers. |
@@ -80,11 +81,13 @@ When changing this path, check the relevant CLI command, the `api/v1alpha1` cont
 
 ## Runtime request flow
 
-At request time, clients do not call server pods directly. Traffic flows through the gateway, which checks grants and sessions before forwarding MCP JSON-RPC calls.
+At request time, clients do not call server pods directly. Traffic flows through the gateway, which checks grants and sessions before forwarding MCP JSON-RPC calls. Optional agent adapters run beside the client when a framework or IDE cannot attach the issued governance headers itself.
 
 ```mermaid
 flowchart TD
-    Client[MCP client] --> Route[Ingress route]
+    Client[MCP client] --> Adapter[Optional HTTP or stdio adapter]
+    Adapter --> Route[Ingress route]
+    Client --> Route
     Route --> Gateway[Sentinel gateway or proxy]
     Gateway --> Authz[pkg/policy evaluation]
     Authz -->|allow| Server[MCP server pod]
@@ -106,6 +109,8 @@ Governance-related changes usually span `api/v1alpha1/access_types.go`, `pkg/acc
 ```mermaid
 flowchart TB
     Cmd[cmd/mcp-runtime] --> CLIRoot[internal/cli/root]
+    AgentProxy[cmd/mcp-runtime-agent-proxy] --> AgentAdapter[internal/agentadapter]
+    AgentShim[cmd/mcp-runtime-mcp-shim] --> AgentAdapter
     CLIRoot --> CLICommands[internal/cli/<command>]
     CLICommands --> CLICore[internal/cli/core]
     CLICommands --> Metadata[pkg/metadata]
@@ -171,6 +176,7 @@ workflows.
 | Change generated manifests | `pkg/metadata`, `pkg/manifest`, `config/`, examples | targeted package tests plus manifest diff review |
 | Change reconciliation behavior | `internal/operator`, API types, k8s helpers | `go test ./internal/operator/... -race -count=1` |
 | Change governance policy | `pkg/access`, `pkg/policy`, `services/api`, `services/mcp-proxy`, access CRDs | targeted package/service tests plus e2e policy scenario |
+| Change agent adapters | `internal/agentadapter`, `cmd/mcp-runtime-agent-proxy`, `cmd/mcp-runtime-mcp-shim`, `docs/agent-adapters.md` | `go test ./internal/agentadapter -count=1` and `make build-adapters` |
 | Change Sentinel event storage | `pkg/events`, `pkg/clickhouse`, `services/ingest`, `services/processor`, `services/api`, `services/mcp-proxy` | package tests plus touched service tests |
 | Change docs site behavior | `docs/mkdocs.yml`, `docs/nginx.conf`, Markdown pages | MkDocs build or docs container build |
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -1857,6 +1857,9 @@ const (
 	EnvHostHeader      = "MCP_RUNTIME_HOST_HEADER"
 	EnvListenAddr      = "MCP_RUNTIME_LISTEN_ADDR"
 	EnvProtocolVersion = "MCP_RUNTIME_PROTOCOL_VERSION"
+	EnvSetXForwarded   = "MCP_RUNTIME_SET_XFF"
+	EnvRequestTimeout  = "MCP_RUNTIME_REQUEST_TIMEOUT"
+	EnvLogLevel        = "MCP_RUNTIME_LOG_LEVEL"
 
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
@@ -1910,14 +1913,18 @@ func ValidateConfig(cfg Config) error
 <a id="agent-adapters-type-config-struct"></a>
 ```text
 type Config struct {
-	RuntimeURL      *url.URL
-	HumanID         string
-	AgentID         string
-	SessionID       string
-	HostHeader      string
-	ListenAddr      string
-	ProtocolVersion string
-	HTTPClient      *http.Client
+	RuntimeURL        *url.URL
+	HumanID           string
+	AgentID           string
+	SessionID         string
+	HostHeader        string
+	ListenAddr        string
+	ProtocolVersion   string
+	HTTPClient        *http.Client
+	RequestTimeout    time.Duration
+	LogLevel          string
+	LogWriter         io.Writer
+	DisableXForwarded bool
 }
     Config is the shared configuration for agent-side adapters.
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -13,6 +13,7 @@ python3 docs/scripts/generate_go_package_reference.py
 
 - [API types](#api-types) `mcp-runtime/api/v1alpha1`
 - [Metadata helpers](#metadata-helpers) `mcp-runtime/pkg/metadata`
+- [Agent adapters](#agent-adapters) `mcp-runtime/internal/agentadapter`
 - [Operator internals](#operator-internals) `mcp-runtime/internal/operator`
 - [CLI command routing](#cli-command-routing) `mcp-runtime/internal/cli/root`
 - [CLI core](#cli-core) `mcp-runtime/internal/cli/core`
@@ -1803,6 +1804,147 @@ const (
 	TrustLevelMedium TrustLevel = "medium"
 	TrustLevelHigh   TrustLevel = "high"
 )
+```
+
+<a id="agent-adapters"></a>
+## Agent adapters
+
+Package: `agentadapter`
+Import path: `mcp-runtime/internal/agentadapter`
+
+Source command:
+
+```bash
+go doc -all ./internal/agentadapter
+```
+
+<a id="agent-adapters-overview"></a>
+### Overview
+
+Package agentadapter implements optional agent-side HTTP and stdio adapters that
+forward MCP traffic to governed MCP Runtime routes.
+
+### Jump To
+
+- [Overview](#agent-adapters-overview)
+- [Index](#agent-adapters-index)
+- [Constants](#agent-adapters-constants)
+- [Functions](#agent-adapters-functions)
+- [Types](#agent-adapters-types)
+
+<a id="agent-adapters-index"></a>
+### Index
+
+- [`Constants`](#agent-adapters-constants)
+- [`func NewHTTPProxyHandler(cfg Config) (http.Handler, error)`](#agent-adapters-func-newhttpproxyhandler-cfg-config-http-handler-error)
+- [`func RunHTTPProxy(ctx context.Context, cfg Config) error`](#agent-adapters-func-runhttpproxy-ctx-context-context-cfg-config-error)
+- [`func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error`](#agent-adapters-func-runstdioshim-ctx-context-context-cfg-config-opts-stdiooptions-error)
+- [`func ValidateConfig(cfg Config) error`](#agent-adapters-func-validateconfig-cfg-config-error)
+- [`type Config struct`](#agent-adapters-type-config-struct)
+- [`func LoadProxyConfigFromEnv() (Config, error)`](#agent-adapters-func-loadproxyconfigfromenv-config-error)
+- [`func LoadShimConfigFromEnv() (Config, error)`](#agent-adapters-func-loadshimconfigfromenv-config-error)
+- [`type StdioOptions struct`](#agent-adapters-type-stdiooptions-struct)
+
+<a id="agent-adapters-constants"></a>
+### Constants
+
+```text
+const (
+	EnvRuntimeURL      = "MCP_RUNTIME_URL"
+	EnvHumanID         = "MCP_RUNTIME_HUMAN_ID"
+	EnvAgentID         = "MCP_RUNTIME_AGENT_ID"
+	EnvSessionID       = "MCP_RUNTIME_SESSION_ID"
+	EnvHostHeader      = "MCP_RUNTIME_HOST_HEADER"
+	EnvListenAddr      = "MCP_RUNTIME_LISTEN_ADDR"
+	EnvProtocolVersion = "MCP_RUNTIME_PROTOCOL_VERSION"
+
+	DefaultListenAddr      = "127.0.0.1:8099"
+	DefaultProtocolVersion = "2025-06-18"
+
+	HumanIDHeader      = "X-MCP-Human-ID"
+	AgentIDHeader      = "X-MCP-Agent-ID"
+	AgentSessionHeader = "X-MCP-Agent-Session"
+	MCPProtocolHeader  = "Mcp-Protocol-Version"
+	MCPSessionHeader   = "Mcp-Session-Id"
+)
+```
+
+<a id="agent-adapters-functions"></a>
+### Functions
+
+<a id="agent-adapters-func-newhttpproxyhandler-cfg-config-http-handler-error"></a>
+```text
+func NewHTTPProxyHandler(cfg Config) (http.Handler, error)
+    NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic
+    to the configured runtime route and injects issued governance identity
+    headers.
+
+```
+
+<a id="agent-adapters-func-runhttpproxy-ctx-context-context-cfg-config-error"></a>
+```text
+func RunHTTPProxy(ctx context.Context, cfg Config) error
+    RunHTTPProxy serves the local HTTP adapter until the context is cancelled.
+
+```
+
+<a id="agent-adapters-func-runstdioshim-ctx-context-context-cfg-config-opts-stdiooptions-error"></a>
+```text
+func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error
+    RunStdioShim reads newline-delimited stdio MCP JSON-RPC messages, forwards
+    them to the configured Streamable HTTP route, and writes JSON-RPC responses
+    back to stdout.
+
+```
+
+<a id="agent-adapters-func-validateconfig-cfg-config-error"></a>
+```text
+func ValidateConfig(cfg Config) error
+    ValidateConfig checks the common adapter invariants without reading process
+    state.
+```
+
+<a id="agent-adapters-types"></a>
+### Types
+
+<a id="agent-adapters-type-config-struct"></a>
+```text
+type Config struct {
+	RuntimeURL      *url.URL
+	HumanID         string
+	AgentID         string
+	SessionID       string
+	HostHeader      string
+	ListenAddr      string
+	ProtocolVersion string
+	HTTPClient      *http.Client
+}
+    Config is the shared configuration for agent-side adapters.
+
+```
+
+<a id="agent-adapters-func-loadproxyconfigfromenv-config-error"></a>
+```text
+func LoadProxyConfigFromEnv() (Config, error)
+    LoadProxyConfigFromEnv loads HTTP proxy configuration from environment
+    variables.
+
+```
+
+<a id="agent-adapters-func-loadshimconfigfromenv-config-error"></a>
+```text
+func LoadShimConfigFromEnv() (Config, error)
+    LoadShimConfigFromEnv loads stdio shim configuration from environment
+    variables.
+
+```
+
+<a id="agent-adapters-type-stdiooptions-struct"></a>
+```text
+type StdioOptions struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+}
 ```
 
 <a id="operator-internals"></a>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Home: README.md
   - Getting Started: getting-started.md
   - Publish an MCP Server: publish-mcp-server.md
+  - Agent Adapters: agent-adapters.md
   - Architecture: architecture.md
   - Runtime: runtime.md
   - CLI: cli.md

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -134,6 +134,19 @@ X-MCP-Agent-ID:    ops-agent
 X-MCP-Agent-Session: sess-8f1b9d
 ```
 
+### Agent adapters
+
+Agent-side adapters are optional helper processes for frameworks and IDEs that
+cannot attach these headers directly. `mcp-runtime-agent-proxy` accepts local
+Streamable HTTP MCP traffic, and `mcp-runtime-mcp-shim` accepts stdio MCP
+traffic, then both forward to the governed MCP Runtime route with the issued
+identity/session headers. They do not create grants or sessions and do not
+evaluate policy; the gateway still enforces `MCPAccessGrant` and
+`MCPAgentSession` on the request path.
+
+See [Agent Adapters](agent-adapters.md) for build commands and integration
+examples.
+
 ## Operator internals (high-level)
 
 The operator is a single-controller `controller-runtime` manager:

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -144,6 +144,10 @@ identity/session headers. They do not create grants or sessions and do not
 evaluate policy; the gateway still enforces `MCPAccessGrant` and
 `MCPAgentSession` on the request path.
 
+These adapters expose only the two standard MCP transports: Streamable HTTP and
+stdio. Event-stream handling is an internal Streamable HTTP response parser, not
+a separate legacy HTTP+SSE transport.
+
 See [Agent Adapters](agent-adapters.md) for build commands and integration
 examples.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -148,6 +148,13 @@ These adapters expose only the two standard MCP transports: Streamable HTTP and
 stdio. Event-stream handling is an internal Streamable HTTP response parser, not
 a separate legacy HTTP+SSE transport.
 
+For local debugging, set `MCP_RUNTIME_LOG_LEVEL=info` on either adapter to print
+runtime 4xx denials to stderr. The proxy can suppress local `X-Forwarded-*`
+headers with `MCP_RUNTIME_SET_XFF=false`; the shim can opt into request
+deadlines with `MCP_RUNTIME_REQUEST_TIMEOUT=<duration>`. The stdio shim streams
+Streamable HTTP event frames to stdout as they arrive and continues reading
+stdin while an upstream event stream is open.
+
 See [Agent Adapters](agent-adapters.md) for build commands and integration
 examples.
 

--- a/docs/scripts/generate_go_package_reference.py
+++ b/docs/scripts/generate_go_package_reference.py
@@ -14,6 +14,7 @@ OUT = ROOT / "docs" / "internals" / "go-package-reference.md"
 PACKAGES = [
     ("API types", ["go", "doc", "-all", "./api/v1alpha1"]),
     ("Metadata helpers", ["go", "doc", "-all", "./pkg/metadata"]),
+    ("Agent adapters", ["go", "doc", "-all", "./internal/agentadapter"]),
     ("Operator internals", ["go", "doc", "-all", "./internal/operator"]),
     ("CLI command routing", ["go", "doc", "-all", "./internal/cli/root"]),
     ("CLI core", ["go", "doc", "-all", "./internal/cli/core"]),

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -2,10 +2,12 @@ package agentadapter
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+	"time"
 )
 
 const (
@@ -16,6 +18,9 @@ const (
 	EnvHostHeader      = "MCP_RUNTIME_HOST_HEADER"
 	EnvListenAddr      = "MCP_RUNTIME_LISTEN_ADDR"
 	EnvProtocolVersion = "MCP_RUNTIME_PROTOCOL_VERSION"
+	EnvSetXForwarded   = "MCP_RUNTIME_SET_XFF"
+	EnvRequestTimeout  = "MCP_RUNTIME_REQUEST_TIMEOUT"
+	EnvLogLevel        = "MCP_RUNTIME_LOG_LEVEL"
 
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
@@ -31,14 +36,18 @@ type envLookup func(string) string
 
 // Config is the shared configuration for agent-side adapters.
 type Config struct {
-	RuntimeURL      *url.URL
-	HumanID         string
-	AgentID         string
-	SessionID       string
-	HostHeader      string
-	ListenAddr      string
-	ProtocolVersion string
-	HTTPClient      *http.Client
+	RuntimeURL        *url.URL
+	HumanID           string
+	AgentID           string
+	SessionID         string
+	HostHeader        string
+	ListenAddr        string
+	ProtocolVersion   string
+	HTTPClient        *http.Client
+	RequestTimeout    time.Duration
+	LogLevel          string
+	LogWriter         io.Writer
+	DisableXForwarded bool
 }
 
 // LoadProxyConfigFromEnv loads HTTP proxy configuration from environment variables.
@@ -58,6 +67,7 @@ func loadConfig(lookup envLookup, includeListen bool) (Config, error) {
 		SessionID:       strings.TrimSpace(lookup(EnvSessionID)),
 		HostHeader:      strings.TrimSpace(lookup(EnvHostHeader)),
 		ProtocolVersion: strings.TrimSpace(lookup(EnvProtocolVersion)),
+		LogLevel:        strings.TrimSpace(lookup(EnvLogLevel)),
 	}
 	if cfg.ProtocolVersion == "" {
 		cfg.ProtocolVersion = DefaultProtocolVersion
@@ -82,6 +92,23 @@ func loadConfig(lookup envLookup, includeListen bool) (Config, error) {
 			return Config{}, fmt.Errorf("%s must use http or https", EnvRuntimeURL)
 		}
 		cfg.RuntimeURL = parsed
+	}
+	if rawSetXForwarded := strings.TrimSpace(lookup(EnvSetXForwarded)); rawSetXForwarded != "" {
+		setXForwarded, err := parseAdapterBool(rawSetXForwarded)
+		if err != nil {
+			return Config{}, fmt.Errorf("%s is invalid: %w", EnvSetXForwarded, err)
+		}
+		cfg.DisableXForwarded = !setXForwarded
+	}
+	if rawRequestTimeout := strings.TrimSpace(lookup(EnvRequestTimeout)); rawRequestTimeout != "" {
+		requestTimeout, err := time.ParseDuration(rawRequestTimeout)
+		if err != nil {
+			return Config{}, fmt.Errorf("%s is invalid: %w", EnvRequestTimeout, err)
+		}
+		if requestTimeout <= 0 {
+			return Config{}, fmt.Errorf("%s must be greater than zero", EnvRequestTimeout)
+		}
+		cfg.RequestTimeout = requestTimeout
 	}
 
 	if err := ValidateConfig(cfg); err != nil {
@@ -109,6 +136,17 @@ func ValidateConfig(cfg Config) error {
 		return fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
 	}
 	return nil
+}
+
+func parseAdapterBool(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "t", "true", "y", "yes", "on":
+		return true, nil
+	case "0", "f", "false", "n", "no", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("expected true or false")
+	}
 }
 
 func cloneURL(in *url.URL) *url.URL {

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -1,0 +1,132 @@
+package agentadapter
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	EnvRuntimeURL      = "MCP_RUNTIME_URL"
+	EnvHumanID         = "MCP_RUNTIME_HUMAN_ID"
+	EnvAgentID         = "MCP_RUNTIME_AGENT_ID"
+	EnvSessionID       = "MCP_RUNTIME_SESSION_ID"
+	EnvHostHeader      = "MCP_RUNTIME_HOST_HEADER"
+	EnvListenAddr      = "MCP_RUNTIME_LISTEN_ADDR"
+	EnvProtocolVersion = "MCP_RUNTIME_PROTOCOL_VERSION"
+
+	DefaultListenAddr      = "127.0.0.1:8099"
+	DefaultProtocolVersion = "2025-06-18"
+
+	HumanIDHeader          = "X-MCP-Human-ID"
+	AgentIDHeader          = "X-MCP-Agent-ID"
+	AgentSessionHeader     = "X-MCP-Agent-Session"
+	MCPProtocolHeader      = "Mcp-Protocol-Version"
+	MCPSessionHeader       = "Mcp-Session-Id"
+	defaultHTTPClientLimit = 60 * time.Second
+)
+
+type envLookup func(string) string
+
+// Config is the shared configuration for agent-side adapters.
+type Config struct {
+	RuntimeURL      *url.URL
+	HumanID         string
+	AgentID         string
+	SessionID       string
+	HostHeader      string
+	ListenAddr      string
+	ProtocolVersion string
+	HTTPClient      *http.Client
+}
+
+// LoadProxyConfigFromEnv loads HTTP proxy configuration from environment variables.
+func LoadProxyConfigFromEnv() (Config, error) {
+	return loadConfig(os.Getenv, true)
+}
+
+// LoadShimConfigFromEnv loads stdio shim configuration from environment variables.
+func LoadShimConfigFromEnv() (Config, error) {
+	return loadConfig(os.Getenv, false)
+}
+
+func loadConfig(lookup envLookup, includeListen bool) (Config, error) {
+	cfg := Config{
+		HumanID:         strings.TrimSpace(lookup(EnvHumanID)),
+		AgentID:         strings.TrimSpace(lookup(EnvAgentID)),
+		SessionID:       strings.TrimSpace(lookup(EnvSessionID)),
+		HostHeader:      strings.TrimSpace(lookup(EnvHostHeader)),
+		ProtocolVersion: strings.TrimSpace(lookup(EnvProtocolVersion)),
+		HTTPClient:      &http.Client{Timeout: defaultHTTPClientLimit},
+	}
+	if cfg.ProtocolVersion == "" {
+		cfg.ProtocolVersion = DefaultProtocolVersion
+	}
+	if includeListen {
+		cfg.ListenAddr = strings.TrimSpace(lookup(EnvListenAddr))
+		if cfg.ListenAddr == "" {
+			cfg.ListenAddr = DefaultListenAddr
+		}
+	}
+
+	rawRuntimeURL := strings.TrimSpace(lookup(EnvRuntimeURL))
+	if rawRuntimeURL != "" {
+		parsed, err := url.Parse(rawRuntimeURL)
+		if err != nil {
+			return Config{}, fmt.Errorf("%s is invalid: %w", EnvRuntimeURL, err)
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return Config{}, fmt.Errorf("%s must be an absolute HTTP URL", EnvRuntimeURL)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return Config{}, fmt.Errorf("%s must use http or https", EnvRuntimeURL)
+		}
+		cfg.RuntimeURL = parsed
+	}
+
+	if err := ValidateConfig(cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// ValidateConfig checks the common adapter invariants without reading process state.
+func ValidateConfig(cfg Config) error {
+	var missing []string
+	if cfg.RuntimeURL == nil {
+		missing = append(missing, EnvRuntimeURL)
+	}
+	if strings.TrimSpace(cfg.HumanID) == "" {
+		missing = append(missing, EnvHumanID)
+	}
+	if strings.TrimSpace(cfg.AgentID) == "" {
+		missing = append(missing, EnvAgentID)
+	}
+	if strings.TrimSpace(cfg.SessionID) == "" {
+		missing = append(missing, EnvSessionID)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required environment variables: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func cloneURL(in *url.URL) *url.URL {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func applyGovernanceHeaders(headers http.Header, cfg Config) {
+	headers.Del(HumanIDHeader)
+	headers.Del(AgentIDHeader)
+	headers.Del(AgentSessionHeader)
+	headers.Set(HumanIDHeader, cfg.HumanID)
+	headers.Set(AgentIDHeader, cfg.AgentID)
+	headers.Set(AgentSessionHeader, cfg.SessionID)
+}

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 )
 
 const (
@@ -21,12 +20,11 @@ const (
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
 
-	HumanIDHeader          = "X-MCP-Human-ID"
-	AgentIDHeader          = "X-MCP-Agent-ID"
-	AgentSessionHeader     = "X-MCP-Agent-Session"
-	MCPProtocolHeader      = "Mcp-Protocol-Version"
-	MCPSessionHeader       = "Mcp-Session-Id"
-	defaultHTTPClientLimit = 60 * time.Second
+	HumanIDHeader      = "X-MCP-Human-ID"
+	AgentIDHeader      = "X-MCP-Agent-ID"
+	AgentSessionHeader = "X-MCP-Agent-Session"
+	MCPProtocolHeader  = "Mcp-Protocol-Version"
+	MCPSessionHeader   = "Mcp-Session-Id"
 )
 
 type envLookup func(string) string
@@ -60,7 +58,6 @@ func loadConfig(lookup envLookup, includeListen bool) (Config, error) {
 		SessionID:       strings.TrimSpace(lookup(EnvSessionID)),
 		HostHeader:      strings.TrimSpace(lookup(EnvHostHeader)),
 		ProtocolVersion: strings.TrimSpace(lookup(EnvProtocolVersion)),
-		HTTPClient:      &http.Client{Timeout: defaultHTTPClientLimit},
 	}
 	if cfg.ProtocolVersion == "" {
 		cfg.ProtocolVersion = DefaultProtocolVersion

--- a/internal/agentadapter/config_test.go
+++ b/internal/agentadapter/config_test.go
@@ -1,0 +1,59 @@
+package agentadapter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadProxyConfigRequiresRuntimeIdentityAndSession(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadConfig(func(string) string { return "" }, true)
+	if err == nil {
+		t.Fatal("loadConfig() error = nil, want missing environment error")
+	}
+	for _, name := range []string{EnvRuntimeURL, EnvHumanID, EnvAgentID, EnvSessionID} {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("loadConfig() error = %q, missing %s", err, name)
+		}
+	}
+}
+
+func TestLoadShimConfigRejectsNonHTTPRuntimeURL(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		EnvRuntimeURL: "file:///tmp/mcp.sock",
+		EnvHumanID:    "human-1",
+		EnvAgentID:    "agent-1",
+		EnvSessionID:  "session-1",
+	}
+	_, err := loadConfig(func(key string) string { return env[key] }, false)
+	if err == nil {
+		t.Fatal("loadConfig() error = nil, want URL scheme error")
+	}
+	if !strings.Contains(err.Error(), "must be an absolute HTTP URL") && !strings.Contains(err.Error(), "must use http or https") {
+		t.Fatalf("loadConfig() error = %q, want HTTP URL error", err)
+	}
+}
+
+func TestLoadProxyConfigAppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		EnvRuntimeURL: "http://localhost:18080/demo/mcp",
+		EnvHumanID:    "human-1",
+		EnvAgentID:    "agent-1",
+		EnvSessionID:  "session-1",
+	}
+	cfg, err := loadConfig(func(key string) string { return env[key] }, true)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.ListenAddr != DefaultListenAddr {
+		t.Fatalf("ListenAddr = %q, want %q", cfg.ListenAddr, DefaultListenAddr)
+	}
+	if cfg.ProtocolVersion != DefaultProtocolVersion {
+		t.Fatalf("ProtocolVersion = %q, want %q", cfg.ProtocolVersion, DefaultProtocolVersion)
+	}
+}

--- a/internal/agentadapter/config_test.go
+++ b/internal/agentadapter/config_test.go
@@ -3,6 +3,7 @@ package agentadapter
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadProxyConfigRequiresRuntimeIdentityAndSession(t *testing.T) {
@@ -56,6 +57,15 @@ func TestLoadProxyConfigAppliesDefaults(t *testing.T) {
 	if cfg.ProtocolVersion != DefaultProtocolVersion {
 		t.Fatalf("ProtocolVersion = %q, want %q", cfg.ProtocolVersion, DefaultProtocolVersion)
 	}
+	if cfg.DisableXForwarded {
+		t.Fatal("DisableXForwarded = true, want default proxy X-Forwarded headers enabled")
+	}
+	if cfg.RequestTimeout != 0 {
+		t.Fatalf("RequestTimeout = %s, want unbounded default", cfg.RequestTimeout)
+	}
+	if cfg.LogLevel != "" {
+		t.Fatalf("LogLevel = %q, want empty default", cfg.LogLevel)
+	}
 }
 
 func TestLoadShimConfigDoesNotSetDefaultHTTPTimeout(t *testing.T) {
@@ -73,5 +83,68 @@ func TestLoadShimConfigDoesNotSetDefaultHTTPTimeout(t *testing.T) {
 	}
 	if cfg.HTTPClient != nil {
 		t.Fatalf("HTTPClient = %#v, want nil so stdio shim uses an unbounded default client", cfg.HTTPClient)
+	}
+}
+
+func TestLoadConfigParsesOptionalRuntimeControls(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		EnvRuntimeURL:     "http://localhost:18080/demo/mcp",
+		EnvHumanID:        "human-1",
+		EnvAgentID:        "agent-1",
+		EnvSessionID:      "session-1",
+		EnvSetXForwarded:  "false",
+		EnvRequestTimeout: "300s",
+		EnvLogLevel:       "info",
+	}
+	cfg, err := loadConfig(func(key string) string { return env[key] }, true)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if !cfg.DisableXForwarded {
+		t.Fatal("DisableXForwarded = false, want true when MCP_RUNTIME_SET_XFF=false")
+	}
+	if cfg.RequestTimeout != 300*time.Second {
+		t.Fatalf("RequestTimeout = %s, want 300s", cfg.RequestTimeout)
+	}
+	if cfg.LogLevel != "info" {
+		t.Fatalf("LogLevel = %q, want info", cfg.LogLevel)
+	}
+}
+
+func TestLoadConfigRejectsInvalidRuntimeControls(t *testing.T) {
+	t.Parallel()
+
+	baseEnv := map[string]string{
+		EnvRuntimeURL: "http://localhost:18080/demo/mcp",
+		EnvHumanID:    "human-1",
+		EnvAgentID:    "agent-1",
+		EnvSessionID:  "session-1",
+	}
+	tests := []struct {
+		name string
+		key  string
+		val  string
+	}{
+		{name: "set xff", key: EnvSetXForwarded, val: "maybe"},
+		{name: "request timeout", key: EnvRequestTimeout, val: "0s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			env := map[string]string{}
+			for key, val := range baseEnv {
+				env[key] = val
+			}
+			env[tt.key] = tt.val
+			_, err := loadConfig(func(key string) string { return env[key] }, true)
+			if err == nil {
+				t.Fatal("loadConfig() error = nil, want invalid runtime control error")
+			}
+			if !strings.Contains(err.Error(), tt.key) {
+				t.Fatalf("loadConfig() error = %q, want %s", err, tt.key)
+			}
+		})
 	}
 }

--- a/internal/agentadapter/config_test.go
+++ b/internal/agentadapter/config_test.go
@@ -57,3 +57,21 @@ func TestLoadProxyConfigAppliesDefaults(t *testing.T) {
 		t.Fatalf("ProtocolVersion = %q, want %q", cfg.ProtocolVersion, DefaultProtocolVersion)
 	}
 }
+
+func TestLoadShimConfigDoesNotSetDefaultHTTPTimeout(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		EnvRuntimeURL: "http://localhost:18080/demo/mcp",
+		EnvHumanID:    "human-1",
+		EnvAgentID:    "agent-1",
+		EnvSessionID:  "session-1",
+	}
+	cfg, err := loadConfig(func(key string) string { return env[key] }, false)
+	if err != nil {
+		t.Fatalf("loadConfig() error = %v", err)
+	}
+	if cfg.HTTPClient != nil {
+		t.Fatalf("HTTPClient = %#v, want nil so stdio shim uses an unbounded default client", cfg.HTTPClient)
+	}
+}

--- a/internal/agentadapter/doc.go
+++ b/internal/agentadapter/doc.go
@@ -1,0 +1,3 @@
+// Package agentadapter implements optional agent-side HTTP and stdio adapters
+// that forward MCP traffic to governed MCP Runtime routes.
+package agentadapter

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -1,11 +1,14 @@
 package agentadapter
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -15,6 +18,8 @@ const (
 	proxyShutdownTimeout   = 10 * time.Second
 )
 
+type rpcRequestMetadataContextKey struct{}
+
 // NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic to
 // the configured runtime route and injects issued governance identity headers.
 func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
@@ -23,14 +28,39 @@ func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
 	}
 	target := cloneURL(cfg.RuntimeURL)
 	proxy := &httputil.ReverseProxy{
+		FlushInterval: -1,
 		Rewrite: func(req *httputil.ProxyRequest) {
 			rewriteToRuntimeRoute(req.Out.URL, target, req.In.URL.RawQuery)
 			req.Out.Host = target.Host
 			if cfg.HostHeader != "" {
 				req.Out.Host = cfg.HostHeader
 			}
-			req.SetXForwarded()
+			if !cfg.DisableXForwarded {
+				req.SetXForwarded()
+			}
 			applyGovernanceHeaders(req.Out.Header, cfg)
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			if resp.StatusCode < http.StatusBadRequest || resp.StatusCode >= http.StatusInternalServerError {
+				return nil
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			resp.ContentLength = int64(len(body))
+			resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
+			meta := rpcRequestMetadataFromContext(resp.Request.Context())
+			logRuntimeDenial(cfg, "mcp-runtime-agent-proxy", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
+			return nil
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			meta := rpcRequestMetadataFromContext(r.Context())
+			w.Header().Set("content-type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write(jsonRPCHTTPError(rpcIDOrNull(meta), http.StatusBadGateway, err.Error(), nil))
 		},
 	}
 
@@ -39,6 +69,12 @@ func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		meta, err := captureRPCRequestMetadata(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		r = r.WithContext(context.WithValue(r.Context(), rpcRequestMetadataContextKey{}, meta))
 		proxy.ServeHTTP(w, r)
 	}), nil
 }
@@ -103,4 +139,26 @@ func mergeRawQuery(first, second string) string {
 	default:
 		return first + "&" + second
 	}
+}
+
+func captureRPCRequestMetadata(r *http.Request) (rpcRequestMetadata, error) {
+	if r.Body == nil {
+		return rpcRequestMetadata{}, nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return rpcRequestMetadata{}, err
+	}
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return parseRPCRequestMetadata(bytes.TrimSpace(body)), nil
+}
+
+func rpcRequestMetadataFromContext(ctx context.Context) rpcRequestMetadata {
+	meta, _ := ctx.Value(rpcRequestMetadataContextKey{}).(rpcRequestMetadata)
+	return meta
 }

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -1,0 +1,99 @@
+package agentadapter
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+// NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic to
+// the configured runtime route and injects issued governance identity headers.
+func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
+	if err := ValidateConfig(cfg); err != nil {
+		return nil, err
+	}
+	target := cloneURL(cfg.RuntimeURL)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(req *httputil.ProxyRequest) {
+			rewriteToRuntimeRoute(req.Out.URL, target, req.In.URL.RawQuery)
+			req.Out.Host = target.Host
+			if cfg.HostHeader != "" {
+				req.Out.Host = cfg.HostHeader
+			}
+			req.SetXForwarded()
+			applyGovernanceHeaders(req.Out.Header, cfg)
+		},
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		proxy.ServeHTTP(w, r)
+	}), nil
+}
+
+// RunHTTPProxy serves the local HTTP adapter until the context is cancelled.
+func RunHTTPProxy(ctx context.Context, cfg Config) error {
+	if strings.TrimSpace(cfg.ListenAddr) == "" {
+		cfg.ListenAddr = DefaultListenAddr
+	}
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		return err
+	}
+	server := &http.Server{
+		Addr:    cfg.ListenAddr,
+		Handler: handler,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultHTTPClientLimit)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		err := <-errCh
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+func rewriteToRuntimeRoute(out, target *url.URL, inboundRawQuery string) {
+	out.Scheme = target.Scheme
+	out.Host = target.Host
+	out.Path = target.Path
+	out.RawPath = target.RawPath
+	out.OmitHost = false
+	out.ForceQuery = false
+	out.Fragment = ""
+	out.RawQuery = mergeRawQuery(target.RawQuery, inboundRawQuery)
+}
+
+func mergeRawQuery(first, second string) string {
+	switch {
+	case first == "":
+		return second
+	case second == "":
+		return first
+	default:
+		return first + "&" + second
+	}
+}

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -7,6 +7,12 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"time"
+)
+
+const (
+	proxyReadHeaderTimeout = 5 * time.Second
+	proxyShutdownTimeout   = 10 * time.Second
 )
 
 // NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic to
@@ -47,8 +53,9 @@ func RunHTTPProxy(ctx context.Context, cfg Config) error {
 		return err
 	}
 	server := &http.Server{
-		Addr:    cfg.ListenAddr,
-		Handler: handler,
+		Addr:              cfg.ListenAddr,
+		Handler:           handler,
+		ReadHeaderTimeout: proxyReadHeaderTimeout,
 	}
 
 	errCh := make(chan error, 1)
@@ -58,7 +65,7 @@ func RunHTTPProxy(ctx context.Context, cfg Config) error {
 
 	select {
 	case <-ctx.Done():
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaultHTTPClientLimit)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), proxyShutdownTimeout)
 		defer cancel()
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			return err

--- a/internal/agentadapter/proxy_test.go
+++ b/internal/agentadapter/proxy_test.go
@@ -1,0 +1,130 @@
+package agentadapter
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestHTTPProxyInjectsGovernanceHeadersAndPreservesMCPHeaders(t *testing.T) {
+	t.Parallel()
+
+	var upstreamHost string
+	var upstreamPath string
+	var upstreamQuery string
+	var upstreamHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHost = r.Host
+		upstreamPath = r.URL.Path
+		upstreamQuery = r.URL.RawQuery
+		upstreamHeaders = r.Header.Clone()
+		w.Header().Set(MCPSessionHeader, "runtime-mcp-session")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL + "/go-example-mcp/mcp?source=runtime")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	handler, err := NewHTTPProxyHandler(Config{
+		RuntimeURL: target,
+		HumanID:    "support-lead",
+		AgentID:    "ticket-triage-agent",
+		SessionID:  "sess-ticket-triage-agent",
+		HostHeader: "mcp.example.local",
+	})
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp?client=true", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("accept", "application/json, text/event-stream")
+	req.Header.Set(MCPProtocolHeader, "2025-06-18")
+	req.Header.Set(MCPSessionHeader, "client-mcp-session")
+	req.Header.Set(HumanIDHeader, "spoofed-human")
+	req.Header.Set(AgentIDHeader, "spoofed-agent")
+	req.Header.Set(AgentSessionHeader, "spoofed-session")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if upstreamHost != "mcp.example.local" {
+		t.Fatalf("upstream host = %q, want host header override", upstreamHost)
+	}
+	if upstreamPath != "/go-example-mcp/mcp" {
+		t.Fatalf("upstream path = %q, want exact runtime route", upstreamPath)
+	}
+	if upstreamQuery != "source=runtime&client=true" {
+		t.Fatalf("upstream query = %q, want merged query", upstreamQuery)
+	}
+	assertHeader(t, upstreamHeaders, HumanIDHeader, "support-lead")
+	assertHeader(t, upstreamHeaders, AgentIDHeader, "ticket-triage-agent")
+	assertHeader(t, upstreamHeaders, AgentSessionHeader, "sess-ticket-triage-agent")
+	assertHeader(t, upstreamHeaders, MCPProtocolHeader, "2025-06-18")
+	assertHeader(t, upstreamHeaders, MCPSessionHeader, "client-mcp-session")
+	assertHeader(t, upstreamHeaders, "content-type", "application/json")
+	assertHeader(t, upstreamHeaders, "accept", "application/json, text/event-stream")
+	if got := recorder.Header().Get(MCPSessionHeader); got != "runtime-mcp-session" {
+		t.Fatalf("response %s = %q, want runtime-mcp-session", MCPSessionHeader, got)
+	}
+}
+
+func TestHTTPProxyPropagatesRuntimeDenial(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"trust_too_low"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	handler, err := NewHTTPProxyHandler(testConfig(target))
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"upper"}}`))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+	body, err := io.ReadAll(recorder.Result().Body)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if strings.TrimSpace(string(body)) != `{"error":"trust_too_low"}` {
+		t.Fatalf("body = %q, want trust_too_low denial", strings.TrimSpace(string(body)))
+	}
+}
+
+func testConfig(runtimeURL *url.URL) Config {
+	return Config{
+		RuntimeURL: runtimeURL,
+		HumanID:    "human-1",
+		AgentID:    "agent-1",
+		SessionID:  "session-1",
+	}
+}
+
+func assertHeader(t *testing.T, headers http.Header, name, want string) {
+	t.Helper()
+	if got := headers.Get(name); got != want {
+		t.Fatalf("%s = %q, want %q", name, got, want)
+	}
+}

--- a/internal/agentadapter/proxy_test.go
+++ b/internal/agentadapter/proxy_test.go
@@ -1,12 +1,17 @@
 package agentadapter
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestHTTPProxyInjectsGovernanceHeadersAndPreservesMCPHeaders(t *testing.T) {
@@ -110,6 +115,190 @@ func TestHTTPProxyPropagatesRuntimeDenial(t *testing.T) {
 	}
 	if strings.TrimSpace(string(body)) != `{"error":"trust_too_low"}` {
 		t.Fatalf("body = %q, want trust_too_low denial", strings.TrimSpace(string(body)))
+	}
+}
+
+func TestHTTPProxyLogsRuntimeDenialWhenInfoEnabled(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"trust_too_low"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	var logs bytes.Buffer
+	cfg := testConfig(target)
+	cfg.LogLevel = "info"
+	cfg.LogWriter = &logs
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"upper"}}`))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	logLine := logs.String()
+	for _, want := range []string{"mcp-runtime-agent-proxy:", "403", "trust_too_low", "method=tools/call", "tool=upper"} {
+		if !strings.Contains(logLine, want) {
+			t.Fatalf("log line = %q, want %q", logLine, want)
+		}
+	}
+}
+
+func TestHTTPProxyConvertsUpstreamConnectionFailureToJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	target, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	upstream.Close()
+
+	handler, err := NewHTTPProxyHandler(testConfig(target))
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}`))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	if contentType := recorder.Header().Get("content-type"); !strings.Contains(contentType, "application/json") {
+		t.Fatalf("content-type = %q, want application/json", contentType)
+	}
+	var response rpcErrorResponse
+	if err := json.Unmarshal(bytes.TrimSpace(recorder.Body.Bytes()), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v; body=%s", err, recorder.Body.String())
+	}
+	if string(response.ID) != `"call-1"` {
+		t.Fatalf("id = %s, want call-1", response.ID)
+	}
+	if response.Error.Code != -32000 {
+		t.Fatalf("error code = %d, want -32000", response.Error.Code)
+	}
+	if response.Error.Data["http_status"] != float64(http.StatusBadGateway) {
+		t.Fatalf("http_status = %#v, want %d", response.Error.Data["http_status"], http.StatusBadGateway)
+	}
+}
+
+func TestHTTPProxyCanSuppressXForwardedHeaders(t *testing.T) {
+	t.Parallel()
+
+	var upstreamHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamHeaders = r.Header.Clone()
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	cfg := testConfig(target)
+	cfg.DisableXForwarded = true
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	req.Header.Set("X-Forwarded-For", "198.51.100.1")
+	req.Header.Set("X-Forwarded-Host", "evil.example")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	for _, header := range []string{"X-Forwarded-For", "X-Forwarded-Host", "X-Forwarded-Proto"} {
+		if got := upstreamHeaders.Get(header); got != "" {
+			t.Fatalf("%s = %q, want empty when X-Forwarded headers are disabled", header, got)
+		}
+	}
+}
+
+func TestHTTPProxyFlushesStreamableHTTPEventFrames(t *testing.T) {
+	t.Parallel()
+
+	releaseSecond := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseSecond) }) }
+	defer release()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("response writer does not implement http.Flusher")
+		}
+		w.Header().Set("content-type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"step\":1}}\n\n"))
+		flusher.Flush()
+		<-releaseSecond
+		_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"step\":2}}\n\n"))
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	handler, err := NewHTTPProxyHandler(testConfig(target))
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+	proxy := httptest.NewServer(handler)
+	t.Cleanup(proxy.Close)
+
+	resp, err := proxy.Client().Post(proxy.URL+"/mcp", "application/json", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"upper"}}`))
+	if err != nil {
+		t.Fatalf("Post() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	firstLineCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			errCh <- err
+			return
+		}
+		firstLineCh <- line
+	}()
+
+	select {
+	case line := <-firstLineCh:
+		if !strings.Contains(line, `"step":1`) {
+			t.Fatalf("first event line = %q, want step 1", line)
+		}
+	case err := <-errCh:
+		t.Fatalf("ReadString() error = %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first event before upstream response completed")
+	}
+
+	release()
+	rest, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if !strings.Contains(string(rest), `"step":2`) {
+		t.Fatalf("remaining stream = %q, want step 2", string(rest))
 	}
 }
 

--- a/internal/agentadapter/rpc_metadata.go
+++ b/internal/agentadapter/rpc_metadata.go
@@ -1,0 +1,94 @@
+package agentadapter
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const maxLogFieldBytes = 120
+
+type rpcRequestMetadata struct {
+	ID       json.RawMessage
+	HasID    bool
+	Method   string
+	ToolName string
+}
+
+func parseRPCRequestMetadata(payload []byte) rpcRequestMetadata {
+	envelope, hasID, err := parseRPCEnvelope(payload)
+	if err != nil {
+		return rpcRequestMetadata{}
+	}
+	meta := rpcRequestMetadata{
+		HasID:    hasID,
+		Method:   envelope.Method,
+		ToolName: toolNameFromRPCParams(envelope.Method, envelope.Params),
+	}
+	if len(envelope.ID) > 0 {
+		meta.ID = append(json.RawMessage(nil), envelope.ID...)
+	}
+	return meta
+}
+
+func rpcIDOrNull(meta rpcRequestMetadata) json.RawMessage {
+	if meta.HasID && len(meta.ID) > 0 {
+		return meta.ID
+	}
+	return json.RawMessage("null")
+}
+
+func toolNameFromRPCParams(method string, params json.RawMessage) string {
+	if method != "tools/call" || len(params) == 0 {
+		return ""
+	}
+	var toolCall struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(params, &toolCall); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(toolCall.Name)
+}
+
+func logRuntimeDenial(cfg Config, component string, status int, message string, meta rpcRequestMetadata) {
+	if status < http.StatusBadRequest || status >= http.StatusInternalServerError {
+		return
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.LogLevel), "info") {
+		return
+	}
+	writer := cfg.LogWriter
+	if writer == nil {
+		writer = os.Stderr
+	}
+
+	fmt.Fprintf(writer, "%s: %d %s", component, status, sanitizeLogField(message))
+	if meta.Method != "" {
+		fmt.Fprintf(writer, " method=%s", sanitizeLogField(meta.Method))
+	}
+	if meta.ToolName != "" {
+		fmt.Fprintf(writer, " tool=%s", sanitizeLogField(meta.ToolName))
+	}
+	fmt.Fprintln(writer)
+}
+
+func sanitizeLogField(value string) string {
+	value = strings.Join(strings.Fields(strings.TrimSpace(value)), "_")
+	if value == "" {
+		return "unknown"
+	}
+	if len(value) > maxLogFieldBytes {
+		return value[:maxLogFieldBytes]
+	}
+	return value
+}
+
+func closeIfPossible(reader io.Reader) {
+	if closer, ok := reader.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 const (
@@ -26,9 +27,18 @@ type StdioOptions struct {
 type stdioShim struct {
 	cfg             Config
 	client          *http.Client
+	mu              sync.Mutex
 	sessionID       string
 	protocolVersion string
 }
+
+type stdioScanResult struct {
+	line []byte
+	err  error
+	done bool
+}
+
+type stdioResponseEmitter func([]byte) error
 
 type rpcRequestEnvelope struct {
 	ID     json.RawMessage `json:"id"`
@@ -66,7 +76,7 @@ func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
 		return fmt.Errorf("stdout is required")
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = &http.Client{}
+		cfg.HTTPClient = &http.Client{Timeout: cfg.RequestTimeout}
 	}
 	if strings.TrimSpace(cfg.ProtocolVersion) == "" {
 		cfg.ProtocolVersion = DefaultProtocolVersion
@@ -78,52 +88,119 @@ func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
 		protocolVersion: cfg.ProtocolVersion,
 	}
 
-	scanner := bufio.NewScanner(opts.Stdin)
-	scanner.Buffer(make([]byte, 0, 64*1024), maxStdioMessageBytes)
-	for scanner.Scan() {
-		line := bytes.TrimSpace(scanner.Bytes())
-		if len(line) == 0 {
-			continue
-		}
-		responses, err := shim.forward(ctx, append([]byte(nil), line...))
-		if err != nil {
+	scanResults := scanStdioLines(ctx, opts.Stdin)
+	var stdoutMu sync.Mutex
+	emit := func(response []byte) error {
+		stdoutMu.Lock()
+		defer stdoutMu.Unlock()
+		if _, err := opts.Stdout.Write(response); err != nil {
 			return err
 		}
-		for _, response := range responses {
-			if _, err := opts.Stdout.Write(response); err != nil {
-				return err
-			}
-			if _, err := opts.Stdout.Write([]byte("\n")); err != nil {
-				return err
-			}
+		if _, err := opts.Stdout.Write([]byte("\n")); err != nil {
+			return err
+		}
+		return nil
+	}
+	var forwards sync.WaitGroup
+	errCh := make(chan error, 1)
+	sendErr := func(err error) {
+		if err == nil {
+			return
+		}
+		select {
+		case errCh <- err:
+		default:
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return err
+	for {
+		select {
+		case <-ctx.Done():
+			closeIfPossible(opts.Stdin)
+			forwards.Wait()
+			return nil
+		case err := <-errCh:
+			closeIfPossible(opts.Stdin)
+			forwards.Wait()
+			return err
+		case result := <-scanResults:
+			if result.done {
+				if result.err != nil {
+					if ctx.Err() != nil {
+						return nil
+					}
+					return result.err
+				}
+				forwards.Wait()
+				select {
+				case err := <-errCh:
+					return err
+				default:
+				}
+				return nil
+			}
+			line := bytes.TrimSpace(result.line)
+			if len(line) == 0 {
+				continue
+			}
+			payload := append([]byte(nil), line...)
+			if parseRPCRequestMetadata(payload).Method == "initialize" {
+				if err := shim.forward(ctx, payload, emit); err != nil {
+					if ctx.Err() != nil {
+						return nil
+					}
+					return err
+				}
+				continue
+			}
+			forwards.Add(1)
+			go func() {
+				defer forwards.Done()
+				if err := shim.forward(ctx, payload, emit); err != nil && ctx.Err() == nil {
+					sendErr(err)
+				}
+			}()
+		}
 	}
-	return nil
 }
 
-func (s *stdioShim) forward(ctx context.Context, payload []byte) ([][]byte, error) {
+func scanStdioLines(ctx context.Context, stdin io.Reader) <-chan stdioScanResult {
+	results := make(chan stdioScanResult, 1)
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxStdioMessageBytes)
+	go func() {
+		for scanner.Scan() {
+			line := append([]byte(nil), scanner.Bytes()...)
+			select {
+			case results <- stdioScanResult{line: line}:
+			case <-ctx.Done():
+				return
+			}
+		}
+		select {
+		case results <- stdioScanResult{err: scanner.Err(), done: true}:
+		case <-ctx.Done():
+		}
+	}()
+	return results
+}
+
+func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioResponseEmitter) error {
+	meta := parseRPCRequestMetadata(payload)
 	envelope, hasResponseID, parseErr := parseRPCEnvelope(payload)
 	if parseErr != nil {
-		return [][]byte{jsonRPCParseError(parseErr.Error())}, nil
+		return emit(jsonRPCParseError(parseErr.Error()))
 	}
-	if envelope.Method == "initialize" {
-		if protocolVersion := protocolVersionFromInitialize(envelope.Params); protocolVersion != "" {
-			s.protocolVersion = protocolVersion
-		}
-	}
+	protocolVersion, sessionID := s.prepareRequestState(envelope)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.RuntimeURL.String(), bytes.NewReader(payload))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("accept", "application/json, text/event-stream")
-	req.Header.Set(MCPProtocolHeader, s.protocolVersion)
-	if s.sessionID != "" {
-		req.Header.Set(MCPSessionHeader, s.sessionID)
+	req.Header.Set(MCPProtocolHeader, protocolVersion)
+	if sessionID != "" {
+		req.Header.Set(MCPSessionHeader, sessionID)
 	}
 	applyGovernanceHeaders(req.Header, s.cfg)
 	if s.cfg.HostHeader != "" {
@@ -133,47 +210,66 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte) ([][]byte, erro
 	resp, err := s.client.Do(req)
 	if err != nil {
 		if hasResponseID {
-			return [][]byte{jsonRPCHTTPError(envelope.ID, http.StatusBadGateway, err.Error(), nil)}, nil
+			return emit(jsonRPCHTTPError(envelope.ID, http.StatusBadGateway, err.Error(), nil))
 		}
-		return nil, nil
+		return nil
 	}
 	defer resp.Body.Close()
 
 	if runtimeSessionID := resp.Header.Get(MCPSessionHeader); runtimeSessionID != "" {
-		s.sessionID = runtimeSessionID
+		s.setRuntimeSessionID(runtimeSessionID)
+	}
+
+	if resp.StatusCode < http.StatusBadRequest && strings.Contains(strings.ToLower(resp.Header.Get("content-type")), "text/event-stream") {
+		return streamStreamableHTTPEventMessages(resp.Body, emit)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes+1))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(body) > maxHTTPResponseBytes {
 		if hasResponseID {
-			return [][]byte{jsonRPCHTTPError(envelope.ID, http.StatusBadGateway, "upstream response too large", nil)}, nil
+			return emit(jsonRPCHTTPError(envelope.ID, http.StatusBadGateway, "upstream response too large", nil))
 		}
-		return nil, nil
+		return nil
 	}
 	body = bytes.TrimSpace(body)
 
 	if resp.StatusCode >= http.StatusBadRequest {
+		logRuntimeDenial(s.cfg, "mcp-runtime-mcp-shim", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
 		if len(body) > 0 && looksLikeJSONRPC(body) {
-			return [][]byte{body}, nil
+			return emit(body)
 		}
 		if hasResponseID {
-			return [][]byte{jsonRPCHTTPError(envelope.ID, resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), body)}, nil
+			return emit(jsonRPCHTTPError(envelope.ID, resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), body))
 		}
-		return nil, nil
+		return nil
 	}
 	if !hasResponseID {
-		return nil, nil
+		return nil
 	}
 	if len(body) == 0 {
-		return nil, nil
+		return nil
 	}
-	if strings.Contains(strings.ToLower(resp.Header.Get("content-type")), "text/event-stream") {
-		return decodeStreamableHTTPEventMessages(body), nil
+	return emit(body)
+}
+
+func (s *stdioShim) prepareRequestState(envelope rpcRequestEnvelope) (string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if envelope.Method == "initialize" {
+		if protocolVersion := protocolVersionFromInitialize(envelope.Params); protocolVersion != "" {
+			s.protocolVersion = protocolVersion
+		}
 	}
-	return [][]byte{body}, nil
+	return s.protocolVersion, s.sessionID
+}
+
+func (s *stdioShim) setRuntimeSessionID(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessionID = sessionID
 }
 
 func parseRPCEnvelope(payload []byte) (rpcRequestEnvelope, bool, error) {
@@ -281,33 +377,50 @@ func jsonRPCParseError(detail string) []byte {
 
 func decodeStreamableHTTPEventMessages(payload []byte) [][]byte {
 	var responses [][]byte
+	_ = scanStreamableHTTPEventMessages(bytes.NewReader(payload), func(data []byte) error {
+		responses = append(responses, append([]byte(nil), data...))
+		return nil
+	})
+	return responses
+}
+
+func streamStreamableHTTPEventMessages(payload io.Reader, emit stdioResponseEmitter) error {
+	return scanStreamableHTTPEventMessages(payload, emit)
+}
+
+func scanStreamableHTTPEventMessages(payload io.Reader, emit stdioResponseEmitter) error {
 	var dataLines []string
-	flush := func() {
+	flush := func() error {
 		if len(dataLines) == 0 {
-			return
+			return nil
 		}
 		data := strings.TrimSpace(strings.Join(dataLines, "\n"))
 		dataLines = nil
 		if data == "" || data == "[DONE]" {
-			return
+			return nil
 		}
 		if json.Valid([]byte(data)) {
-			responses = append(responses, []byte(data))
+			return emit([]byte(data))
 		}
+		return nil
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(payload))
+	scanner := bufio.NewScanner(payload)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxHTTPResponseBytes)
 	for scanner.Scan() {
 		line := bytes.TrimRight(scanner.Bytes(), "\r")
 		if len(line) == 0 {
-			flush()
+			if err := flush(); err != nil {
+				return err
+			}
 			continue
 		}
 		if bytes.HasPrefix(line, eventStreamDataPrefix) {
 			dataLines = append(dataLines, string(bytes.TrimSpace(bytes.TrimPrefix(line, eventStreamDataPrefix))))
 		}
 	}
-	flush()
-	return responses
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return flush()
 }

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -16,6 +16,8 @@ const (
 	maxHTTPResponseBytes = 32 << 20
 )
 
+var eventStreamDataPrefix = []byte("data:")
+
 type StdioOptions struct {
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -64,7 +66,7 @@ func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
 		return fmt.Errorf("stdout is required")
 	}
 	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = &http.Client{Timeout: defaultHTTPClientLimit}
+		cfg.HTTPClient = &http.Client{}
 	}
 	if strings.TrimSpace(cfg.ProtocolVersion) == "" {
 		cfg.ProtocolVersion = DefaultProtocolVersion
@@ -103,7 +105,10 @@ func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
 }
 
 func (s *stdioShim) forward(ctx context.Context, payload []byte) ([][]byte, error) {
-	envelope, hasResponseID, _ := parseRPCEnvelope(payload)
+	envelope, hasResponseID, parseErr := parseRPCEnvelope(payload)
+	if parseErr != nil {
+		return [][]byte{jsonRPCParseError(parseErr.Error())}, nil
+	}
 	if envelope.Method == "initialize" {
 		if protocolVersion := protocolVersionFromInitialize(envelope.Params); protocolVersion != "" {
 			s.protocolVersion = protocolVersion
@@ -166,7 +171,7 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte) ([][]byte, erro
 		return nil, nil
 	}
 	if strings.Contains(strings.ToLower(resp.Header.Get("content-type")), "text/event-stream") {
-		return decodeSSEDataMessages(body), nil
+		return decodeStreamableHTTPEventMessages(body), nil
 	}
 	return [][]byte{body}, nil
 }
@@ -255,7 +260,26 @@ func jsonRPCHTTPError(id json.RawMessage, status int, message string, payload []
 	return encoded
 }
 
-func decodeSSEDataMessages(payload []byte) [][]byte {
+func jsonRPCParseError(detail string) []byte {
+	response := rpcErrorResponse{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("null"),
+		Error: rpcError{
+			Code:    -32700,
+			Message: "parse error",
+			Data: map[string]any{
+				"detail": detail,
+			},
+		},
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"parse error"}}`)
+	}
+	return encoded
+}
+
+func decodeStreamableHTTPEventMessages(payload []byte) [][]byte {
 	var responses [][]byte
 	var dataLines []string
 	flush := func() {
@@ -275,13 +299,13 @@ func decodeSSEDataMessages(payload []byte) [][]byte {
 	scanner := bufio.NewScanner(bytes.NewReader(payload))
 	scanner.Buffer(make([]byte, 0, 64*1024), maxHTTPResponseBytes)
 	for scanner.Scan() {
-		line := strings.TrimRight(scanner.Text(), "\r")
-		if line == "" {
+		line := bytes.TrimRight(scanner.Bytes(), "\r")
+		if len(line) == 0 {
 			flush()
 			continue
 		}
-		if strings.HasPrefix(line, "data:") {
-			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		if bytes.HasPrefix(line, eventStreamDataPrefix) {
+			dataLines = append(dataLines, string(bytes.TrimSpace(bytes.TrimPrefix(line, eventStreamDataPrefix))))
 		}
 	}
 	flush()

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -1,0 +1,289 @@
+package agentadapter
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	maxStdioMessageBytes = 16 << 20
+	maxHTTPResponseBytes = 32 << 20
+)
+
+type StdioOptions struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+}
+
+type stdioShim struct {
+	cfg             Config
+	client          *http.Client
+	sessionID       string
+	protocolVersion string
+}
+
+type rpcRequestEnvelope struct {
+	ID     json.RawMessage `json:"id"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+type rpcErrorResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   rpcError        `json:"error"`
+}
+
+type rpcError struct {
+	Code    int            `json:"code"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data,omitempty"`
+}
+
+// RunStdioShim reads newline-delimited stdio MCP JSON-RPC messages, forwards
+// them to the configured Streamable HTTP route, and writes JSON-RPC responses
+// back to stdout.
+func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
+	if err := ValidateConfig(cfg); err != nil {
+		return err
+	}
+	if opts.Stdin == nil {
+		return fmt.Errorf("stdin is required")
+	}
+	if opts.Stdout == nil {
+		return fmt.Errorf("stdout is required")
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: defaultHTTPClientLimit}
+	}
+	if strings.TrimSpace(cfg.ProtocolVersion) == "" {
+		cfg.ProtocolVersion = DefaultProtocolVersion
+	}
+
+	shim := &stdioShim{
+		cfg:             cfg,
+		client:          cfg.HTTPClient,
+		protocolVersion: cfg.ProtocolVersion,
+	}
+
+	scanner := bufio.NewScanner(opts.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxStdioMessageBytes)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		responses, err := shim.forward(ctx, append([]byte(nil), line...))
+		if err != nil {
+			return err
+		}
+		for _, response := range responses {
+			if _, err := opts.Stdout.Write(response); err != nil {
+				return err
+			}
+			if _, err := opts.Stdout.Write([]byte("\n")); err != nil {
+				return err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *stdioShim) forward(ctx context.Context, payload []byte) ([][]byte, error) {
+	envelope, hasResponseID, _ := parseRPCEnvelope(payload)
+	if envelope.Method == "initialize" {
+		if protocolVersion := protocolVersionFromInitialize(envelope.Params); protocolVersion != "" {
+			s.protocolVersion = protocolVersion
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.RuntimeURL.String(), bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("accept", "application/json, text/event-stream")
+	req.Header.Set(MCPProtocolHeader, s.protocolVersion)
+	if s.sessionID != "" {
+		req.Header.Set(MCPSessionHeader, s.sessionID)
+	}
+	applyGovernanceHeaders(req.Header, s.cfg)
+	if s.cfg.HostHeader != "" {
+		req.Host = s.cfg.HostHeader
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		if hasResponseID {
+			return [][]byte{jsonRPCHTTPError(envelope.ID, http.StatusBadGateway, err.Error(), nil)}, nil
+		}
+		return nil, nil
+	}
+	defer resp.Body.Close()
+
+	if runtimeSessionID := resp.Header.Get(MCPSessionHeader); runtimeSessionID != "" {
+		s.sessionID = runtimeSessionID
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxHTTPResponseBytes {
+		if hasResponseID {
+			return [][]byte{jsonRPCHTTPError(envelope.ID, http.StatusBadGateway, "upstream response too large", nil)}, nil
+		}
+		return nil, nil
+	}
+	body = bytes.TrimSpace(body)
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		if len(body) > 0 && looksLikeJSONRPC(body) {
+			return [][]byte{body}, nil
+		}
+		if hasResponseID {
+			return [][]byte{jsonRPCHTTPError(envelope.ID, resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), body)}, nil
+		}
+		return nil, nil
+	}
+	if !hasResponseID {
+		return nil, nil
+	}
+	if len(body) == 0 {
+		return nil, nil
+	}
+	if strings.Contains(strings.ToLower(resp.Header.Get("content-type")), "text/event-stream") {
+		return decodeSSEDataMessages(body), nil
+	}
+	return [][]byte{body}, nil
+}
+
+func parseRPCEnvelope(payload []byte) (rpcRequestEnvelope, bool, error) {
+	var envelope rpcRequestEnvelope
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return envelope, false, err
+	}
+	return envelope, len(envelope.ID) > 0, nil
+}
+
+func protocolVersionFromInitialize(params json.RawMessage) string {
+	if len(params) == 0 {
+		return ""
+	}
+	var initParams initializeParams
+	if err := json.Unmarshal(params, &initParams); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(initParams.ProtocolVersion)
+}
+
+func looksLikeJSONRPC(payload []byte) bool {
+	var response struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &response); err != nil {
+		return false
+	}
+	return response.JSONRPC == "2.0" && (len(response.ID) > 0 || len(response.Result) > 0 || len(response.Error) > 0)
+}
+
+func extractHTTPErrorMessage(status int, payload []byte) string {
+	if len(payload) > 0 {
+		var object struct {
+			Error any `json:"error"`
+		}
+		if err := json.Unmarshal(payload, &object); err == nil {
+			switch value := object.Error.(type) {
+			case string:
+				if strings.TrimSpace(value) != "" {
+					return value
+				}
+			case map[string]any:
+				if message, ok := value["message"].(string); ok && strings.TrimSpace(message) != "" {
+					return message
+				}
+			}
+		}
+		if text := strings.TrimSpace(string(payload)); text != "" {
+			if len(text) > 240 {
+				return text[:240]
+			}
+			return text
+		}
+	}
+	if text := http.StatusText(status); text != "" {
+		return text
+	}
+	return fmt.Sprintf("upstream HTTP %d", status)
+}
+
+func jsonRPCHTTPError(id json.RawMessage, status int, message string, payload []byte) []byte {
+	response := rpcErrorResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: rpcError{
+			Code:    -32000,
+			Message: message,
+			Data: map[string]any{
+				"http_status": status,
+			},
+		},
+	}
+	if len(payload) > 0 && len(payload) <= 4096 {
+		response.Error.Data["upstream_body"] = string(payload)
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":"upstream error"}}`)
+	}
+	return encoded
+}
+
+func decodeSSEDataMessages(payload []byte) [][]byte {
+	var responses [][]byte
+	var dataLines []string
+	flush := func() {
+		if len(dataLines) == 0 {
+			return
+		}
+		data := strings.TrimSpace(strings.Join(dataLines, "\n"))
+		dataLines = nil
+		if data == "" || data == "[DONE]" {
+			return
+		}
+		if json.Valid([]byte(data)) {
+			responses = append(responses, []byte(data))
+		}
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(payload))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxHTTPResponseBytes)
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r")
+		if line == "" {
+			flush()
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	flush()
+	return responses
+}

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -1,0 +1,188 @@
+package agentadapter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type capturedRuntimeRequest struct {
+	Host    string
+	Headers http.Header
+	Body    string
+}
+
+func TestRunStdioShimInjectsHeadersAndMaintainsRuntimeMCPSession(t *testing.T) {
+	t.Parallel()
+
+	var requests []capturedRuntimeRequest
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		requests = append(requests, capturedRuntimeRequest{
+			Host:    r.Host,
+			Headers: r.Header.Clone(),
+			Body:    string(body),
+		})
+		switch len(requests) {
+		case 1:
+			w.Header().Set(MCPSessionHeader, "runtime-mcp-session")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
+		default:
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"5"}]}}`))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	input := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"add","arguments":{"a":2,"b":3}}}`,
+	}, "\n") + "\n"
+	var output bytes.Buffer
+
+	err = RunStdioShim(context.Background(), Config{
+		RuntimeURL:      runtimeURL,
+		HumanID:         "support-lead",
+		AgentID:         "ticket-triage-agent",
+		SessionID:       "sess-ticket-triage-agent",
+		HostHeader:      "mcp.example.local",
+		ProtocolVersion: "2025-01-01",
+		HTTPClient:      upstream.Client(),
+	}, StdioOptions{
+		Stdin:  strings.NewReader(input),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+
+	lines := nonEmptyLines(output.String())
+	if len(lines) != 2 {
+		t.Fatalf("output lines = %#v, want 2 responses", lines)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("runtime requests = %d, want 2", len(requests))
+	}
+	first := requests[0]
+	if first.Host != "mcp.example.local" {
+		t.Fatalf("first host = %q, want host override", first.Host)
+	}
+	assertHeader(t, first.Headers, HumanIDHeader, "support-lead")
+	assertHeader(t, first.Headers, AgentIDHeader, "ticket-triage-agent")
+	assertHeader(t, first.Headers, AgentSessionHeader, "sess-ticket-triage-agent")
+	assertHeader(t, first.Headers, MCPProtocolHeader, "2025-06-18")
+	if got := first.Headers.Get(MCPSessionHeader); got != "" {
+		t.Fatalf("first %s = %q, want empty before initialize response", MCPSessionHeader, got)
+	}
+	assertHeader(t, requests[1].Headers, MCPSessionHeader, "runtime-mcp-session")
+	assertHeader(t, requests[1].Headers, MCPProtocolHeader, "2025-06-18")
+}
+
+func TestRunStdioShimConvertsHTTPDenialToJSONRPCError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"trust_too_low"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	var output bytes.Buffer
+	err = RunStdioShim(context.Background(), Config{
+		RuntimeURL: runtimeURL,
+		HumanID:    "human-1",
+		AgentID:    "agent-1",
+		SessionID:  "session-1",
+		HTTPClient: upstream.Client(),
+	}, StdioOptions{
+		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+
+	var response rpcErrorResponse
+	if err := json.Unmarshal(bytes.TrimSpace(output.Bytes()), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, output.String())
+	}
+	if string(response.ID) != `"call-1"` {
+		t.Fatalf("id = %s, want call-1", response.ID)
+	}
+	if response.Error.Message != "trust_too_low" {
+		t.Fatalf("error message = %q, want trust_too_low", response.Error.Message)
+	}
+	if response.Error.Data["http_status"] != float64(http.StatusForbidden) {
+		t.Fatalf("http_status = %#v, want %d", response.Error.Data["http_status"], http.StatusForbidden)
+	}
+}
+
+func TestRunStdioShimDoesNotWriteResponseForNotificationAcceptedByHTTP(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	var output bytes.Buffer
+	err = RunStdioShim(context.Background(), Config{
+		RuntimeURL: runtimeURL,
+		HumanID:    "human-1",
+		AgentID:    "agent-1",
+		SessionID:  "session-1",
+		HTTPClient: upstream.Client(),
+	}, StdioOptions{
+		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("output = %q, want empty for notification", output.String())
+	}
+}
+
+func TestDecodeSSEDataMessages(t *testing.T) {
+	t.Parallel()
+
+	messages := decodeSSEDataMessages([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n"))
+	if len(messages) != 1 {
+		t.Fatalf("messages = %#v, want one message", messages)
+	}
+	if string(messages[0]) != `{"jsonrpc":"2.0","id":1,"result":{}}` {
+		t.Fatalf("message = %s", messages[0])
+	}
+}
+
+func nonEmptyLines(output string) []string {
+	var lines []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -1,6 +1,7 @@
 package agentadapter
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -9,7 +10,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 type capturedRuntimeRequest struct {
@@ -134,6 +137,195 @@ func TestRunStdioShimConvertsHTTPDenialToJSONRPCError(t *testing.T) {
 	}
 }
 
+func TestRunStdioShimLogsRuntimeDenialWhenInfoEnabled(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"trust_too_low"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	var output bytes.Buffer
+	var logs bytes.Buffer
+	err = RunStdioShim(context.Background(), Config{
+		RuntimeURL: runtimeURL,
+		HumanID:    "human-1",
+		AgentID:    "agent-1",
+		SessionID:  "session-1",
+		HTTPClient: upstream.Client(),
+		LogLevel:   "info",
+		LogWriter:  &logs,
+	}, StdioOptions{
+		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	logLine := logs.String()
+	for _, want := range []string{"mcp-runtime-mcp-shim:", "403", "trust_too_low", "method=tools/call", "tool=upper"} {
+		if !strings.Contains(logLine, want) {
+			t.Fatalf("log line = %q, want %q", logLine, want)
+		}
+	}
+}
+
+func TestRunStdioShimAppliesRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(time.Second):
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":"call-1","result":{}}`))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	var output bytes.Buffer
+	err = RunStdioShim(context.Background(), Config{
+		RuntimeURL:     runtimeURL,
+		HumanID:        "human-1",
+		AgentID:        "agent-1",
+		SessionID:      "session-1",
+		RequestTimeout: 10 * time.Millisecond,
+	}, StdioOptions{
+		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+
+	var response rpcErrorResponse
+	if err := json.Unmarshal(bytes.TrimSpace(output.Bytes()), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, output.String())
+	}
+	if string(response.ID) != `"call-1"` {
+		t.Fatalf("id = %s, want call-1", response.ID)
+	}
+	if response.Error.Code != -32000 {
+		t.Fatalf("error code = %d, want -32000", response.Error.Code)
+	}
+	if response.Error.Data["http_status"] != float64(http.StatusBadGateway) {
+		t.Fatalf("http_status = %#v, want %d", response.Error.Data["http_status"], http.StatusBadGateway)
+	}
+}
+
+func TestRunStdioShimStreamsEventsAndContinuesReadingStdin(t *testing.T) {
+	t.Parallel()
+
+	secondRequest := make(chan string, 1)
+	releaseFinal := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseFinal) }) }
+	defer release()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("ReadAll() error = %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		bodyText := string(body)
+		if strings.Contains(bodyText, `"id":"server-1"`) {
+			secondRequest <- bodyText
+			w.WriteHeader(http.StatusAccepted)
+			release()
+			return
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("response writer does not implement http.Flusher")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("content-type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":\"server-1\",\"method\":\"sampling/createMessage\",\"params\":{}}\n\n"))
+		flusher.Flush()
+		select {
+		case <-releaseFinal:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"id\":\"client-1\",\"result\":{\"ok\":true}}\n\n"))
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	stdin, stdinWriter := io.Pipe()
+	stdoutReader, stdout := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		defer stdout.Close()
+		done <- RunStdioShim(ctx, Config{
+			RuntimeURL: runtimeURL,
+			HumanID:    "human-1",
+			AgentID:    "agent-1",
+			SessionID:  "session-1",
+			HTTPClient: upstream.Client(),
+		}, StdioOptions{
+			Stdin:  stdin,
+			Stdout: stdout,
+		})
+	}()
+
+	if _, err := stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":"client-1","method":"tools/call","params":{"name":"upper"}}` + "\n")); err != nil {
+		t.Fatalf("stdin Write() error = %v", err)
+	}
+	reader := bufio.NewReader(stdoutReader)
+	firstLine := readLineWithin(t, reader, 2*time.Second)
+	if !strings.Contains(firstLine, `"id":"server-1"`) {
+		t.Fatalf("first stdout line = %q, want streamed server request", firstLine)
+	}
+
+	if _, err := stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":"server-1","result":{"content":[]}}` + "\n")); err != nil {
+		t.Fatalf("stdin follow-up Write() error = %v", err)
+	}
+	select {
+	case body := <-secondRequest:
+		if !strings.Contains(body, `"id":"server-1"`) {
+			t.Fatalf("second runtime request = %q, want server-1 response", body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for shim to forward follow-up stdin message")
+	}
+
+	finalLine := readLineWithin(t, reader, 2*time.Second)
+	if !strings.Contains(finalLine, `"id":"client-1"`) {
+		t.Fatalf("final stdout line = %q, want original request response", finalLine)
+	}
+	cancel()
+	_ = stdinWriter.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunStdioShim() error = %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunStdioShim() did not exit after cancellation")
+	}
+}
+
 func TestRunStdioShimDoesNotWriteResponseForNotificationAcceptedByHTTP(t *testing.T) {
 	t.Parallel()
 
@@ -212,6 +404,41 @@ func TestRunStdioShimReturnsParseErrorForMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestRunStdioShimReturnsWhenContextCancelledWhileIdle(t *testing.T) {
+	t.Parallel()
+
+	runtimeURL, err := url.Parse("http://127.0.0.1:1/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	stdin, stdinWriter := io.Pipe()
+	t.Cleanup(func() { _ = stdinWriter.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+
+	go func() {
+		done <- RunStdioShim(ctx, Config{
+			RuntimeURL: runtimeURL,
+			HumanID:    "human-1",
+			AgentID:    "agent-1",
+			SessionID:  "session-1",
+		}, StdioOptions{
+			Stdin:  stdin,
+			Stdout: io.Discard,
+		})
+	}()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RunStdioShim() error = %v, want nil after context cancellation", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunStdioShim() did not return after context cancellation")
+	}
+}
+
 func TestDecodeStreamableHTTPEventMessages(t *testing.T) {
 	t.Parallel()
 
@@ -232,4 +459,27 @@ func nonEmptyLines(output string) []string {
 		}
 	}
 	return lines
+}
+
+func readLineWithin(t *testing.T, reader *bufio.Reader, timeout time.Duration) string {
+	t.Helper()
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		line, err := reader.ReadString('\n')
+		ch <- result{line: line, err: err}
+	}()
+	select {
+	case got := <-ch:
+		if got.err != nil {
+			t.Fatalf("ReadString() error = %v", got.err)
+		}
+		return got.line
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for stdout line")
+		return ""
+	}
 }

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -165,10 +165,57 @@ func TestRunStdioShimDoesNotWriteResponseForNotificationAcceptedByHTTP(t *testin
 	}
 }
 
-func TestDecodeSSEDataMessages(t *testing.T) {
+func TestRunStdioShimReturnsParseErrorForMalformedJSON(t *testing.T) {
 	t.Parallel()
 
-	messages := decodeSSEDataMessages([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n"))
+	upstreamCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, err := url.Parse(upstream.URL + "/go-example-mcp/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	var output bytes.Buffer
+	err = RunStdioShim(context.Background(), Config{
+		RuntimeURL: runtimeURL,
+		HumanID:    "human-1",
+		AgentID:    "agent-1",
+		SessionID:  "session-1",
+		HTTPClient: upstream.Client(),
+	}, StdioOptions{
+		Stdin:  strings.NewReader("{not-json\n"),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if upstreamCalled {
+		t.Fatal("malformed JSON should not be forwarded upstream")
+	}
+
+	var response rpcErrorResponse
+	if err := json.Unmarshal(bytes.TrimSpace(output.Bytes()), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, output.String())
+	}
+	if string(response.ID) != "null" {
+		t.Fatalf("id = %s, want null", response.ID)
+	}
+	if response.Error.Code != -32700 {
+		t.Fatalf("error code = %d, want -32700", response.Error.Code)
+	}
+	if response.Error.Message != "parse error" {
+		t.Fatalf("error message = %q, want parse error", response.Error.Message)
+	}
+}
+
+func TestDecodeStreamableHTTPEventMessages(t *testing.T) {
+	t.Parallel()
+
+	messages := decodeStreamableHTTPEventMessages([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n\n"))
 	if len(messages) != 1 {
 		t.Fatalf("messages = %#v, want one message", messages)
 	}


### PR DESCRIPTION
fixes #147 
<!-- kody-pr-summary:start -->
This pull request introduces optional governed agent adapters to the MCP Runtime, enabling agent frameworks and IDEs to integrate with the platform's governance model without directly handling identity and session headers.

Key changes include:

*   **New Agent Adapters**:
    *   `mcp-runtime-agent-proxy`: An HTTP reverse proxy that listens locally and forwards requests to a configured MCP Runtime route.
    *   `mcp-runtime-mcp-shim`: A stdio shim that reads newline-delimited JSON-RPC messages from stdin, converts them to HTTP requests, and writes JSON-RPC responses to stdout.
*   **Governance Header Injection**: Both adapters automatically inject required governance identity and session headers (`X-MCP-Human-ID`, `X-MCP-Agent-ID`, `X-MCP-Agent-Session`) into all forwarded requests. This ensures that all agent traffic is properly attributed and subject to platform-level policy enforcement.
*   **Clear Governance Model**: The adapters are designed to *only present* issued identity values. They do not create grants or sessions, nor do they evaluate policy; the MCP Runtime gateway remains the sole enforcement point for `MCPAccessGrant` and `MCPAgentSession`.
*   **Configuration**: Adapters are configured via environment variables, including the target `MCP_RUNTIME_URL`, human and agent IDs, session ID, and optional host header or listen address.
*   **Behavioral Enhancements**:
    *   The HTTP proxy merges query parameters from the client and the configured runtime URL, allows host header overrides, and preserves standard MCP protocol headers.
    *   The stdio shim handles the `initialize` method to extract the protocol version, maintains the `Mcp-Session-Id` from runtime responses, converts upstream HTTP errors (e.g., `403 Forbidden` due to `trust_too_low`) into JSON-RPC error responses for the client, and decodes Server-Sent Events (SSE) data messages.
*   **Comprehensive Documentation**: A new `docs/agent-adapters.md` file provides detailed instructions on building, configuring, and integrating with the adapters, including examples for direct HTTP clients, the HTTP proxy, and the stdio shim. Existing documentation (READMEs, internal docs, getting started guide) has been updated to reflect the new components.
*   **Build Integration**: A new `make build-adapters` command has been added to simplify the compilation of these new binaries.
<!-- kody-pr-summary:end -->