### PR TITLE
fix(sentinel): harden service auth and shutdown paths

### DIFF
--- a/.github/workflows/security-trivy.yaml
+++ b/.github/workflows/security-trivy.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           sarif_file: trivy-fs.sarif
+          category: trivy-fs-vuln
 
       - name: Trivy repository misconfiguration scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -72,6 +73,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           sarif_file: trivy-misconfig.sarif
+          category: trivy-fs-misconfig
 
   trivy-image:
     name: Trivy Operator Image Scan
@@ -119,3 +121,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@ed410739ba306e4ebe5e123421a6bd694e494a2b # v4
         with:
           sarif_file: trivy-image.sarif
+          category: trivy-operator-image

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,6 +1,6 @@
-# Keep the operator image on the latest patched Go 1.26.x builder so Trivy
+# Keep the operator image on a patched Go 1.26.x builder so Trivy
 # does not flag fixed stdlib CVEs in the shipped binary.
-FROM golang:1.26.2-alpine3.23 AS builder
+FROM golang:1.26.3-alpine3.23 AS builder
 
 WORKDIR /build
 

--- a/services/api/internal/runtimeapi/access.go
+++ b/services/api/internal/runtimeapi/access.go
@@ -125,7 +125,7 @@ func (s *RuntimeServer) handleRuntimeGrantApply(w http.ResponseWriter, r *http.R
 		}
 		return
 	}
-	if err := s.bindAccessSubjectTeamID(r.Context(), req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
+	if err := s.bindAccessSubjectTeamID(ctx, req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
 	}
@@ -245,7 +245,7 @@ func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http
 		}
 		return
 	}
-	if err := s.bindAccessSubjectTeamID(r.Context(), req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
+	if err := s.bindAccessSubjectTeamID(ctx, req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
 	}

--- a/services/api/internal/runtimeapi/deployments.go
+++ b/services/api/internal/runtimeapi/deployments.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -35,7 +36,10 @@ const (
 	traefikWatchRoleName  = "traefik-watch"
 )
 
-var errPrincipalIdentityRequired = errors.New("authenticated user identity required")
+var (
+	errPrincipalIdentityRequired = errors.New("authenticated user identity required")
+	deployImageTagPattern        = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+)
 
 type managedNamespaceOptions struct {
 	ingressFromNamespaces []string
@@ -247,6 +251,11 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	}
 	image := req.Image
 	if req.Version != "" && !strings.Contains(image[strings.LastIndex(image, "/")+1:], ":") {
+		if !deployImageTagPattern.MatchString(req.Version) {
+			s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, namespace, req.Image, "version must be a valid image tag"))
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "version must be a valid image tag"})
+			return
+		}
 		image += ":" + req.Version
 	}
 	team, teamNamespace := p.TeamForNamespace(namespace)

--- a/services/api/internal/runtimeapi/deployments_test.go
+++ b/services/api/internal/runtimeapi/deployments_test.go
@@ -168,6 +168,36 @@ func TestHandleDeploymentApplyAdminUsesRequestedNamespace(t *testing.T) {
 	}
 }
 
+func TestHandleDeploymentApplyRejectsInvalidVersionTag(t *testing.T) {
+	client := kubernetesfake.NewSimpleClientset()
+	server := &RuntimeServer{
+		k8sClients: &k8sclient.Clients{Clientset: client},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/api/deployments", bytes.NewReader([]byte(`{
+		"name": "demo-workload",
+		"image": "registry.mcpruntime.org/mcp-servers/demo",
+		"version": "latest@sha256:abc",
+		"namespace": "tenant-a",
+		"replicas": 1,
+		"port": 8088
+	}`)))
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleAdmin,
+		Subject:   "admin-1",
+		Namespace: "admin-ns",
+	}))
+	recorder := httptest.NewRecorder()
+
+	server.handleDeploymentApply(recorder, request)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "version must be a valid image tag") {
+		t.Fatalf("body = %q, want invalid version message", recorder.Body.String())
+	}
+}
+
 func TestHandleDeploymentApplyWritesAuditEvent(t *testing.T) {
 	client := kubernetesfake.NewSimpleClientset()
 	audit := &fakeAuditWriter{}

--- a/services/ingest/main.go
+++ b/services/ingest/main.go
@@ -59,6 +59,9 @@ func main() {
 	if (oidcIssuer != "" || oidcAudience != "") && jwksURL == "" {
 		log.Fatal("OIDC_JWKS_URL is required when OIDC_ISSUER or OIDC_AUDIENCE is configured")
 	}
+	if jwksURL != "" && oidcIssuer == "" && oidcAudience == "" {
+		log.Fatal("OIDC_ISSUER or OIDC_AUDIENCE is required when OIDC_JWKS_URL is configured")
+	}
 	jwks := (*keyfunc.JWKS)(nil)
 	if jwksURL != "" {
 		var err error
@@ -246,6 +249,10 @@ func (s *ingestServer) auth(next http.Handler) http.Handler {
 			parser := jwt.NewParser(jwt.WithValidMethods([]string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"}))
 			parsed, err := parser.Parse(token, s.jwks.Keyfunc)
 			if err == nil && parsed.Valid {
+				if s.oidcIssuer == "" && s.oidcAudience == "" {
+					writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid_token"})
+					return
+				}
 				if s.oidcIssuer != "" || s.oidcAudience != "" {
 					claims, ok := parsed.Claims.(jwt.MapClaims)
 					if !ok {

--- a/services/ingest/main_test.go
+++ b/services/ingest/main_test.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/MicahParks/keyfunc"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 func TestHandleEventsRejectsWhitespaceOnlyRequiredFields(t *testing.T) {
@@ -58,5 +67,84 @@ func TestHandleReadyWithoutKafkaReturnsServiceUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(recorder.Body.String(), `"error":"kafka_unavailable"`) {
 		t.Fatalf("body = %q, want kafka_unavailable", recorder.Body.String())
+	}
+}
+
+func TestAuthRejectsJWKSOnlyBearerToken(t *testing.T) {
+	t.Parallel()
+
+	issuer := newTestIngestJWTIssuer(t)
+	jwks, err := keyfunc.Get(issuer.server.URL+"/keys", keyfunc.Options{})
+	if err != nil {
+		t.Fatalf("keyfunc.Get() error = %v", err)
+	}
+	server := &ingestServer{jwks: jwks}
+	called := false
+	handler := server.auth(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, "/events", nil)
+	req.Header.Set("Authorization", "Bearer "+issuer.sign(t, jwt.MapClaims{
+		"iss": "https://issuer.example.com",
+		"aud": "mcp-runtime",
+		"sub": "user-1",
+		"exp": time.Now().Add(time.Hour).Unix(),
+	}))
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+	}
+	if called {
+		t.Fatal("handler should not be called when issuer and audience are both unset")
+	}
+}
+
+type testIngestJWTIssuer struct {
+	privateKey *rsa.PrivateKey
+	server     *httptest.Server
+}
+
+func newTestIngestJWTIssuer(t *testing.T) *testIngestJWTIssuer {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+
+	issuer := &testIngestJWTIssuer{privateKey: privateKey}
+	issuer.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]string{ingestRSAJWK(&privateKey.PublicKey)},
+		})
+	}))
+	t.Cleanup(issuer.server.Close)
+	return issuer
+}
+
+func (i *testIngestJWTIssuer) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	signed, err := token.SignedString(i.privateKey)
+	if err != nil {
+		t.Fatalf("SignedString() error = %v", err)
+	}
+	return signed
+}
+
+func ingestRSAJWK(publicKey *rsa.PublicKey) map[string]string {
+	return map[string]string{
+		"kty": "RSA",
+		"alg": "RS256",
+		"use": "sig",
+		"kid": "test-key",
+		"n":   base64.RawURLEncoding.EncodeToString(publicKey.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(publicKey.E)).Bytes()),
 	}
 }

--- a/services/mcp-proxy/analytics.go
+++ b/services/mcp-proxy/analytics.go
@@ -62,13 +62,13 @@ func (s *proxyServer) emitIfEnabled(event events.Envelope) {
 	if s.analyticsURL == "" {
 		return
 	}
-	if s.analyticsEventQueue() == nil {
+	queue := s.analyticsEventQueue()
+	if queue == nil {
 		return
 	}
 	s.analyticsMu.Lock()
 	defer s.analyticsMu.Unlock()
-	queue := s.analyticsQueue
-	if queue == nil || s.analyticsClosed {
+	if s.analyticsClosed {
 		return
 	}
 	select {

--- a/services/mcp-proxy/analytics.go
+++ b/services/mcp-proxy/analytics.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"time"
 
 	"mcp-runtime/pkg/events"
 )
@@ -17,25 +18,23 @@ func (s *proxyServer) startAnalyticsDispatcher() {
 	}
 	s.analyticsOnce.Do(func() {
 		s.analyticsMu.Lock()
+		if s.analyticsClosed {
+			s.analyticsMu.Unlock()
+			return
+		}
 		if s.analyticsQueue == nil {
 			s.analyticsQueue = make(chan events.Envelope, analyticsQueueSize)
 		}
 		queue := s.analyticsQueue
-		ctx, cancel := context.WithCancel(context.Background())
-		s.analyticsCancel = cancel
+		s.analyticsWG.Add(analyticsWorkerCount)
 		s.analyticsMu.Unlock()
 		for i := 0; i < analyticsWorkerCount; i++ {
 			go func() {
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case event, ok := <-queue:
-						if !ok {
-							return
-						}
-						s.emit(ctx, event)
-					}
+				defer s.analyticsWG.Done()
+				for event := range queue {
+					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(analyticsEmitTimeout)*time.Second)
+					s.emit(ctx, event)
+					cancel()
 				}
 			}()
 		}
@@ -44,19 +43,32 @@ func (s *proxyServer) startAnalyticsDispatcher() {
 
 func (s *proxyServer) stopAnalyticsDispatcher() {
 	s.analyticsMu.Lock()
-	cancel := s.analyticsCancel
-	s.analyticsMu.Unlock()
-	if cancel != nil {
-		cancel()
+	if s.analyticsClosed {
+		s.analyticsMu.Unlock()
+		s.analyticsWG.Wait()
+		return
 	}
+	s.analyticsClosed = true
+	queue := s.analyticsQueue
+	s.analyticsQueue = nil
+	if queue != nil {
+		close(queue)
+	}
+	s.analyticsMu.Unlock()
+	s.analyticsWG.Wait()
 }
 
 func (s *proxyServer) emitIfEnabled(event events.Envelope) {
 	if s.analyticsURL == "" {
 		return
 	}
-	queue := s.analyticsEventQueue()
-	if queue == nil {
+	if s.analyticsEventQueue() == nil {
+		return
+	}
+	s.analyticsMu.Lock()
+	defer s.analyticsMu.Unlock()
+	queue := s.analyticsQueue
+	if queue == nil || s.analyticsClosed {
 		return
 	}
 	select {
@@ -78,6 +90,9 @@ func (s *proxyServer) analyticsEventQueue() chan events.Envelope {
 	}
 	s.analyticsMu.Lock()
 	defer s.analyticsMu.Unlock()
+	if s.analyticsClosed {
+		return nil
+	}
 	return s.analyticsQueue
 }
 

--- a/services/mcp-proxy/main.go
+++ b/services/mcp-proxy/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -104,9 +107,29 @@ func main() {
 		WriteTimeout:      5 * time.Minute,
 		IdleTimeout:       60 * time.Second,
 	}
-	if err := httpServer.ListenAndServe(); err != nil {
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- httpServer.ListenAndServe()
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	select {
+	case err := <-serverErr:
 		srv.stopAnalyticsDispatcher()
-		log.Fatalf("server failed: %v", err)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("server failed: %v", err)
+		}
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			srv.stopAnalyticsDispatcher()
+			log.Fatalf("server shutdown failed: %v", err)
+		}
+		srv.stopAnalyticsDispatcher()
 	}
 }
 

--- a/services/mcp-proxy/main_test.go
+++ b/services/mcp-proxy/main_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -423,6 +424,33 @@ func TestEmitIfEnabledDropsWhenQueueIsFull(t *testing.T) {
 		}
 	default:
 		t.Fatal("analytics queue unexpectedly drained")
+	}
+}
+
+func TestStopAnalyticsDispatcherDrainsQueue(t *testing.T) {
+	t.Parallel()
+
+	var received int32
+	ingest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		atomic.AddInt32(&received, 1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(ingest.Close)
+
+	proxy := &proxyServer{
+		analyticsURL: ingest.URL,
+		httpClient:   ingest.Client(),
+	}
+	proxy.startAnalyticsDispatcher()
+	for i := 0; i < 3; i++ {
+		proxy.emitIfEnabled(events.Envelope{Source: "proxy", EventType: "mcp.request"})
+	}
+
+	proxy.stopAnalyticsDispatcher()
+
+	if got := atomic.LoadInt32(&received); got != 3 {
+		t.Fatalf("received analytics events = %d, want 3", got)
 	}
 }
 

--- a/services/mcp-proxy/types.go
+++ b/services/mcp-proxy/types.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -71,9 +70,10 @@ type proxyServer struct {
 	defaultPolicyMode     string
 	defaultPolicyDecision string
 	defaultPolicyVersion  string
-	analyticsCancel       context.CancelFunc
 	analyticsMu           sync.Mutex
 	analyticsOnce         sync.Once
+	analyticsWG           sync.WaitGroup
+	analyticsClosed       bool
 	oauthMu               sync.Mutex
 	oauthProviders        map[string]*oauthProvider
 	policyState           atomic.Value
@@ -89,6 +89,7 @@ const (
 	maxRPCBodyBytes       = 1 << 20
 	analyticsQueueSize    = 256
 	analyticsWorkerCount  = 4
+	analyticsEmitTimeout  = 5
 	defaultHumanHeader    = "X-MCP-Human-ID"
 	defaultAgentHeader    = "X-MCP-Agent-ID"
 	defaultTeamHeader     = "X-MCP-Team-ID"

--- a/services/traefik-plugins/pii-redactor/redactor.go
+++ b/services/traefik-plugins/pii-redactor/redactor.go
@@ -86,6 +86,14 @@ func (m *Middleware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	hdr := rec.Header()
 	m.redactResponseHeaders(hdr)
+	if rec.overflow {
+		copyHeader(rw.Header(), hdr)
+		rw.Header().Del("Content-Length")
+		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		rw.WriteHeader(http.StatusBadGateway)
+		_, _ = rw.Write([]byte("response body too large for redaction\n"))
+		return
+	}
 	body := rec.bodyBytes()
 	if shouldRedactResponse(hdr.Get("Content-Type")) {
 		body = m.redactBody(body)
@@ -206,6 +214,7 @@ type responseCapture struct {
 	buf           bytes.Buffer
 	maxBody       int64
 	streaming     bool
+	overflow      bool
 	redactHeaders func(http.Header)
 }
 
@@ -235,7 +244,14 @@ func (r *responseCapture) Write(p []byte) (int, error) {
 	if r.code == 0 {
 		r.code = http.StatusOK
 	}
+	if r.overflow {
+		return len(p), nil
+	}
 	if !shouldRedactResponse(r.header.Get("Content-Type")) || int64(r.buf.Len()+len(p)) > r.maxBody {
+		if shouldRedactResponse(r.header.Get("Content-Type")) {
+			r.overflow = true
+			return len(p), nil
+		}
 		if err := r.startPassthrough(); err != nil {
 			return 0, err
 		}

--- a/services/traefik-plugins/pii-redactor/redactor.go
+++ b/services/traefik-plugins/pii-redactor/redactor.go
@@ -89,6 +89,7 @@ func (m *Middleware) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if rec.overflow {
 		copyHeader(rw.Header(), hdr)
 		rw.Header().Del("Content-Length")
+		rw.Header().Del("Content-Encoding")
 		rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		rw.WriteHeader(http.StatusBadGateway)
 		_, _ = rw.Write([]byte("response body too large for redaction\n"))

--- a/services/traefik-plugins/pii-redactor/redactor_test.go
+++ b/services/traefik-plugins/pii-redactor/redactor_test.go
@@ -136,6 +136,7 @@ func TestStreamingResponsesBypassBodyRedaction(t *testing.T) {
 func TestOversizedRedactableResponseFailsClosed(t *testing.T) {
 	handler, err := New(context.Background(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
 		w.Header().Set("Authorization", "Bearer keep-me")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"email":"alice@example.com","token":"fixture-value"}`))
@@ -156,6 +157,9 @@ func TestOversizedRedactableResponseFailsClosed(t *testing.T) {
 	}
 	if got := rec.Header().Get("Authorization"); got != "[redacted]" {
 		t.Fatalf("Authorization response header should be redacted, got %q", got)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "" {
+		t.Fatalf("Content-Encoding should be cleared for plain text error body, got %q", got)
 	}
 }
 

--- a/services/traefik-plugins/pii-redactor/redactor_test.go
+++ b/services/traefik-plugins/pii-redactor/redactor_test.go
@@ -133,6 +133,32 @@ func TestStreamingResponsesBypassBodyRedaction(t *testing.T) {
 	}
 }
 
+func TestOversizedRedactableResponseFailsClosed(t *testing.T) {
+	handler, err := New(context.Background(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Authorization", "Bearer keep-me")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"email":"alice@example.com","token":"fixture-value"}`))
+	}), &Config{MaxBodyBytes: 8}, "pii")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "http://traefik.local/api", nil))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "alice@example.com") || strings.Contains(body, "fixture-value") {
+		t.Fatalf("oversized response leaked sensitive data: %q", body)
+	}
+	if got := rec.Header().Get("Authorization"); got != "[redacted]" {
+		t.Fatalf("Authorization response header should be redacted, got %q", got)
+	}
+}
+
 func TestBinaryAndCompressedRequestsBypassBodyRedaction(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several enhancements to improve service security, authentication correctness, and graceful shutdown mechanisms across various components.

Key changes include:

*   **API Service (runtimeapi)**:
    *   Implemented stricter validation for deployment image version tags, ensuring they conform to a valid image tag pattern. Invalid tags will now result in a `400 Bad Request` and an audit event.
    *   Minor refactoring to ensure consistent context usage in access grant and session apply handlers.

*   **Ingest Service**:
    *   Hardened OIDC/JWT authentication configuration by requiring both `OIDC_JWKS_URL` and either `OIDC_ISSUER` or `OIDC_AUDIENCE` to be configured for JWT validation. This prevents misconfigurations where a JWKS URL is provided without corresponding OIDC issuer/audience details, which could lead to insecure authentication.
    *   Added runtime checks to reject bearer tokens if OIDC issuer and audience are not configured, even if a JWKS URL is present.

*   **MCP Proxy Service**:
    *   Improved the graceful shutdown process for the analytics dispatcher. The dispatcher now uses a `sync.WaitGroup` and a `closed` flag to ensure all queued analytics events are processed within a timeout before the service fully shuts down. New events are prevented from being added during shutdown.
    *   Implemented graceful shutdown for the main HTTP server, allowing it to properly terminate ongoing connections and clean up resources (including the analytics dispatcher) upon receiving interrupt or terminate signals.

*   **PII Redactor Traefik Plugin**:
    *   Enhanced security for handling oversized responses that require PII redaction. If a response body exceeds the configured `MaxBodyBytes` limit, the plugin will now fail closed by returning a `502 Bad Gateway` with a generic error message ("response body too large for redaction"). This prevents partial redaction and potential leakage of sensitive information in overly large responses.
<!-- kody-pr-summary:end -->