### PR TITLE
[codex] Enable gateway tracing and observability e2e

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,15 @@ envtest assets and set `KUBEBUILDER_ASSETS`.
 - `go test ./internal/agentadapter -count=1` (agent-side HTTP proxy and stdio shim behavior)
 - `go test ./test/golden/... -count=1` (CLI help snapshots; update `test/golden/cli/testdata/*.golden` when you change Cobra help text on purpose)
 - `go test ./test/integration/...` (needs `KUBEBUILDER_ASSETS`; see `Makefile.operator` and CI for envtest setup)
-- `E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh` for repeated local Kind e2e debugging without recreating the cluster or rebuilding cached images. The e2e traffic path uses deterministic curl-based MCP requests; omit cache mode for CI-equivalent fresh runs.
+- `E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh`
+  for repeated local Kind e2e debugging without recreating the cluster or
+  rebuilding cached images. The e2e script defaults to
+  `CLUSTER_NAME=mcp-e2e`; when reusing the contributor cluster from
+  `docs/getting-started.md#3-contributor-test-mode-cluster`, set
+  `CLUSTER_NAME=mcp-runtime E2E_CACHE_MODE=1 E2E_KEEP_CLUSTER=1` so agents do
+  not create duplicate clusters, registries, or image builds. The e2e traffic
+  path uses deterministic curl-based MCP requests; omit cache mode for
+  CI-equivalent fresh runs.
 - Sentinel services: run `go test -race -count=1 ./...` inside touched service directories such as `services/api`, `services/mcp-proxy`, `services/ingest`, `services/processor`, and `services/ui` (CI runs service tests explicitly)
 
 **CI** (`.github/workflows/ci.yaml`) runs: `gofmt` check, `go vet`, `staticcheck`, unit tests, golden tests, service tests, `test/integration`, SBOM generation, then Kind e2e on `main`/`PR` branches. Normal PRs, `main`, and manual runs use `E2E_SCENARIOS=all`; Dependabot PRs use `E2E_SCENARIOS=smoke-auth,governance` so dependency bumps still cover MCP ingress/auth and grant/session behavior while keeping runtime low. Security workflows add pinned gosec, Gitleaks, Trivy, and dependency-review checks. Align local changes with that before opening a PR.
@@ -99,6 +107,7 @@ containerdConfigPatches:
 EOF
 
 kind create cluster --name mcp-runtime --config /tmp/mcp-runtime-kind.yaml
+kubectl config use-context kind-mcp-runtime
 ./bin/mcp-runtime bootstrap                              # preflight cluster prerequisites
 MCP_SETUP_WAIT_TIMEOUT=900 ./bin/mcp-runtime setup --test-mode --ingress-manifest config/ingress/overlays/http
 ./bin/mcp-runtime cluster doctor                         # post-install registry/component diagnostics
@@ -110,6 +119,10 @@ gateway proxy, and Sentinel images with `latest` tags to the configured or
 bundled registry, then deploys pods that pull those images. In Kind test mode,
 implicit internal image refs use `registry.registry.svc.cluster.local:5000/...`
 so the documented containerd mirror matches the image host exactly.
+Before rerunning setup or e2e locally, check `kind get clusters` and prefer the
+existing `kind-mcp-runtime` context when it is healthy. Create a new Kind
+cluster only when you need a clean CI-equivalent run or the existing contributor
+cluster is intentionally disposable.
 
 - **Status:** `./bin/mcp-runtime status`
 - **Contributor smoke:** for dashboard access, local image push, MCP JSON-RPC request, Sentinel event checks, service iteration, and tenant visibility probes, start with `docs/contributor/README.md`. The shorter install path remains in `docs/getting-started.md#3-contributor-test-mode-cluster`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -412,6 +412,12 @@ PY
 - Sentinel: `kubectl logs -n mcp-sentinel deploy/<api|ingest|processor|ui|gateway>`
 - **Cluster summary:** `./bin/mcp-runtime status`
 - Dashboards: Grafana and Prometheus via the ingress base URL in dev.
+- Full request tracing: run
+  `E2E_SCENARIOS=smoke-auth,governance,trust,oauth,observability bash test/e2e/kind.sh`.
+  The observability scenario must find one trace through the gateway,
+  `mcp-sentinel-ingest`, and `mcp-sentinel-processor`, with `kafka.produce`,
+  `kafka.consume`, and `clickhouse.insert_event` spans visible through both
+  direct Tempo and Grafana's Tempo datasource.
 
 ## Clean start (keep the cluster, wipe user workloads)
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -58,6 +58,7 @@ func main() {
 		IngressReadinessMode:      ingressReadinessMode,
 		ProvisionedRegistry:       registryConfig,
 		GatewayProxyImage:         gatewayProxyImageFromEnv(os.Getenv),
+		GatewayOTLPEndpoint:       gatewayOTLPEndpointFromEnv(os.Getenv),
 		DefaultAnalyticsIngestURL: analyticsIngestURLFromEnv(os.Getenv),
 		ClusterName:               clusterNameFromEnv(os.Getenv),
 	}).SetupWithManager(mgr); err != nil {
@@ -148,6 +149,10 @@ func registryConfigFromEnv(getenv func(string) string) *operator.RegistryConfig 
 
 func gatewayProxyImageFromEnv(getenv func(string) string) string {
 	return getenv("MCP_GATEWAY_PROXY_IMAGE")
+}
+
+func gatewayOTLPEndpointFromEnv(getenv func(string) string) string {
+	return getenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT")
 }
 
 func analyticsIngestURLFromEnv(getenv func(string) string) string {

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -62,6 +62,25 @@ func TestGatewayProxyImageFromEnv(t *testing.T) {
 	})
 }
 
+func TestGatewayOTLPEndpointFromEnv(t *testing.T) {
+	t.Run("returns empty when unset", func(t *testing.T) {
+		getenv := func(string) string { return "" }
+		if got := gatewayOTLPEndpointFromEnv(getenv); got != "" {
+			t.Fatalf("expected empty gateway otel endpoint, got %q", got)
+		}
+	})
+
+	t.Run("returns configured endpoint", func(t *testing.T) {
+		env := map[string]string{
+			"MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector.mcp-sentinel.svc.cluster.local:4318",
+		}
+		getenv := func(key string) string { return env[key] }
+		if got := gatewayOTLPEndpointFromEnv(getenv); got != "http://otel-collector.mcp-sentinel.svc.cluster.local:4318" {
+			t.Fatalf("unexpected gateway otel endpoint: %q", got)
+		}
+	})
+}
+
 func TestAnalyticsIngestURLFromEnv(t *testing.T) {
 	t.Run("returns empty when unset", func(t *testing.T) {
 		getenv := func(string) string { return "" }

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ human workflows.
 
   <div class="docs-actions">
     <a class="docs-button docs-button-primary" href="getting-started/">Get started</a>
-    <a class="docs-button" href="contributor/README/">Contribute</a>
+    <a class="docs-button" href="contributor/">Contribute</a>
     <a class="docs-button" href="architecture/">Architecture</a>
     <a class="docs-button" href="api/">API reference</a>
   </div>
@@ -116,7 +116,7 @@ DNS, ingress, TLS, and k3s configuration, start with
   <span>Review prerequisites for k3s, kind, minikube, Docker Desktop Kubernetes, kubeadm, and EKS.</span>
 </a>
 
-<a class="docs-card" href="contributor/README/">
+<a class="docs-card" href="contributor/">
   <span class="docs-card-kicker">Contribute</span>
   <strong>Use the contributor guide</strong>
   <span>Set up local Kind, iterate on services, verify tenant visibility, and debug the platform.</span>
@@ -168,7 +168,7 @@ DNS, ingress, TLS, and k3s configuration, start with
   <span><code>MCPServer</code>, access grants, sessions, gateway headers, and HTTP APIs.</span>
 </a>
 
-<a class="docs-card" href="internals/README/">
+<a class="docs-card" href="internals/">
   <span class="docs-card-kicker">Codebase</span>
   <strong>Read the internals</strong>
   <span>Use the internal docs for codebase structure, package tours, and implementation details.</span>

--- a/docs/contributor/service-iteration.md
+++ b/docs/contributor/service-iteration.md
@@ -37,7 +37,7 @@ Build and roll the UI:
 SERVICE=ui
 IMAGE_REPO=mcp-sentinel-ui
 DOCKERFILE=services/ui/Dockerfile
-BUILD_CONTEXT=services/ui
+BUILD_CONTEXT=.
 DEPLOYMENT=mcp-sentinel-ui
 CONTAINER=ui
 TAG="${SERVICE}-dev-$(date +%s)"
@@ -79,8 +79,8 @@ For analytics pipeline changes:
 
 | Service | Image repo | Dockerfile | Build context | Deployment | Container |
 |---|---|---|---|---|---|
-| Ingest | `mcp-sentinel-ingest` | `services/ingest/Dockerfile` | `services/ingest` | `mcp-sentinel-ingest` | `ingest` |
-| Processor | `mcp-sentinel-processor` | `services/processor/Dockerfile` | `services/processor` | `mcp-sentinel-processor` | `processor` |
+| Ingest | `mcp-sentinel-ingest` | `services/ingest/Dockerfile` | `.` | `mcp-sentinel-ingest` | `ingest` |
+| Processor | `mcp-sentinel-processor` | `services/processor/Dockerfile` | `.` | `mcp-sentinel-processor` | `processor` |
 
 After rolling either service, generate one MCP request and check both logs:
 
@@ -165,4 +165,3 @@ helper, or `kind load docker-image` for single-node Kind debugging.
 
 Raw `docker push registry.registry.svc.cluster.local:5000/...` from the host is
 expected to fail unless you have added host DNS and insecure registry settings.
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,7 +204,7 @@ For the UI, for example:
 SERVICE=ui
 IMAGE_REPO=mcp-sentinel-ui
 DOCKERFILE=services/ui/Dockerfile
-BUILD_CONTEXT=services/ui
+BUILD_CONTEXT=.
 DEPLOYMENT=mcp-sentinel-ui
 CONTAINER=ui
 TAG="${SERVICE}-dev-$(date +%s)"
@@ -234,10 +234,10 @@ Use the same commands with the variables below for other Sentinel services:
 
 | Service | Edit path | Image repo | Dockerfile | Build context | Deployment | Container |
 |---|---|---|---|---|---|---|
-| UI | `services/ui` | `mcp-sentinel-ui` | `services/ui/Dockerfile` | `services/ui` | `mcp-sentinel-ui` | `ui` |
+| UI | `services/ui` | `mcp-sentinel-ui` | `services/ui/Dockerfile` | `.` | `mcp-sentinel-ui` | `ui` |
 | API | `services/api` | `mcp-sentinel-api` | `services/api/Dockerfile` | `.` | `mcp-sentinel-api` | `api` |
-| Ingest | `services/ingest` | `mcp-sentinel-ingest` | `services/ingest/Dockerfile` | `services/ingest` | `mcp-sentinel-ingest` | `ingest` |
-| Processor | `services/processor` | `mcp-sentinel-processor` | `services/processor/Dockerfile` | `services/processor` | `mcp-sentinel-processor` | `processor` |
+| Ingest | `services/ingest` | `mcp-sentinel-ingest` | `services/ingest/Dockerfile` | `.` | `mcp-sentinel-ingest` | `ingest` |
+| Processor | `services/processor` | `mcp-sentinel-processor` | `services/processor/Dockerfile` | `.` | `mcp-sentinel-processor` | `processor` |
 
 `services/mcp-proxy` is different: it runs as the `mcp-gateway` sidecar inside
 each MCP server pod. To test proxy changes, build and push

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -2131,6 +2131,9 @@ type MCPServerReconciler struct {
 	// GatewayProxyImage is the default image used for the optional MCP gateway sidecar.
 	GatewayProxyImage string
 
+	// GatewayOTLPEndpoint is the OTLP/HTTP endpoint injected into MCP gateway sidecars.
+	GatewayOTLPEndpoint string
+
 	// DefaultAnalyticsIngestURL is the default analytics ingest endpoint used when analytics is enabled.
 	DefaultAnalyticsIngestURL string
 
@@ -2186,6 +2189,9 @@ type OperatorConfig struct {
 
 	// GatewayProxyImage is the default image used for the optional MCP gateway sidecar.
 	GatewayProxyImage string
+
+	// GatewayOTLPEndpoint is the OTLP/HTTP endpoint injected into MCP gateway sidecars.
+	GatewayOTLPEndpoint string
 
 	// AnalyticsIngestURL is the default analytics ingest endpoint for gateway sidecars.
 	AnalyticsIngestURL string

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -2319,6 +2319,7 @@ kubectl clients, terminal output, and test doubles.
 - [`func GetClusterName() string`](#cli-core-func-getclustername-string)
 - [`func GetDefaultServerPort() int`](#cli-core-func-getdefaultserverport-int)
 - [`func GetDeploymentTimeout() time.Duration`](#cli-core-func-getdeploymenttimeout-time-duration)
+- [`func GetGatewayOTLPEndpointOverride() string`](#cli-core-func-getgatewayotlpendpointoverride-string)
 - [`func GetGatewayProxyImageOverride() string`](#cli-core-func-getgatewayproxyimageoverride-string)
 - [`func GetHelperPodTimeout() time.Duration`](#cli-core-func-gethelperpodtimeout-time-duration)
 - [`func GetMcpIngressHost() string`](#cli-core-func-getmcpingresshost-string)
@@ -2706,6 +2707,14 @@ func GetDeploymentTimeout() time.Duration
 
 ```
 
+<a id="cli-core-func-getgatewayotlpendpointoverride-string"></a>
+```text
+func GetGatewayOTLPEndpointOverride() string
+    GetGatewayOTLPEndpointOverride returns the gateway OTLP endpoint override,
+    empty if not set.
+
+```
+
 <a id="cli-core-func-getgatewayproxyimageoverride-string"></a>
 ```text
 func GetGatewayProxyImageOverride() string
@@ -2968,6 +2977,7 @@ type CLIConfig struct {
 	SkopeoImage               string
 	OperatorImage             string // Override for operator image
 	GatewayProxyImage         string // Optional default image for the MCP gateway sidecar
+	GatewayOTLPEndpoint       string // Optional OTLP/HTTP endpoint for MCP gateway sidecar tracing
 	AnalyticsIngestURL        string // Optional analytics ingest URL override for the MCP gateway sidecar
 	IngressReadinessMode      string // Optional operator ingress readiness mode: strict or permissive
 	ClusterName               string // Optional cluster label attached to analytics/audit events

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -71,6 +71,11 @@ real-client agent prompts are disabled so CI and local runs do not consume
 OpenAI or Anthropic tokens while validating gateway policy, auth, audit, and
 observability paths.
 
+The `observability` scenario validates the trace backend through both direct
+Tempo and Grafana's Tempo datasource. It must find a single request trace that
+contains the gateway service, `mcp-sentinel-ingest`, `mcp-sentinel-processor`,
+and the `kafka.produce`, `kafka.consume`, and `clickhouse.insert_event` spans.
+
 Normal PRs, `main`, and manual CI runs execute full Kind e2e with
 `E2E_SCENARIOS=all`. Dependabot PRs run `smoke-auth,governance` only, so
 dependency bumps still exercise MCP ingress/auth and grant/session behavior

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -59,7 +59,15 @@ http {
             return 301 /;
         }
 
+        location = /README/ {
+            return 301 /;
+        }
+
         location ~ ^/(.+)/README\.md$ {
+            return 301 /$1/;
+        }
+
+        location ~ ^/(.+)/README/?$ {
             return 301 /$1/;
         }
 

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -56,7 +56,12 @@ flowchart LR
 2. **Ingest receives the event** on `/events`, validates the shared `pkg/events` envelope, and writes into Kafka topic `mcp.events`.
 3. **Processor batches to ClickHouse.** Reads Kafka envelopes and uses `pkg/clickhouse` storage helpers to write to the event table.
 4. **API exposes query surfaces.** Recent events, stats, sources, types, and filtered audit views use `pkg/clickhouse` query helpers.
-5. **UI + dashboards consume the data.** UI renders the stream; Grafana / Prometheus / Tempo / Loki / Promtail cover the broader observability path.
+5. **Trace context follows the event path.** Gateway request spans propagate to
+   ingest over HTTP, continue through Kafka headers, and resume in the
+   processor. Processor traces include Kafka consume spans and per-event
+   ClickHouse persistence spans so a request can be followed across the
+   gateway, ingest, processor, and storage handoff in Tempo.
+6. **UI + dashboards consume the data.** UI renders the stream; Grafana / Prometheus / Tempo / Loki / Promtail cover the broader observability path.
 
 ## Storage and observability
 
@@ -67,6 +72,10 @@ flowchart LR
 | **Prometheus + Grafana** | Service metrics, scrape config, dashboards. |
 | **OTel Collector + Tempo** | Distributed tracing pipeline. |
 | **Loki + Promtail** | Log shipping and storage. |
+
+The bundled tracing path uses W3C trace context and baggage propagation. For
+batch writes, the processor emits `clickhouse.insert_event` spans under each
+event trace and a `clickhouse.insert_batch` span for the batch operation.
 
 ## Service HTTP reference
 

--- a/internal/cli/core/config.go
+++ b/internal/cli/core/config.go
@@ -36,6 +36,7 @@ type CLIConfig struct {
 	SkopeoImage               string
 	OperatorImage             string // Override for operator image
 	GatewayProxyImage         string // Optional default image for the MCP gateway sidecar
+	GatewayOTLPEndpoint       string // Optional OTLP/HTTP endpoint for MCP gateway sidecar tracing
 	AnalyticsIngestURL        string // Optional analytics ingest URL override for the MCP gateway sidecar
 	IngressReadinessMode      string // Optional operator ingress readiness mode: strict or permissive
 	ClusterName               string // Optional cluster label attached to analytics/audit events
@@ -86,6 +87,7 @@ func LoadCLIConfig() *CLIConfig {
 		SkopeoImage:                 getEnvOrDefault("MCP_SKOPEO_IMAGE", defaultSkopeoImage),
 		OperatorImage:               os.Getenv("MCP_OPERATOR_IMAGE"), // No default, empty means auto
 		GatewayProxyImage:           os.Getenv("MCP_GATEWAY_PROXY_IMAGE"),
+		GatewayOTLPEndpoint:         os.Getenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT"),
 		AnalyticsIngestURL:          getEnvCompat("MCP_SENTINEL_INGEST_URL", "MCP_ANALYTICS_INGEST_URL"),
 		IngressReadinessMode:        os.Getenv("MCP_INGRESS_READINESS_MODE"),
 		ClusterName:                 getEnvOrDefault("MCP_CLUSTER_NAME", "local"),
@@ -196,6 +198,11 @@ func GetOperatorImageOverride() string {
 // GetGatewayProxyImageOverride returns the gateway proxy image override, empty if not set.
 func GetGatewayProxyImageOverride() string {
 	return DefaultCLIConfig.GatewayProxyImage
+}
+
+// GetGatewayOTLPEndpointOverride returns the gateway OTLP endpoint override, empty if not set.
+func GetGatewayOTLPEndpointOverride() string {
+	return DefaultCLIConfig.GatewayOTLPEndpoint
 }
 
 // GetAnalyticsIngestURLOverride returns the analytics ingest URL override, empty if not set.

--- a/internal/cli/core/config_test.go
+++ b/internal/cli/core/config_test.go
@@ -58,6 +58,7 @@ func TestLoadCLIConfigWithProvisionedRegistry(t *testing.T) {
 	t.Setenv("MCP_SKOPEO_IMAGE", "example/skopeo:latest")
 	t.Setenv("MCP_OPERATOR_IMAGE", "example/operator:latest")
 	t.Setenv("MCP_GATEWAY_PROXY_IMAGE", "example/mcp-proxy:latest")
+	t.Setenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", "http://custom-otel:4318")
 	t.Setenv("MCP_SENTINEL_INGEST_URL", "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events")
 	t.Setenv("MCP_INGRESS_READINESS_MODE", "permissive")
 	t.Setenv("MCP_DEFAULT_SERVER_PORT", "9000")
@@ -92,6 +93,9 @@ func TestLoadCLIConfigWithProvisionedRegistry(t *testing.T) {
 	}
 	if cfg.GatewayProxyImage != "example/mcp-proxy:latest" {
 		t.Fatalf("expected gateway proxy image override, got %q", cfg.GatewayProxyImage)
+	}
+	if cfg.GatewayOTLPEndpoint != "http://custom-otel:4318" {
+		t.Fatalf("expected gateway OTLP endpoint override, got %q", cfg.GatewayOTLPEndpoint)
 	}
 	if cfg.AnalyticsIngestURL != "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events" {
 		t.Fatalf("expected analytics ingest url override, got %q", cfg.AnalyticsIngestURL)
@@ -154,6 +158,7 @@ func TestConfigAccessors(t *testing.T) {
 		SkopeoImage:         "skopeo:test",
 		OperatorImage:       "operator:test",
 		GatewayProxyImage:   "proxy:test",
+		GatewayOTLPEndpoint: "http://otel:test",
 		AnalyticsIngestURL:  "http://analytics-ingest",
 		DefaultServerPort:   7070,
 	}
@@ -184,6 +189,9 @@ func TestConfigAccessors(t *testing.T) {
 	}
 	if GetGatewayProxyImageOverride() != "proxy:test" {
 		t.Fatalf("GetGatewayProxyImageOverride mismatch")
+	}
+	if GetGatewayOTLPEndpointOverride() != "http://otel:test" {
+		t.Fatalf("GetGatewayOTLPEndpointOverride mismatch")
 	}
 	if GetAnalyticsIngestURLOverride() != "http://analytics-ingest" {
 		t.Fatalf("GetAnalyticsIngestURLOverride mismatch")

--- a/internal/cli/server/build_image_test.go
+++ b/internal/cli/server/build_image_test.go
@@ -231,6 +231,35 @@ servers:
 		}
 	})
 
+	t.Run("preserves_tool_side_effects", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		metadataFile := filepath.Join(tmpDir, "servers.yaml")
+
+		initialContent := `version: v1
+servers:
+  - name: my-server
+    tools:
+      - name: add
+        requiredTrust: low
+        sideEffect: read
+`
+		if err := os.WriteFile(metadataFile, []byte(initialContent), 0o600); err != nil {
+			t.Fatalf("failed to write initial metadata: %v", err)
+		}
+
+		if err := updateMetadataImage("my-server", "new-image", "v1.0", metadataFile, ""); err != nil {
+			t.Fatalf("updateMetadataImage failed: %v", err)
+		}
+
+		content, err := os.ReadFile(metadataFile)
+		if err != nil {
+			t.Fatalf("failed to read updated metadata: %v", err)
+		}
+		if !strings.Contains(string(content), "sideEffect: read") {
+			t.Fatalf("expected sideEffect to be preserved, got:\n%s", content)
+		}
+	})
+
 	t.Run("finds_metadata_in_directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		metadataDir := filepath.Join(tmpDir, ".mcp")

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -1075,6 +1075,22 @@ func TestPrometheusScrapesProcessorMetricsPort(t *testing.T) {
 	}
 }
 
+func TestTempoLocalBlocksDoNotShareWALPath(t *testing.T) {
+	content, err := os.ReadFile("../../../k8s/16-tempo.yaml")
+	if err != nil {
+		t.Fatalf("failed to read tempo manifest: %v", err)
+	}
+	if !strings.Contains(string(content), "path: /var/tempo/blocks") {
+		t.Fatalf("expected Tempo local block storage under /var/tempo/blocks, got:\n%s", content)
+	}
+	if !strings.Contains(string(content), "path: /var/tempo/wal") {
+		t.Fatalf("expected Tempo WAL storage under /var/tempo/wal, got:\n%s", content)
+	}
+	if strings.Contains(string(content), "local:\n          path: /var/tempo\n") {
+		t.Fatalf("Tempo local block storage must not share the WAL parent path:\n%s", content)
+	}
+}
+
 func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() {

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -1075,6 +1075,42 @@ func TestPrometheusScrapesProcessorMetricsPort(t *testing.T) {
 	}
 }
 
+func TestPrometheusScrapesClickHouseMetricsPort(t *testing.T) {
+	content, err := os.ReadFile("../../../k8s/11-prometheus.yaml")
+	if err != nil {
+		t.Fatalf("failed to read prometheus manifest: %v", err)
+	}
+	if !strings.Contains(string(content), `job_name: clickhouse`) {
+		t.Fatalf("expected Prometheus to define a ClickHouse scrape job, got:\n%s", content)
+	}
+	if !strings.Contains(string(content), `targets: ["clickhouse:9363"]`) {
+		t.Fatalf("expected Prometheus to scrape ClickHouse metrics port 9363, got:\n%s", content)
+	}
+}
+
+func TestClickHouseExposesPrometheusMetrics(t *testing.T) {
+	for _, path := range []string{"../../../k8s/03-clickhouse.yaml", "../../../k8s/03-clickhouse-hostpath.yaml"} {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read clickhouse manifest %s: %v", path, err)
+		}
+		text := string(content)
+		for _, want := range []string{
+			"name: clickhouse-prometheus-config",
+			"<endpoint>/metrics</endpoint>",
+			"<port>9363</port>",
+			"name: metrics",
+			"port: 9363",
+			"containerPort: 9363",
+			"mountPath: /etc/clickhouse-server/config.d/prometheus.xml",
+		} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("expected %s to contain %q, got:\n%s", path, want, text)
+			}
+		}
+	}
+}
+
 func TestTempoLocalBlocksDoNotShareWALPath(t *testing.T) {
 	content, err := os.ReadFile("../../../k8s/16-tempo.yaml")
 	if err != nil {

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -196,6 +196,26 @@ func TestBuildOperatorArgs(t *testing.T) {
 	})
 }
 
+func findOperatorEnvVar(envVars []operatorEnvVar, name string) *operatorEnvVar {
+	for i := range envVars {
+		if envVars[i].Name == name {
+			return &envVars[i]
+		}
+	}
+	return nil
+}
+
+func requireOperatorEnvVar(t *testing.T, envVars []operatorEnvVar, name, want string) {
+	t.Helper()
+	envVar := findOperatorEnvVar(envVars, name)
+	if envVar == nil {
+		t.Fatalf("expected operator env %s in %v", name, envVars)
+	}
+	if envVar.Value != want {
+		t.Fatalf("operator env %s = %q, want %q", name, envVar.Value, want)
+	}
+}
+
 func TestOperatorEnvOverrides(t *testing.T) {
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() {
@@ -204,33 +224,23 @@ func TestOperatorEnvOverrides(t *testing.T) {
 
 	t.Run("returns empty when no gateway override is set", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{}
-		got := operatorEnvOverrides("")
+		got := operatorEnvOverrides("", "")
 		if len(got) != 2 {
 			t.Fatalf("expected gateway otel and default analytics ingest env only, got %v", got)
 		}
-		if got[0].Name != "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT" || got[0].Value != defaultGatewayOTELExporterOTLPEndpoint {
-			t.Fatalf("unexpected gateway otel env override: %+v", got[0])
-		}
-		if got[1].Name != "MCP_SENTINEL_INGEST_URL" || got[1].Value != defaultAnalyticsIngestURL {
-			t.Fatalf("unexpected default env override: %+v", got[1])
-		}
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", defaultGatewayOTELExporterOTLPEndpoint)
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", defaultAnalyticsIngestURL)
 	})
 
 	t.Run("returns gateway proxy image override", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{GatewayProxyImage: "example.com/mcp-proxy:latest"}
-		got := operatorEnvOverrides("")
+		got := operatorEnvOverrides("", "")
 		if len(got) != 3 {
 			t.Fatalf("expected gateway and analytics env overrides, got %d (%v)", len(got), got)
 		}
-		if got[0].Name != "MCP_GATEWAY_PROXY_IMAGE" || got[0].Value != "example.com/mcp-proxy:latest" {
-			t.Fatalf("unexpected env override: %+v", got[0])
-		}
-		if got[1].Name != "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT" || got[1].Value != defaultGatewayOTELExporterOTLPEndpoint {
-			t.Fatalf("unexpected gateway otel env override: %+v", got[1])
-		}
-		if got[2].Name != "MCP_SENTINEL_INGEST_URL" || got[2].Value != defaultAnalyticsIngestURL {
-			t.Fatalf("unexpected analytics env override: %+v", got[2])
-		}
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_PROXY_IMAGE", "example.com/mcp-proxy:latest")
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", defaultGatewayOTELExporterOTLPEndpoint)
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", defaultAnalyticsIngestURL)
 	})
 
 	t.Run("prefers explicit setup image over config override", func(t *testing.T) {
@@ -238,41 +248,54 @@ func TestOperatorEnvOverrides(t *testing.T) {
 			GatewayProxyImage:  "example.com/mcp-proxy:config",
 			AnalyticsIngestURL: "http://custom-analytics-ingest",
 		}
-		got := operatorEnvOverrides("example.com/mcp-proxy:setup")
+		got := operatorEnvOverrides("example.com/mcp-proxy:setup", "")
 		if len(got) != 3 {
 			t.Fatalf("expected gateway and analytics env overrides, got %d (%v)", len(got), got)
 		}
-		if got[0].Value != "example.com/mcp-proxy:setup" {
-			t.Fatalf("expected explicit setup image to win, got %+v", got[0])
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_PROXY_IMAGE", "example.com/mcp-proxy:setup")
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", defaultGatewayOTELExporterOTLPEndpoint)
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", "http://custom-analytics-ingest")
+	})
+
+	t.Run("preserves existing gateway otel endpoint when configured", func(t *testing.T) {
+		core.DefaultCLIConfig = &core.CLIConfig{}
+		got := operatorEnvOverrides("", "http://custom-collector.mcp-observability.svc.cluster.local:4318")
+		if len(got) != 2 {
+			t.Fatalf("expected gateway otel and default analytics ingest env only, got %v", got)
 		}
-		if got[1].Name != "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT" || got[1].Value != defaultGatewayOTELExporterOTLPEndpoint {
-			t.Fatalf("unexpected gateway otel env override: %+v", got[1])
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", "http://custom-collector.mcp-observability.svc.cluster.local:4318")
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", defaultAnalyticsIngestURL)
+	})
+
+	t.Run("prefers explicit gateway otel endpoint over existing operator value", func(t *testing.T) {
+		core.DefaultCLIConfig = &core.CLIConfig{GatewayOTLPEndpoint: "https://otel.example.com/v1/traces"}
+		got := operatorEnvOverrides("", "http://custom-collector.mcp-observability.svc.cluster.local:4318")
+		if len(got) != 2 {
+			t.Fatalf("expected gateway otel and default analytics ingest env only, got %v", got)
 		}
-		if got[2].Name != "MCP_SENTINEL_INGEST_URL" || got[2].Value != "http://custom-analytics-ingest" {
-			t.Fatalf("expected custom analytics env override, got %+v", got[2])
-		}
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", "https://otel.example.com/v1/traces")
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", defaultAnalyticsIngestURL)
 	})
 
 	t.Run("uses analytics ingest override when configured", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{AnalyticsIngestURL: "http://custom-analytics-ingest"}
-		got := operatorEnvOverrides("")
+		got := operatorEnvOverrides("", "")
 		if len(got) != 2 {
-			t.Fatalf("expected analytics ingest env only, got %d (%v)", len(got), got)
+			t.Fatalf("expected gateway otel and analytics ingest env only, got %d (%v)", len(got), got)
 		}
-		if got[1].Value != "http://custom-analytics-ingest" {
-			t.Fatalf("expected custom ingest url, got %+v", got[1])
-		}
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", defaultGatewayOTELExporterOTLPEndpoint)
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", "http://custom-analytics-ingest")
 	})
 
 	t.Run("includes ingress readiness mode when configured", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{IngressReadinessMode: "permissive"}
-		got := operatorEnvOverrides("")
+		got := operatorEnvOverrides("", "")
 		if len(got) != 3 {
 			t.Fatalf("expected analytics plus ingress readiness env overrides, got %v", got)
 		}
-		if got[2].Name != "MCP_INGRESS_READINESS_MODE" || got[2].Value != "permissive" {
-			t.Fatalf("unexpected ingress readiness env override: %+v", got[2])
-		}
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", defaultGatewayOTELExporterOTLPEndpoint)
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", defaultAnalyticsIngestURL)
+		requireOperatorEnvVar(t, got, "MCP_INGRESS_READINESS_MODE", "permissive")
 	})
 
 	t.Run("includes registry endpoint and ingress host when configured", func(t *testing.T) {
@@ -280,16 +303,14 @@ func TestOperatorEnvOverrides(t *testing.T) {
 			RegistryEndpoint:    "10.43.39.164:5000",
 			RegistryIngressHost: "registry.local",
 		}
-		got := operatorEnvOverrides("")
+		got := operatorEnvOverrides("", "")
 		if len(got) != 4 {
 			t.Fatalf("expected analytics plus registry env overrides, got %v", got)
 		}
-		if got[2].Name != "MCP_REGISTRY_ENDPOINT" || got[2].Value != "10.43.39.164:5000" {
-			t.Fatalf("unexpected registry endpoint env override: %+v", got[2])
-		}
-		if got[3].Name != "MCP_REGISTRY_INGRESS_HOST" || got[3].Value != "registry.local" {
-			t.Fatalf("unexpected registry ingress env override: %+v", got[3])
-		}
+		requireOperatorEnvVar(t, got, "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", defaultGatewayOTELExporterOTLPEndpoint)
+		requireOperatorEnvVar(t, got, "MCP_SENTINEL_INGEST_URL", defaultAnalyticsIngestURL)
+		requireOperatorEnvVar(t, got, "MCP_REGISTRY_ENDPOINT", "10.43.39.164:5000")
+		requireOperatorEnvVar(t, got, "MCP_REGISTRY_INGRESS_HOST", "registry.local")
 	})
 }
 
@@ -1540,6 +1561,64 @@ func TestWaitForDeploymentAvailableWithKubectl(t *testing.T) {
 	}
 	if !commandHasArgs(mock.Commands[0], "get", "deployment", "registry", "-n", "registry", "-o", "jsonpath={.status.availableReplicas}") {
 		t.Fatalf("unexpected command args: %v", mock.Commands[0].Args)
+	}
+}
+
+func TestDeployOperatorManifestsWithKubectlPreservesExistingGatewayOTLPEndpoint(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	core.DefaultCLIConfig = &core.CLIConfig{}
+	t.Cleanup(func() {
+		core.DefaultCLIConfig = orig
+	})
+
+	root := repoRootForTest(t)
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working dir: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("chdir to repo root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(origDir)
+	})
+
+	const customEndpoint = "http://custom-collector.mcp-observability.svc.cluster.local:4318"
+	var managerManifest string
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			cmd := &core.MockCommand{Args: spec.Args}
+			if commandHasArgs(spec, "get", "deployment/"+core.OperatorDeploymentName, "-n", core.NamespaceMCPRuntime) {
+				cmd.OutputData = []byte(customEndpoint)
+			}
+			if idx := argIndex(spec.Args, "-f"); idx != -1 && idx+1 < len(spec.Args) {
+				path := spec.Args[idx+1]
+				if strings.Contains(path, "manager-") && strings.HasSuffix(path, ".yaml") {
+					cmd.RunFunc = func() error {
+						data, err := os.ReadFile(path)
+						if err != nil {
+							return err
+						}
+						managerManifest = string(data)
+						return nil
+					}
+				}
+			}
+			return cmd
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+	swapDefaultKubectlClientForTest(t, kubectl)
+
+	if err := deployOperatorManifestsWithKubectl(kubectl, zap.NewNop(), "registry.example.com/mcp-runtime-operator:dev", "", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(managerManifest, "name: MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT") ||
+		!strings.Contains(managerManifest, "value: "+customEndpoint) {
+		t.Fatalf("expected manager manifest to preserve existing gateway OTLP endpoint, got:\n%s", managerManifest)
+	}
+	if strings.Contains(managerManifest, "value: "+defaultGatewayOTELExporterOTLPEndpoint) {
+		t.Fatalf("expected manager manifest not to overwrite custom gateway OTLP endpoint with default, got:\n%s", managerManifest)
 	}
 }
 

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -1062,6 +1062,19 @@ func TestGrafanaPrometheusDatasourceUsesRoutePrefix(t *testing.T) {
 	}
 }
 
+func TestPrometheusScrapesProcessorMetricsPort(t *testing.T) {
+	content, err := os.ReadFile("../../../k8s/11-prometheus.yaml")
+	if err != nil {
+		t.Fatalf("failed to read prometheus manifest: %v", err)
+	}
+	if !strings.Contains(string(content), `targets: ["mcp-sentinel-processor:9102"]`) {
+		t.Fatalf("expected Prometheus to scrape processor metrics port 9102, got:\n%s", content)
+	}
+	if strings.Contains(string(content), `targets: ["mcp-sentinel-processor:9092"]`) {
+		t.Fatalf("Prometheus still scrapes stale processor port 9092:\n%s", content)
+	}
+}
+
 func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() {

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -1044,6 +1044,24 @@ func TestDeployAnalyticsManifestsWithKubectl_RecreatesClickhouseInitJob(t *testi
 	}
 }
 
+func TestGrafanaPrometheusDatasourceUsesRoutePrefix(t *testing.T) {
+	content, err := os.ReadFile("../../../k8s/19-grafana-datasources.yaml")
+	if err != nil {
+		t.Fatalf("failed to read grafana datasource manifest: %v", err)
+	}
+
+	rendered, err := renderAnalyticsManifest(string(content), AnalyticsImageSet{}, "", setupplan.PlatformModeTenant)
+	if err != nil {
+		t.Fatalf("renderAnalyticsManifest returned error: %v", err)
+	}
+	if !strings.Contains(rendered, "url: http://prometheus:9090/prometheus") {
+		t.Fatalf("expected Prometheus datasource URL to include route prefix, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "url: http://prometheus:9090\n") {
+		t.Fatalf("Prometheus datasource URL is missing route prefix:\n%s", rendered)
+	}
+}
+
 func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() {

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -204,25 +205,31 @@ func TestOperatorEnvOverrides(t *testing.T) {
 	t.Run("returns empty when no gateway override is set", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{}
 		got := operatorEnvOverrides("")
-		if len(got) != 1 {
-			t.Fatalf("expected default analytics ingest env only, got %v", got)
+		if len(got) != 2 {
+			t.Fatalf("expected gateway otel and default analytics ingest env only, got %v", got)
 		}
-		if got[0].Name != "MCP_SENTINEL_INGEST_URL" || got[0].Value != defaultAnalyticsIngestURL {
-			t.Fatalf("unexpected default env override: %+v", got[0])
+		if got[0].Name != "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT" || got[0].Value != defaultGatewayOTELExporterOTLPEndpoint {
+			t.Fatalf("unexpected gateway otel env override: %+v", got[0])
+		}
+		if got[1].Name != "MCP_SENTINEL_INGEST_URL" || got[1].Value != defaultAnalyticsIngestURL {
+			t.Fatalf("unexpected default env override: %+v", got[1])
 		}
 	})
 
 	t.Run("returns gateway proxy image override", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{GatewayProxyImage: "example.com/mcp-proxy:latest"}
 		got := operatorEnvOverrides("")
-		if len(got) != 2 {
+		if len(got) != 3 {
 			t.Fatalf("expected gateway and analytics env overrides, got %d (%v)", len(got), got)
 		}
 		if got[0].Name != "MCP_GATEWAY_PROXY_IMAGE" || got[0].Value != "example.com/mcp-proxy:latest" {
 			t.Fatalf("unexpected env override: %+v", got[0])
 		}
-		if got[1].Name != "MCP_SENTINEL_INGEST_URL" || got[1].Value != defaultAnalyticsIngestURL {
-			t.Fatalf("unexpected analytics env override: %+v", got[1])
+		if got[1].Name != "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT" || got[1].Value != defaultGatewayOTELExporterOTLPEndpoint {
+			t.Fatalf("unexpected gateway otel env override: %+v", got[1])
+		}
+		if got[2].Name != "MCP_SENTINEL_INGEST_URL" || got[2].Value != defaultAnalyticsIngestURL {
+			t.Fatalf("unexpected analytics env override: %+v", got[2])
 		}
 	})
 
@@ -232,36 +239,39 @@ func TestOperatorEnvOverrides(t *testing.T) {
 			AnalyticsIngestURL: "http://custom-analytics-ingest",
 		}
 		got := operatorEnvOverrides("example.com/mcp-proxy:setup")
-		if len(got) != 2 {
+		if len(got) != 3 {
 			t.Fatalf("expected gateway and analytics env overrides, got %d (%v)", len(got), got)
 		}
 		if got[0].Value != "example.com/mcp-proxy:setup" {
 			t.Fatalf("expected explicit setup image to win, got %+v", got[0])
 		}
-		if got[1].Name != "MCP_SENTINEL_INGEST_URL" || got[1].Value != "http://custom-analytics-ingest" {
-			t.Fatalf("expected custom analytics env override, got %+v", got[1])
+		if got[1].Name != "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT" || got[1].Value != defaultGatewayOTELExporterOTLPEndpoint {
+			t.Fatalf("unexpected gateway otel env override: %+v", got[1])
+		}
+		if got[2].Name != "MCP_SENTINEL_INGEST_URL" || got[2].Value != "http://custom-analytics-ingest" {
+			t.Fatalf("expected custom analytics env override, got %+v", got[2])
 		}
 	})
 
 	t.Run("uses analytics ingest override when configured", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{AnalyticsIngestURL: "http://custom-analytics-ingest"}
 		got := operatorEnvOverrides("")
-		if len(got) != 1 {
+		if len(got) != 2 {
 			t.Fatalf("expected analytics ingest env only, got %d (%v)", len(got), got)
 		}
-		if got[0].Value != "http://custom-analytics-ingest" {
-			t.Fatalf("expected custom ingest url, got %+v", got[0])
+		if got[1].Value != "http://custom-analytics-ingest" {
+			t.Fatalf("expected custom ingest url, got %+v", got[1])
 		}
 	})
 
 	t.Run("includes ingress readiness mode when configured", func(t *testing.T) {
 		core.DefaultCLIConfig = &core.CLIConfig{IngressReadinessMode: "permissive"}
 		got := operatorEnvOverrides("")
-		if len(got) != 2 {
+		if len(got) != 3 {
 			t.Fatalf("expected analytics plus ingress readiness env overrides, got %v", got)
 		}
-		if got[1].Name != "MCP_INGRESS_READINESS_MODE" || got[1].Value != "permissive" {
-			t.Fatalf("unexpected ingress readiness env override: %+v", got[1])
+		if got[2].Name != "MCP_INGRESS_READINESS_MODE" || got[2].Value != "permissive" {
+			t.Fatalf("unexpected ingress readiness env override: %+v", got[2])
 		}
 	})
 
@@ -271,14 +281,14 @@ func TestOperatorEnvOverrides(t *testing.T) {
 			RegistryIngressHost: "registry.local",
 		}
 		got := operatorEnvOverrides("")
-		if len(got) != 3 {
+		if len(got) != 4 {
 			t.Fatalf("expected analytics plus registry env overrides, got %v", got)
 		}
-		if got[1].Name != "MCP_REGISTRY_ENDPOINT" || got[1].Value != "10.43.39.164:5000" {
-			t.Fatalf("unexpected registry endpoint env override: %+v", got[1])
+		if got[2].Name != "MCP_REGISTRY_ENDPOINT" || got[2].Value != "10.43.39.164:5000" {
+			t.Fatalf("unexpected registry endpoint env override: %+v", got[2])
 		}
-		if got[2].Name != "MCP_REGISTRY_INGRESS_HOST" || got[2].Value != "registry.local" {
-			t.Fatalf("unexpected registry ingress env override: %+v", got[2])
+		if got[3].Name != "MCP_REGISTRY_INGRESS_HOST" || got[3].Value != "registry.local" {
+			t.Fatalf("unexpected registry ingress env override: %+v", got[3])
 		}
 	})
 }
@@ -857,9 +867,11 @@ func TestPrepareAnalyticsImagesUsesTestModeImageSet(t *testing.T) {
 
 	var buildCalls int32
 	var pushCalls int32
+	var buildContexts []string
 	deps := SetupDeps{
-		BuildAnalyticsImage: func(string, string, string) error {
+		BuildAnalyticsImage: func(_, _, buildContext string) error {
 			atomic.AddInt32(&buildCalls, 1)
+			buildContexts = append(buildContexts, buildContext)
 			return nil
 		},
 		PushAnalyticsImage: func(string) error {
@@ -884,6 +896,11 @@ func TestPrepareAnalyticsImagesUsesTestModeImageSet(t *testing.T) {
 	}
 	if atomic.LoadInt32(&buildCalls) != int32(len(analyticsComponents)) {
 		t.Fatalf("expected %d builds in test mode, got %d", len(analyticsComponents), buildCalls)
+	}
+	// Sentinel service Dockerfiles need the repo root context for shared packages and service modules.
+	wantBuildContexts := []string{".", ".", ".", "."}
+	if !slices.Equal(buildContexts, wantBuildContexts) {
+		t.Fatalf("build contexts = %v, want %v", buildContexts, wantBuildContexts)
 	}
 	if atomic.LoadInt32(&pushCalls) != int32(len(analyticsComponents)) {
 		t.Fatalf("expected %d pushes in test mode, got %d", len(analyticsComponents), pushCalls)
@@ -923,6 +940,107 @@ spec:
 	}
 	if !strings.Contains(rendered, "imagePullSecrets:") || !strings.Contains(rendered, "name: "+defaultRegistrySecretName) {
 		t.Fatalf("expected injected imagePullSecrets, got %s", rendered)
+	}
+}
+
+func TestDeployAnalyticsManifestsWithKubectl_RecreatesClickhouseInitJob(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	t.Cleanup(func() {
+		core.DefaultCLIConfig = orig
+	})
+	core.DefaultCLIConfig = &core.CLIConfig{}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	root := t.TempDir()
+	manifestDir := filepath.Join(root, "k8s")
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatalf("failed to create manifest dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "services"), 0o755); err != nil {
+		t.Fatalf("failed to create services dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/test\n"), 0o644); err != nil {
+		t.Fatalf("failed to write go.mod: %v", err)
+	}
+	manifestContent := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: fixture\n  namespace: mcp-sentinel\n"
+	for _, name := range []string{
+		"00-namespace.yaml",
+		"01-config.yaml",
+		"03-clickhouse.yaml",
+		"04-clickhouse-init.yaml",
+		"05-kafka.yaml",
+		"06-ingest.yaml",
+		"07-processor.yaml",
+		"08-api.yaml",
+		"08-api-rbac.yaml",
+		"09-ui.yaml",
+		"10-gateway.yaml",
+		"11-prometheus.yaml",
+		"12-grafana.yaml",
+		"15-otel-collector.yaml",
+		"16-tempo.yaml",
+		"17-loki.yaml",
+		"18-promtail.yaml",
+		"19-grafana-datasources.yaml",
+		"20-postgres.yaml",
+	} {
+		if err := os.WriteFile(filepath.Join(manifestDir, name), []byte(manifestContent), 0o644); err != nil {
+			t.Fatalf("failed to write fixture manifest %s: %v", name, err)
+		}
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("failed to chdir to fixture root: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(cwd)
+	})
+
+	deleteIndex := -1
+	waitIndex := -1
+	var mock *core.MockExecutor
+	mock = &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			cmd := &core.MockCommand{Args: spec.Args}
+			if contains(spec.Args, "get") && contains(spec.Args, "secret") {
+				cmd.OutputData = []byte("Error from server (NotFound): secrets \"mcp-sentinel-secrets\" not found")
+				cmd.OutputErr = errors.New("not found")
+			}
+			if contains(spec.Args, "delete") && contains(spec.Args, "job/clickhouse-init") {
+				deleteIndex = len(mock.Commands) - 1
+				for _, want := range []string{"--ignore-not-found=true", "--wait=true", "--timeout=60s"} {
+					if !contains(spec.Args, want) {
+						t.Fatalf("delete job args missing %s: %v", want, spec.Args)
+					}
+				}
+			}
+			if contains(spec.Args, "wait") && contains(spec.Args, "job/clickhouse-init") {
+				waitIndex = len(mock.Commands) - 1
+			}
+			return cmd
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	err = deployAnalyticsManifestsWithKubectl(kubectl, zap.NewNop(), AnalyticsImageSet{
+		Ingest:    "example.com/mcp-sentinel-ingest:latest",
+		API:       "example.com/mcp-sentinel-api:latest",
+		Processor: "example.com/mcp-sentinel-processor:latest",
+		UI:        "example.com/mcp-sentinel-ui:latest",
+	}, "", setupplan.PlatformModeTenant)
+	if err != nil {
+		t.Fatalf("deployAnalyticsManifestsWithKubectl returned error: %v", err)
+	}
+	if deleteIndex == -1 {
+		t.Fatal("expected setup to delete any existing clickhouse-init job before reapplying it")
+	}
+	if waitIndex == -1 {
+		t.Fatal("expected setup to wait for clickhouse-init job completion")
+	}
+	if deleteIndex > waitIndex {
+		t.Fatalf("expected clickhouse-init delete before wait, got delete index %d wait index %d", deleteIndex, waitIndex)
 	}
 }
 

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -39,6 +39,7 @@ const defaultRegistrySecretName = "mcp-runtime-registry-creds" // #nosec G101 --
 const testModeOperatorImage = "docker.io/library/mcp-runtime-operator:latest"
 const defaultGatewayProxyRepository = "mcp-sentinel-mcp-proxy"
 const defaultAnalyticsIngestURL = "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events"
+const gatewayOTELExporterOTLPEndpointEnv = "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT"
 const defaultGatewayOTELExporterOTLPEndpoint = "http://otel-collector.mcp-sentinel.svc.cluster.local:4318"
 const gatewayProxyDockerfilePath = "services/mcp-proxy/Dockerfile"
 const gatewayProxyBuildContext = "."
@@ -1452,8 +1453,9 @@ func deployOperatorManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap.
 		}
 	}
 
-	// Inject environment variables if provided
-	if envVars := operatorEnvOverrides(gatewayProxyImage); len(envVars) > 0 {
+	// Inject environment variables if provided.
+	existingGatewayOTLPEndpoint := existingOperatorEnvValue(kubectl, gatewayOTELExporterOTLPEndpointEnv)
+	if envVars := operatorEnvOverrides(gatewayProxyImage, existingGatewayOTLPEndpoint); len(envVars) > 0 {
 		envMap := make(map[string]string, len(envVars))
 		for _, ev := range envVars {
 			envMap[ev.Name] = ev.Value
@@ -2269,7 +2271,7 @@ type operatorEnvVar struct {
 }
 
 // operatorEnvOverrides returns the environment variables to set on the operator deployment.
-func operatorEnvOverrides(gatewayProxyImage string) []operatorEnvVar {
+func operatorEnvOverrides(gatewayProxyImage, existingGatewayOTLPEndpoint string) []operatorEnvVar {
 	var envVars []operatorEnvVar
 	image := strings.TrimSpace(gatewayProxyImage)
 	if image == "" {
@@ -2278,7 +2280,14 @@ func operatorEnvOverrides(gatewayProxyImage string) []operatorEnvVar {
 	if image != "" {
 		envVars = append(envVars, operatorEnvVar{Name: "MCP_GATEWAY_PROXY_IMAGE", Value: image})
 	}
-	envVars = append(envVars, operatorEnvVar{Name: "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", Value: defaultGatewayOTELExporterOTLPEndpoint})
+	gatewayOTLPEndpoint := strings.TrimSpace(core.GetGatewayOTLPEndpointOverride())
+	if gatewayOTLPEndpoint == "" {
+		gatewayOTLPEndpoint = strings.TrimSpace(existingGatewayOTLPEndpoint)
+	}
+	if gatewayOTLPEndpoint == "" {
+		gatewayOTLPEndpoint = defaultGatewayOTELExporterOTLPEndpoint
+	}
+	envVars = append(envVars, operatorEnvVar{Name: gatewayOTELExporterOTLPEndpointEnv, Value: gatewayOTLPEndpoint})
 	ingestURL := strings.TrimSpace(core.GetAnalyticsIngestURLOverride())
 	if ingestURL == "" {
 		ingestURL = defaultAnalyticsIngestURL
@@ -2305,6 +2314,23 @@ func operatorEnvOverrides(gatewayProxyImage string) []operatorEnvVar {
 		envVars = append(envVars, operatorEnvVar{Name: "MCP_CLUSTER_NAME", Value: clusterName})
 	}
 	return envVars
+}
+
+func existingOperatorEnvValue(kubectl core.KubectlRunner, name string) string {
+	jsonPath := fmt.Sprintf(
+		`jsonpath={.spec.template.spec.containers[?(@.name=="%s")].env[?(@.name=="%s")].value}`,
+		core.OperatorManagerContainerName,
+		name,
+	)
+	cmd, err := kubectl.CommandArgs([]string{"get", "deployment/" + core.OperatorDeploymentName, "-n", core.NamespaceMCPRuntime, "-o", jsonPath})
+	if err != nil {
+		return ""
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func applySetupPlanToCLIConfig(plan setupplan.Plan) {

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -39,6 +39,7 @@ const defaultRegistrySecretName = "mcp-runtime-registry-creds" // #nosec G101 --
 const testModeOperatorImage = "docker.io/library/mcp-runtime-operator:latest"
 const defaultGatewayProxyRepository = "mcp-sentinel-mcp-proxy"
 const defaultAnalyticsIngestURL = "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events"
+const defaultGatewayOTELExporterOTLPEndpoint = "http://otel-collector.mcp-sentinel.svc.cluster.local:4318"
 const gatewayProxyDockerfilePath = "services/mcp-proxy/Dockerfile"
 const gatewayProxyBuildContext = "."
 const (
@@ -1636,6 +1637,9 @@ func deployAnalyticsManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap
 	}
 
 	core.Info("Initializing ClickHouse schema")
+	if err := deleteJobIfExistsWithKubectl(kubectl, "clickhouse-init", core.DefaultAnalyticsNamespace); err != nil {
+		return fmt.Errorf("delete existing clickhouse init job: %w", err)
+	}
 	if err := applyRenderedManifest(kubectl, "k8s/04-clickhouse-init.yaml", images, imagePullSecretName, platformMode); err != nil {
 		return err
 	}
@@ -2247,6 +2251,10 @@ func waitForJobCompletionWithKubectl(kubectl core.KubectlRunner, name, namespace
 	return kubectl.RunWithOutput([]string{"wait", "--for=condition=complete", "job/" + name, "-n", namespace, "--timeout=" + timeout}, os.Stdout, os.Stderr)
 }
 
+func deleteJobIfExistsWithKubectl(kubectl core.KubectlRunner, name, namespace string) error {
+	return kubectl.RunWithOutput([]string{"delete", "job/" + name, "-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}, os.Stdout, os.Stderr)
+}
+
 func operatorImagePullPolicy(operatorImage string) string {
 	if strings.TrimSpace(operatorImage) == testModeOperatorImage {
 		return "IfNotPresent"
@@ -2270,6 +2278,7 @@ func operatorEnvOverrides(gatewayProxyImage string) []operatorEnvVar {
 	if image != "" {
 		envVars = append(envVars, operatorEnvVar{Name: "MCP_GATEWAY_PROXY_IMAGE", Value: image})
 	}
+	envVars = append(envVars, operatorEnvVar{Name: "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", Value: defaultGatewayOTELExporterOTLPEndpoint})
 	ingestURL := strings.TrimSpace(core.GetAnalyticsIngestURLOverride())
 	if ingestURL == "" {
 		ingestURL = defaultAnalyticsIngestURL

--- a/internal/operator/config.go
+++ b/internal/operator/config.go
@@ -38,6 +38,9 @@ type OperatorConfig struct {
 	// GatewayProxyImage is the default image used for the optional MCP gateway sidecar.
 	GatewayProxyImage string
 
+	// GatewayOTLPEndpoint is the OTLP/HTTP endpoint injected into MCP gateway sidecars.
+	GatewayOTLPEndpoint string
+
 	// AnalyticsIngestURL is the default analytics ingest endpoint for gateway sidecars.
 	AnalyticsIngestURL string
 
@@ -59,6 +62,7 @@ func LoadOperatorConfig() *OperatorConfig {
 		InternalRegistryEndpoint:      getEnvOrDefault("MCP_REGISTRY_ENDPOINT", getEnvOrDefault("MCP_REGISTRY_HOST", "registry.local")),
 		RequeueDelaySeconds:           getEnvIntOrDefault("REQUEUE_DELAY_SECONDS", RequeueDelayNotReady),
 		GatewayProxyImage:             os.Getenv("MCP_GATEWAY_PROXY_IMAGE"),
+		GatewayOTLPEndpoint:           os.Getenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT"),
 		AnalyticsIngestURL:            getEnvCompat("MCP_SENTINEL_INGEST_URL", "MCP_ANALYTICS_INGEST_URL"),
 		ClusterName:                   getEnvOrDefault("MCP_CLUSTER_NAME", "local"),
 	}

--- a/internal/operator/config_test.go
+++ b/internal/operator/config_test.go
@@ -196,6 +196,7 @@ func TestLoadOperatorConfig(t *testing.T) {
 	t.Setenv("PROVISIONED_REGISTRY_SECRET_NAME", "registry-creds")
 	t.Setenv("REQUEUE_DELAY_SECONDS", "45")
 	t.Setenv("MCP_GATEWAY_PROXY_IMAGE", "example.com/mcp-proxy:latest")
+	t.Setenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.mcp-sentinel.svc.cluster.local:4318")
 	t.Setenv("MCP_SENTINEL_INGEST_URL", "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events")
 
 	cfg := LoadOperatorConfig()
@@ -225,6 +226,9 @@ func TestLoadOperatorConfig(t *testing.T) {
 	}
 	if cfg.GatewayProxyImage != "example.com/mcp-proxy:latest" {
 		t.Fatalf("expected gateway proxy image override, got %q", cfg.GatewayProxyImage)
+	}
+	if cfg.GatewayOTLPEndpoint != "http://otel-collector.mcp-sentinel.svc.cluster.local:4318" {
+		t.Fatalf("expected gateway otel endpoint override, got %q", cfg.GatewayOTLPEndpoint)
 	}
 	if cfg.AnalyticsIngestURL != "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events" {
 		t.Fatalf("expected analytics ingest url override, got %q", cfg.AnalyticsIngestURL)

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -49,6 +49,9 @@ type MCPServerReconciler struct {
 	// GatewayProxyImage is the default image used for the optional MCP gateway sidecar.
 	GatewayProxyImage string
 
+	// GatewayOTLPEndpoint is the OTLP/HTTP endpoint injected into MCP gateway sidecars.
+	GatewayOTLPEndpoint string
+
 	// DefaultAnalyticsIngestURL is the default analytics ingest endpoint used when analytics is enabled.
 	DefaultAnalyticsIngestURL string
 

--- a/internal/operator/controller_test.go
+++ b/internal/operator/controller_test.go
@@ -495,8 +495,9 @@ func TestReconcileDeploymentLabels(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&mcpServer).Build()
 	reconciler := MCPServerReconciler{
-		Client: client,
-		Scheme: scheme,
+		Client:              client,
+		Scheme:              scheme,
+		GatewayOTLPEndpoint: "http://otel-collector.mcp-sentinel.svc.cluster.local:4318",
 	}
 
 	if err := reconciler.reconcileDeployment(context.Background(), &mcpServer); err != nil {
@@ -590,8 +591,9 @@ func TestReconcileDeploymentAddsGatewaySidecar(t *testing.T) {
 
 	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&mcpServer).Build()
 	reconciler := MCPServerReconciler{
-		Client: client,
-		Scheme: scheme,
+		Client:              client,
+		Scheme:              scheme,
+		GatewayOTLPEndpoint: "http://otel-collector.mcp-sentinel.svc.cluster.local:4318",
 	}
 	reconciler.setDefaults(&mcpServer)
 
@@ -624,6 +626,8 @@ func TestReconcileDeploymentAddsGatewaySidecar(t *testing.T) {
 	}
 	assertEqual(t, "gatewayPortEnv", envByName["PORT"].Value, "8091")
 	assertEqual(t, "gatewayUpstreamEnv", envByName["UPSTREAM_URL"].Value, "http://127.0.0.1:8088")
+	assertEqual(t, "gatewayOTELServiceName", envByName["OTEL_SERVICE_NAME"].Value, "gateway-server-gateway")
+	assertEqual(t, "gatewayOTELEndpoint", envByName["OTEL_EXPORTER_OTLP_ENDPOINT"].Value, "http://otel-collector.mcp-sentinel.svc.cluster.local:4318")
 	if _, ok := envByName["EXTERNAL_BASE_URL"]; ok {
 		t.Fatal("expected EXTERNAL_BASE_URL to be unset for hostless path-based routing")
 	}

--- a/internal/operator/deployment.go
+++ b/internal/operator/deployment.go
@@ -391,6 +391,12 @@ func (r *MCPServerReconciler) buildGatewayContainer(mcpServer *mcpv1alpha1.MCPSe
 	if externalBaseURL := gatewayExternalBaseURL(mcpServer); externalBaseURL != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "EXTERNAL_BASE_URL", Value: externalBaseURL})
 	}
+	if endpoint := strings.TrimSpace(r.GatewayOTLPEndpoint); endpoint != "" {
+		envVars = append(envVars,
+			corev1.EnvVar{Name: "OTEL_SERVICE_NAME", Value: mcpServer.Name + "-gateway"},
+			corev1.EnvVar{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: endpoint},
+		)
+	}
 	if mcpServer.Spec.Policy != nil {
 		envVars = append(envVars,
 			corev1.EnvVar{Name: "POLICY_MODE", Value: string(mcpServer.Spec.Policy.Mode)},

--- a/k8s/03-clickhouse-hostpath.yaml
+++ b/k8s/03-clickhouse-hostpath.yaml
@@ -27,6 +27,23 @@ spec:
                 - "true"
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-prometheus-config
+  namespace: mcp-sentinel
+data:
+  prometheus.xml: |
+    <clickhouse>
+      <prometheus>
+        <endpoint>/metrics</endpoint>
+        <port>9363</port>
+        <metrics>true</metrics>
+        <events>true</events>
+        <asynchronous_metrics>true</asynchronous_metrics>
+      </prometheus>
+    </clickhouse>
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: clickhouse
@@ -41,6 +58,9 @@ spec:
     - name: http
       port: 8123
       targetPort: 8123
+    - name: metrics
+      port: 9363
+      targetPort: 9363
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -82,6 +102,7 @@ spec:
           ports:
             - containerPort: 9000
             - containerPort: 8123
+            - containerPort: 9363
           livenessProbe:
             httpGet:
               path: /ping
@@ -110,6 +131,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/clickhouse
+            - name: prometheus-config
+              mountPath: /etc/clickhouse-server/config.d/prometheus.xml
+              subPath: prometheus.xml
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: clickhouse-prometheus-config
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/k8s/03-clickhouse.yaml
+++ b/k8s/03-clickhouse.yaml
@@ -1,4 +1,21 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-prometheus-config
+  namespace: mcp-sentinel
+data:
+  prometheus.xml: |
+    <clickhouse>
+      <prometheus>
+        <endpoint>/metrics</endpoint>
+        <port>9363</port>
+        <metrics>true</metrics>
+        <events>true</events>
+        <asynchronous_metrics>true</asynchronous_metrics>
+      </prometheus>
+    </clickhouse>
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: clickhouse
@@ -13,6 +30,9 @@ spec:
     - name: http
       port: 8123
       targetPort: 8123
+    - name: metrics
+      port: 9363
+      targetPort: 9363
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -37,6 +57,7 @@ spec:
           ports:
             - containerPort: 9000
             - containerPort: 8123
+            - containerPort: 9363
           env:
             - name: CLICKHOUSE_DB
               valueFrom:
@@ -46,6 +67,13 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/clickhouse
+            - name: prometheus-config
+              mountPath: /etc/clickhouse-server/config.d/prometheus.xml
+              subPath: prometheus.xml
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: clickhouse-prometheus-config
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/k8s/11-prometheus.yaml
+++ b/k8s/11-prometheus.yaml
@@ -17,6 +17,9 @@ data:
       - job_name: mcp-sentinel-processor
         static_configs:
           - targets: ["mcp-sentinel-processor:9102"]
+      - job_name: clickhouse
+        static_configs:
+          - targets: ["clickhouse:9363"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/11-prometheus.yaml
+++ b/k8s/11-prometheus.yaml
@@ -16,7 +16,7 @@ data:
           - targets: ["mcp-sentinel-ingest:9091"]
       - job_name: mcp-sentinel-processor
         static_configs:
-          - targets: ["mcp-sentinel-processor:9092"]
+          - targets: ["mcp-sentinel-processor:9102"]
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/16-tempo.yaml
+++ b/k8s/16-tempo.yaml
@@ -24,7 +24,7 @@ data:
       trace:
         backend: local
         local:
-          path: /var/tempo
+          path: /var/tempo/blocks
         wal:
           path: /var/tempo/wal
 ---

--- a/k8s/19-grafana-datasources.yaml
+++ b/k8s/19-grafana-datasources.yaml
@@ -9,7 +9,7 @@ data:
     datasources:
       - name: Prometheus
         type: prometheus
-        url: http://prometheus:9090
+        url: http://prometheus:9090/prometheus
         access: proxy
         isDefault: true
       - name: Tempo

--- a/pkg/serviceutil/otel.go
+++ b/pkg/serviceutil/otel.go
@@ -9,6 +9,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
@@ -52,8 +53,52 @@ func OTLPTraceOptions(endpoint string) []otlptracehttp.Option {
 	return opts
 }
 
+// ConfigureTracePropagation enables W3C trace context and baggage propagation.
+func ConfigureTracePropagation() {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+}
+
+// CaptureTraceContext serializes the active trace context for async handoffs.
+func CaptureTraceContext(ctx context.Context) map[string]string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	if len(carrier) == 0 {
+		return nil
+	}
+	headers := make(map[string]string, len(carrier))
+	for key, value := range carrier {
+		if strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
+			continue
+		}
+		headers[key] = value
+	}
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
+}
+
+// ContextWithTraceContext extracts serialized trace context into ctx.
+func ContextWithTraceContext(ctx context.Context, headers map[string]string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if len(headers) == 0 {
+		return ctx
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(headers))
+}
+
 // InitTracer initializes OpenTelemetry tracing from OTEL_* environment variables.
 func InitTracer(serviceName string) (func(context.Context) error, error) {
+	ConfigureTracePropagation()
+
 	if envName := strings.TrimSpace(os.Getenv("OTEL_SERVICE_NAME")); envName != "" {
 		serviceName = envName
 	}

--- a/pkg/serviceutil/otel_test.go
+++ b/pkg/serviceutil/otel_test.go
@@ -1,0 +1,45 @@
+package serviceutil
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestInitTracerWithoutEndpointInstallsTracePropagator(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(previous)
+	})
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+
+	shutdown, err := InitTracer("test-service")
+	if err != nil {
+		t.Fatalf("InitTracer() error = %v", err)
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown() error = %v", err)
+	}
+
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	spanID := trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8}
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	}))
+
+	headers := CaptureTraceContext(ctx)
+	if headers["traceparent"] == "" {
+		t.Fatalf("CaptureTraceContext() missing traceparent: %#v", headers)
+	}
+	extracted := trace.SpanContextFromContext(ContextWithTraceContext(context.Background(), headers))
+	if extracted.TraceID() != traceID {
+		t.Fatalf("extracted trace ID = %s, want %s", extracted.TraceID(), traceID)
+	}
+	if !extracted.IsRemote() {
+		t.Fatal("extracted span context should be remote")
+	}
+}

--- a/services/ingest/main.go
+++ b/services/ingest/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -18,14 +19,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/segmentio/kafka-go"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"mcp-runtime/pkg/events"
 	"mcp-runtime/pkg/serviceutil"
 )
 
+type eventWriter interface {
+	WriteMessages(context.Context, ...kafka.Message) error
+}
+
 type ingestServer struct {
-	writer       *kafka.Writer
+	writer       eventWriter
 	brokers      []string
+	topic        string
 	apiKeys      map[string]struct{}
 	jwks         *keyfunc.JWKS
 	oidcIssuer   string
@@ -80,6 +89,7 @@ func main() {
 	server := &ingestServer{
 		writer:       writer,
 		brokers:      brokers,
+		topic:        topic,
 		apiKeys:      apiKeys,
 		jwks:         jwks,
 		oidcIssuer:   oidcIssuer,
@@ -215,13 +225,38 @@ func (s *ingestServer) handleEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.writer.WriteMessages(r.Context(), kafka.Message{Value: raw})
+	spanOpts := []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindProducer)}
+	if s.topic != "" {
+		spanOpts = append(spanOpts, trace.WithAttributes(attribute.String("kafka.topic", s.topic)))
+	}
+	writeCtx, span := otel.Tracer("mcp-sentinel-ingest").Start(r.Context(), "kafka.produce", spanOpts...)
+	err = s.writer.WriteMessages(writeCtx, kafkaMessageWithTraceContext(writeCtx, raw))
 	if err != nil {
+		span.RecordError(err)
+		span.End()
 		serviceutil.WriteJSON(w, http.StatusInternalServerError, map[string]string{"error": "enqueue_failed"})
 		return
 	}
+	span.End()
 
 	serviceutil.WriteJSON(w, http.StatusAccepted, map[string]any{"ok": true})
+}
+
+func kafkaMessageWithTraceContext(ctx context.Context, value []byte) kafka.Message {
+	msg := kafka.Message{Value: value}
+	headers := serviceutil.CaptureTraceContext(ctx)
+	if len(headers) == 0 {
+		return msg
+	}
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		msg.Headers = append(msg.Headers, kafka.Header{Key: key, Value: []byte(headers[key])})
+	}
+	return msg
 }
 
 // auth is middleware that enforces API key authentication.

--- a/services/ingest/main_test.go
+++ b/services/ingest/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -14,6 +15,10 @@ import (
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/segmentio/kafka-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestHandleEventsRejectsWhitespaceOnlyRequiredFields(t *testing.T) {
@@ -70,6 +75,39 @@ func TestHandleReadyWithoutKafkaReturnsServiceUnavailable(t *testing.T) {
 	}
 }
 
+func TestHandleEventsPropagatesTraceContextToKafka(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(previous)
+	})
+
+	traceID := trace.TraceID{32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17}
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{2, 4, 6, 8, 10, 12, 14, 16},
+		TraceFlags: trace.FlagsSampled,
+	}))
+
+	writer := &recordingEventWriter{}
+	server := &ingestServer{writer: writer, topic: "mcp.events"}
+	req := httptest.NewRequest(http.MethodPost, "/events", strings.NewReader(`{"source":"mcp-proxy","event_type":"mcp.request","payload":{"ok":true}}`)).WithContext(ctx)
+	recorder := httptest.NewRecorder()
+
+	server.handleEvents(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusAccepted, recorder.Body.String())
+	}
+	if len(writer.messages) != 1 {
+		t.Fatalf("written messages = %d, want 1", len(writer.messages))
+	}
+	traceparent := kafkaHeaderValue(writer.messages[0].Headers, "traceparent")
+	if !strings.Contains(traceparent, traceID.String()) {
+		t.Fatalf("traceparent = %q, want trace ID %s", traceparent, traceID)
+	}
+}
+
 func TestAuthRejectsJWKSOnlyBearerToken(t *testing.T) {
 	t.Parallel()
 
@@ -101,6 +139,24 @@ func TestAuthRejectsJWKSOnlyBearerToken(t *testing.T) {
 	if called {
 		t.Fatal("handler should not be called when issuer and audience are both unset")
 	}
+}
+
+type recordingEventWriter struct {
+	messages []kafka.Message
+}
+
+func (w *recordingEventWriter) WriteMessages(_ context.Context, messages ...kafka.Message) error {
+	w.messages = append(w.messages, messages...)
+	return nil
+}
+
+func kafkaHeaderValue(headers []kafka.Header, key string) string {
+	for _, header := range headers {
+		if strings.EqualFold(header.Key, key) {
+			return string(header.Value)
+		}
+	}
+	return ""
 }
 
 type testIngestJWTIssuer struct {

--- a/services/mcp-proxy/analytics.go
+++ b/services/mcp-proxy/analytics.go
@@ -9,7 +9,11 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+
 	"mcp-runtime/pkg/events"
+	"mcp-runtime/pkg/serviceutil"
 )
 
 func (s *proxyServer) startAnalyticsDispatcher() {
@@ -23,7 +27,7 @@ func (s *proxyServer) startAnalyticsDispatcher() {
 			return
 		}
 		if s.analyticsQueue == nil {
-			s.analyticsQueue = make(chan events.Envelope, analyticsQueueSize)
+			s.analyticsQueue = make(chan analyticsEvent, analyticsQueueSize)
 		}
 		queue := s.analyticsQueue
 		s.analyticsWG.Add(analyticsWorkerCount)
@@ -32,8 +36,9 @@ func (s *proxyServer) startAnalyticsDispatcher() {
 			go func() {
 				defer s.analyticsWG.Done()
 				for event := range queue {
-					ctx, cancel := context.WithTimeout(context.Background(), time.Duration(analyticsEmitTimeout)*time.Second)
-					s.emit(ctx, event)
+					parentCtx := serviceutil.ContextWithTraceContext(context.Background(), event.TraceContext)
+					ctx, cancel := context.WithTimeout(parentCtx, time.Duration(analyticsEmitTimeout)*time.Second)
+					s.emit(ctx, event.Envelope)
 					cancel()
 				}
 			}()
@@ -58,7 +63,7 @@ func (s *proxyServer) stopAnalyticsDispatcher() {
 	s.analyticsWG.Wait()
 }
 
-func (s *proxyServer) emitIfEnabled(event events.Envelope) {
+func (s *proxyServer) emitIfEnabled(ctx context.Context, event events.Envelope) {
 	if s.analyticsURL == "" {
 		return
 	}
@@ -71,13 +76,17 @@ func (s *proxyServer) emitIfEnabled(event events.Envelope) {
 	if s.analyticsClosed {
 		return
 	}
+	item := analyticsEvent{
+		Envelope:     event,
+		TraceContext: serviceutil.CaptureTraceContext(ctx),
+	}
 	select {
-	case queue <- event:
+	case queue <- item:
 	default:
 	}
 }
 
-func (s *proxyServer) analyticsEventQueue() chan events.Envelope {
+func (s *proxyServer) analyticsEventQueue() chan analyticsEvent {
 	s.analyticsMu.Lock()
 	queue := s.analyticsQueue
 	s.analyticsMu.Unlock()
@@ -111,6 +120,7 @@ func (s *proxyServer) emit(ctx context.Context, event events.Envelope) {
 	if s.apiKey != "" {
 		req.Header.Set("x-api-key", s.apiKey)
 	}
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/services/mcp-proxy/main_test.go
+++ b/services/mcp-proxy/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -17,6 +18,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
 	"mcp-runtime/pkg/events"
 	policypkg "mcp-runtime/pkg/policy"
@@ -401,13 +405,13 @@ func TestEmitIfEnabledDropsWhenQueueIsFull(t *testing.T) {
 
 	proxy := &proxyServer{
 		analyticsURL:   "http://analytics.example.com",
-		analyticsQueue: make(chan events.Envelope, 1),
+		analyticsQueue: make(chan analyticsEvent, 1),
 	}
-	proxy.analyticsQueue <- events.Envelope{Source: "existing"}
+	proxy.analyticsQueue <- analyticsEvent{Envelope: events.Envelope{Source: "existing"}}
 
 	done := make(chan struct{})
 	go func() {
-		proxy.emitIfEnabled(events.Envelope{Source: "dropped"})
+		proxy.emitIfEnabled(context.Background(), events.Envelope{Source: "dropped"})
 		close(done)
 	}()
 
@@ -419,7 +423,7 @@ func TestEmitIfEnabledDropsWhenQueueIsFull(t *testing.T) {
 
 	select {
 	case event := <-proxy.analyticsQueue:
-		if event.Source != "existing" {
+		if event.Envelope.Source != "existing" {
 			t.Fatalf("analytics queue head = %#v, want existing event to remain", event)
 		}
 	default:
@@ -444,13 +448,52 @@ func TestStopAnalyticsDispatcherDrainsQueue(t *testing.T) {
 	}
 	proxy.startAnalyticsDispatcher()
 	for i := 0; i < 3; i++ {
-		proxy.emitIfEnabled(events.Envelope{Source: "proxy", EventType: "mcp.request"})
+		proxy.emitIfEnabled(context.Background(), events.Envelope{Source: "proxy", EventType: "mcp.request"})
 	}
 
 	proxy.stopAnalyticsDispatcher()
 
 	if got := atomic.LoadInt32(&received); got != 3 {
 		t.Fatalf("received analytics events = %d, want 3", got)
+	}
+}
+
+func TestAnalyticsDispatcherPropagatesTraceContext(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(previous)
+	})
+
+	traceparents := make(chan string, 1)
+	ingest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		traceparents <- r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(ingest.Close)
+
+	traceID := trace.TraceID{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     trace.SpanID{1, 3, 5, 7, 9, 11, 13, 15},
+		TraceFlags: trace.FlagsSampled,
+	}))
+	proxy := &proxyServer{
+		analyticsURL: ingest.URL,
+		httpClient:   ingest.Client(),
+	}
+	proxy.startAnalyticsDispatcher()
+	proxy.emitIfEnabled(ctx, events.Envelope{Source: "proxy", EventType: "mcp.request"})
+	proxy.stopAnalyticsDispatcher()
+
+	select {
+	case traceparent := <-traceparents:
+		if !strings.Contains(traceparent, traceID.String()) {
+			t.Fatalf("traceparent = %q, want trace ID %s", traceparent, traceID)
+		}
+	default:
+		t.Fatal("ingest did not receive analytics request")
 	}
 }
 

--- a/services/mcp-proxy/proxy.go
+++ b/services/mcp-proxy/proxy.go
@@ -158,7 +158,7 @@ func (s *proxyServer) emitAuditEvent(
 	if err != nil {
 		return
 	}
-	s.emitIfEnabled(envelope)
+	s.emitIfEnabled(r.Context(), envelope)
 }
 
 func (s *proxyServer) auditPayload(

--- a/services/mcp-proxy/types.go
+++ b/services/mcp-proxy/types.go
@@ -49,13 +49,18 @@ type oauthAuthResult struct {
 	Token    string
 }
 
+type analyticsEvent struct {
+	Envelope     events.Envelope
+	TraceContext map[string]string
+}
+
 type proxyServer struct {
 	proxy                 *httputil.ReverseProxy
 	analyticsURL          string
 	apiKey                string
 	source                string
 	eventType             string
-	analyticsQueue        chan events.Envelope
+	analyticsQueue        chan analyticsEvent
 	stripPrefix           string
 	externalBaseURL       *url.URL
 	httpClient            *http.Client

--- a/services/processor/main.go
+++ b/services/processor/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/segmentio/kafka-go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	clickhousepkg "mcp-runtime/pkg/clickhouse"
 	"mcp-runtime/pkg/events"
@@ -124,18 +125,21 @@ func main() {
 
 	batch := make([]events.Envelope, 0, batchSize)
 	batchMessages := make([]kafka.Message, 0, batchSize)
+	batchSpanContexts := make([]trace.SpanContext, 0, batchSize)
 	pausedForFlush := false
 
 	flush := func() {
 		if len(batch) == 0 {
 			return
 		}
-		flushCtx, span := tracer.Start(ctx, "clickhouse.insert_batch")
-		span.SetAttributes(attribute.Int("batch.size", len(batch)))
+		eventSpans := startClickHouseEventSpans(tracer, ctx, batchSpanContexts, len(batch))
+		flushCtx, spanOpts := clickhouseFlushTraceContext(ctx, batchSpanContexts, len(batch))
+		flushCtx, span := tracer.Start(flushCtx, "clickhouse.insert_batch", spanOpts...)
 		if err := clickhouseClient.InsertEvents(flushCtx, batch); err != nil {
 			log.Printf("insert failed: %v", err)
 			span.RecordError(err)
 			span.End()
+			endClickHouseEventSpans(eventSpans, err)
 			return
 		}
 		if err := reader.CommitMessages(ctx, batchMessages...); err != nil {
@@ -143,8 +147,10 @@ func main() {
 			span.RecordError(err)
 		}
 		span.End()
+		endClickHouseEventSpans(eventSpans, nil)
 		batch = batch[:0]
 		batchMessages = batchMessages[:0]
+		batchSpanContexts = batchSpanContexts[:0]
 	}
 
 	msgChan := make(chan kafka.Message, 100)
@@ -190,11 +196,14 @@ func main() {
 			flush()
 			return
 		case msg := <-messageInput:
-			_, span := tracer.Start(ctx, "kafka.consume")
-			span.SetAttributes(
-				attribute.String("kafka.topic", msg.Topic),
-				attribute.Int("kafka.partition", msg.Partition),
-				attribute.Int64("kafka.offset", msg.Offset),
+			consumeCtx := contextFromKafkaTraceHeaders(ctx, msg.Headers)
+			consumeCtx, span := tracer.Start(consumeCtx, "kafka.consume",
+				trace.WithSpanKind(trace.SpanKindConsumer),
+				trace.WithAttributes(
+					attribute.String("kafka.topic", msg.Topic),
+					attribute.Int("kafka.partition", msg.Partition),
+					attribute.Int64("kafka.offset", msg.Offset),
+				),
 			)
 
 			var payload events.Envelope
@@ -212,11 +221,78 @@ func main() {
 
 			batch = append(batch, payload)
 			batchMessages = append(batchMessages, msg)
+			batchSpanContexts = append(batchSpanContexts, trace.SpanContextFromContext(consumeCtx))
 			span.End()
 			if len(batch) >= batchSize {
 				flush()
 			}
 		}
+	}
+}
+
+func contextFromKafkaTraceHeaders(parent context.Context, headers []kafka.Header) context.Context {
+	if len(headers) == 0 {
+		return parent
+	}
+	carrier := make(map[string]string, len(headers))
+	for _, header := range headers {
+		key := strings.ToLower(strings.TrimSpace(header.Key))
+		if key == "" || len(header.Value) == 0 {
+			continue
+		}
+		carrier[key] = string(header.Value)
+	}
+	return serviceutil.ContextWithTraceContext(parent, carrier)
+}
+
+func clickhouseFlushTraceContext(parent context.Context, spanContexts []trace.SpanContext, batchSize int) (context.Context, []trace.SpanStartOption) {
+	opts := []trace.SpanStartOption{
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.Int("batch.size", batchSize)),
+	}
+	validSpanContexts := make([]trace.SpanContext, 0, len(spanContexts))
+	for _, spanContext := range spanContexts {
+		if spanContext.IsValid() {
+			validSpanContexts = append(validSpanContexts, spanContext)
+		}
+	}
+	if len(validSpanContexts) == 0 {
+		return parent, opts
+	}
+	parent = trace.ContextWithSpanContext(parent, validSpanContexts[0])
+	if len(validSpanContexts) == 1 {
+		return parent, opts
+	}
+	links := make([]trace.Link, 0, len(validSpanContexts)-1)
+	for _, spanContext := range validSpanContexts[1:] {
+		links = append(links, trace.Link{SpanContext: spanContext})
+	}
+	return parent, append(opts, trace.WithLinks(links...))
+}
+
+func startClickHouseEventSpans(tracer trace.Tracer, parent context.Context, spanContexts []trace.SpanContext, batchSize int) []trace.Span {
+	spans := make([]trace.Span, 0, len(spanContexts))
+	for _, spanContext := range spanContexts {
+		if !spanContext.IsValid() {
+			continue
+		}
+		_, span := tracer.Start(
+			trace.ContextWithSpanContext(parent, spanContext),
+			"clickhouse.insert_event",
+			trace.WithSpanKind(trace.SpanKindClient),
+			trace.WithAttributes(attribute.Int("batch.size", batchSize)),
+		)
+		spans = append(spans, span)
+	}
+	return spans
+}
+
+func endClickHouseEventSpans(spans []trace.Span, err error) {
+	for _, span := range spans {
+		if err != nil {
+			span.RecordError(err)
+		}
+		span.End()
 	}
 }
 

--- a/services/processor/main_test.go
+++ b/services/processor/main_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/segmentio/kafka-go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestMessageInputForBatchPausesAtConfiguredLimit(t *testing.T) {
@@ -17,5 +21,32 @@ func TestMessageInputForBatchPausesAtConfiguredLimit(t *testing.T) {
 	}
 	if got := messageInputForBatch(3, 2, input); got != nil {
 		t.Fatal("messageInputForBatch() did not pause above batch limit")
+	}
+}
+
+func TestContextFromKafkaTraceHeadersExtractsTraceparent(t *testing.T) {
+	previous := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		otel.SetTextMapPropagator(previous)
+	})
+
+	traceID := trace.TraceID{48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33}
+	parentSpanID := trace.SpanID{3, 6, 9, 12, 15, 18, 21, 24}
+	traceparent := "00-" + traceID.String() + "-" + parentSpanID.String() + "-01"
+
+	ctx := contextFromKafkaTraceHeaders(context.Background(), []kafka.Header{
+		{Key: "TraceParent", Value: []byte(traceparent)},
+	})
+	spanContext := trace.SpanContextFromContext(ctx)
+
+	if spanContext.TraceID() != traceID {
+		t.Fatalf("trace ID = %s, want %s", spanContext.TraceID(), traceID)
+	}
+	if spanContext.SpanID() != parentSpanID {
+		t.Fatalf("span ID = %s, want %s", spanContext.SpanID(), parentSpanID)
+	}
+	if !spanContext.IsRemote() {
+		t.Fatal("span context should be remote")
 	}
 }

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -34,6 +34,25 @@ func TestConfigDoesNotExposeAPIKey(t *testing.T) {
 	}
 }
 
+func TestConfigExposesPlatformMode(t *testing.T) {
+	t.Setenv("PLATFORM_MODE", "org")
+	mux, err := newMux("/api", "http://127.0.0.1:1", "secret", "api-secret")
+	if err != nil {
+		t.Fatalf("newMux() error = %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/config.js", nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, `window.MCP_PLATFORM_MODE = "org"`) {
+		t.Fatalf("config.js missing platform mode: %q", body)
+	}
+}
+
 func TestAPIProxyRequiresAuthenticatedSession(t *testing.T) {
 	upstreamCalled := false
 	store := newUISessionStore(time.Now)

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -4649,6 +4649,13 @@ print("-" * (width + 8))
 for key, value in rows:
     print(f"{key:{width}}  {value}")
 PY
+
+  tempo_log_errors="$(kubectl logs -n mcp-sentinel statefulset/tempo --since=20m 2>/dev/null | grep -E 'failed to poll or create index for tenant.*tenant=wal|invalid UUID length' || true)"
+  if [[ -n "${tempo_log_errors}" ]]; then
+    log_line error "tempo logged WAL blocklist parse errors; local block storage must not share the WAL parent path"
+    printf '%s\n' "${tempo_log_errors}" | tail -n 20 >&2
+    exit 1
+  fi
 fi
 
 if scenario_selected "multitenancy"; then

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -163,6 +163,7 @@ LOCAL_REGISTRY_PUSH_HOST="${LOCAL_REGISTRY_PUSH_HOST:-127.0.0.1:${LOCAL_REGISTRY
 LOCAL_REGISTRY_MIRROR_ENDPOINT="${LOCAL_REGISTRY_NAME}:5000"
 LOCAL_REGISTRY_RETRY_TRIES="${LOCAL_REGISTRY_RETRY_TRIES:-5}"
 LOCAL_REGISTRY_RETRY_DELAY="${LOCAL_REGISTRY_RETRY_DELAY:-5}"
+E2E_WORKLOAD_TAG="${E2E_WORKLOAD_TAG:-e2e}"
 E2E_ARTIFACT_DIR="${E2E_ARTIFACT_DIR:-}"
 E2E_SCENARIOS="${E2E_SCENARIOS-all}"
 E2E_SCENARIOS="${E2E_SCENARIOS//[[:space:]]/}"
@@ -1738,34 +1739,25 @@ deploy_example_server_via_pipeline() {
   mkdir -p "$(dirname "${example_workspace_dir}")"
   cp -R "${example_source_dir}" "${example_workspace_dir}"
 
-  image_repo="docker.io/library/${server_name}"
-  image_ref="${image_repo}:latest"
+  image_repo="registry.registry.svc.cluster.local:5000/${server_name}"
+  image_ref="${image_repo}:${E2E_WORKLOAD_TAG}"
   prepare_example_metadata "${example_workspace_dir}/.mcp" "${server_name}" "${ingress_host}" "${route_path}" "${image_repo}"
 
-  if pull_cached_image "${image_ref}"; then
-    echo "[cache] skipping example image build/push for ${server_name}:latest"
+  if cache_mode_enabled && docker image inspect "${image_ref}" >/dev/null 2>&1; then
+    echo "[cache] skipping example image build for ${image_ref}"
   else
-    echo "[deploy] building example image ${server_name}:latest"
+    echo "[deploy] building example image ${image_ref}"
     (
       cd "${example_workspace_dir}"
       "${PROJECT_ROOT}/bin/mcp-runtime" server build image "${server_name}" \
         --metadata-dir .mcp \
         --dockerfile Dockerfile \
-        --registry "docker.io/library" \
-        --tag latest \
+        --registry "registry.registry.svc.cluster.local:5000" \
+        --tag "${E2E_WORKLOAD_TAG}" \
         --context .
     )
-
-    echo "[deploy] pushing ${server_name}:latest via registry CLI"
-    (
-      cd "${example_workspace_dir}"
-      "${PROJECT_ROOT}/bin/mcp-runtime" registry push \
-        --image "${image_ref}" \
-        --mode direct \
-        --registry "${LOCAL_REGISTRY_PUSH_HOST}" \
-        --name "library/${server_name}"
-    )
   fi
+  load_image_into_kind "${image_ref}"
 
   (
     cd "${example_workspace_dir}"
@@ -1856,6 +1848,12 @@ cache_mode_enabled() {
 
 kind_cluster_exists() {
   kind get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}"
+}
+
+load_image_into_kind() {
+  local image="$1"
+  echo "[kind] loading ${image} into kind cluster ${CLUSTER_NAME}"
+  kind load docker-image --name "${CLUSTER_NAME}" "${image}"
 }
 
 registry_target_exists() {
@@ -2076,6 +2074,7 @@ export MCP_SETUP_WAIT_TIMEOUT="${MCP_SETUP_WAIT_TIMEOUT:-900}"
 export MCP_DEPLOYMENT_TIMEOUT="${MCP_DEPLOYMENT_TIMEOUT:-900s}"
 export MCP_REGISTRY_ENDPOINT="${MCP_REGISTRY_ENDPOINT:-registry.registry.svc.cluster.local:5000}"
 export MCP_INGRESS_READINESS_MODE="${MCP_INGRESS_READINESS_MODE:-permissive}"
+export MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT="${MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector.mcp-sentinel.svc.cluster.local:4318}"
 if [[ "${PLATFORM_CACHE_READY}" == "1" ]]; then
   echo "[setup] skipping platform setup because E2E_CACHE_MODE=1 found a ready platform"
 else
@@ -2142,6 +2141,10 @@ if cache_mode_enabled; then
   kubectl delete pod -n mcp-servers -l "app=${MT_TENANT_B}" --ignore-not-found --wait=false >/dev/null
   echo "[cache] deleting stale pending mcp-servers pods before cluster doctor"
   kubectl delete pod -n mcp-servers --field-selector=status.phase=Pending --ignore-not-found --wait=false >/dev/null
+  echo "[cache] refreshing operator e2e environment before cluster doctor"
+  kubectl set env deploy/mcp-runtime-operator-controller-manager -n mcp-runtime \
+    "MCP_INGRESS_READINESS_MODE=${MCP_INGRESS_READINESS_MODE}" \
+    "MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT=${MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT}" >/dev/null
   echo "[cache] restarting operator before cluster doctor to avoid stale retained reconcile logs"
   kubectl rollout restart deploy/mcp-runtime-operator-controller-manager -n mcp-runtime >/dev/null
   rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
@@ -2188,10 +2191,20 @@ if [[ -z "${INGEST_API_KEY}" ]]; then
   echo "[error] failed to resolve mcp-sentinel ingest API key from secret" >&2
   exit 1
 fi
+GRAFANA_ADMIN_USER=""
+GRAFANA_ADMIN_PASSWORD=""
+if scenario_selected "observability"; then
+  GRAFANA_ADMIN_USER="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.GRAFANA_ADMIN_USER}' | decode_base64)"
+  GRAFANA_ADMIN_PASSWORD="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.GRAFANA_ADMIN_PASSWORD}' | decode_base64)"
+  if [[ -z "${GRAFANA_ADMIN_USER}" || -z "${GRAFANA_ADMIN_PASSWORD}" ]]; then
+    echo "[error] failed to resolve Grafana admin credentials from mcp-sentinel-secrets" >&2
+    exit 1
+  fi
+fi
 
 METADATA_FILE="${WORKDIR}/metadata.yaml"
 MANIFEST_DIR="${WORKDIR}/manifests"
-SERVER_IMAGE="docker.io/library/${SERVER_NAME}:latest"
+SERVER_IMAGE="registry.registry.svc.cluster.local:5000/${SERVER_NAME}:${E2E_WORKLOAD_TAG}"
 SERVER_SECRET_NAME="${SERVER_NAME}-analytics-creds"
 PYTHON_EXAMPLE_SOURCE_DIR="${PROJECT_ROOT}/examples/python-mcp-server"
 PYTHON_EXAMPLE_WORKDIR="${WORKDIR}/python-mcp-server"
@@ -2266,19 +2279,18 @@ servers:
         key: api-key
 EOF
 
-if pull_cached_image "${SERVER_IMAGE}"; then
-  echo "[cache] skipping MCP server image build/push for ${SERVER_IMAGE}"
+if cache_mode_enabled && docker image inspect "${SERVER_IMAGE}" >/dev/null 2>&1; then
+  echo "[cache] skipping MCP server image build for ${SERVER_IMAGE}"
 else
   echo "[cli] building MCP server image via CLI"
   ./bin/mcp-runtime server build image "${SERVER_NAME}" \
     --metadata-file "${METADATA_FILE}" \
     --dockerfile "${GO_EXAMPLE_SOURCE_DIR}/Dockerfile" \
-    --registry docker.io/library \
-    --tag latest \
+    --registry registry.registry.svc.cluster.local:5000 \
+    --tag "${E2E_WORKLOAD_TAG}" \
     --context "${GO_EXAMPLE_SOURCE_DIR}"
-
-  publish_image_to_local_registry "${SERVER_IMAGE}"
 fi
+load_image_into_kind "${SERVER_IMAGE}"
 
 echo "[cli] generating and deploying MCPServer manifests"
 ./bin/mcp-runtime pipeline generate --file "${METADATA_FILE}" --output "${MANIFEST_DIR}"
@@ -4002,8 +4014,13 @@ PY
   OAUTH_AGENT_ID="${OAUTH_AGENT_ID}" \
   SENTINEL_BASE="http://127.0.0.1:${SENTINEL_PORT}" \
   TEMPO_BASE="http://127.0.0.1:${TEMPO_PORT}" \
+  GRAFANA_BASE="http://127.0.0.1:${SENTINEL_PORT}/grafana" \
+  PROMETHEUS_BASE="http://127.0.0.1:${SENTINEL_PORT}/prometheus" \
+  GRAFANA_ADMIN_USER="${GRAFANA_ADMIN_USER}" \
+  GRAFANA_ADMIN_PASSWORD="${GRAFANA_ADMIN_PASSWORD}" \
   LOKI_BASE="http://127.0.0.1:${LOKI_PORT}" \
   python3 <<'PY'
+import base64
 import json
 import os
 import time
@@ -4018,8 +4035,13 @@ oauth_server_name = os.environ["OAUTH_SERVER_NAME"]
 oauth_human_id = os.environ["OAUTH_HUMAN_ID"]
 oauth_agent_id = os.environ["OAUTH_AGENT_ID"]
 tempo_base = os.environ["TEMPO_BASE"]
+grafana_base = os.environ["GRAFANA_BASE"]
+prometheus_base = os.environ["PROMETHEUS_BASE"]
+grafana_user = os.environ["GRAFANA_ADMIN_USER"]
+grafana_password = os.environ["GRAFANA_ADMIN_PASSWORD"]
 loki_base = os.environ["LOKI_BASE"]
 sentinel_base = os.environ["SENTINEL_BASE"]
+gateway_trace_services = (f"{server_name}-gateway", f"{oauth_server_name}-gateway")
 
 
 import os as _os; exec(open(_os.environ["E2E_HELPERS"]).read())
@@ -4061,9 +4083,101 @@ def post_json(url, body, headers):
     with urllib.request.urlopen(req, timeout=10) as resp:
         return resp.getcode(), resp.read().decode()
 
+def basic_auth_headers(user, password):
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
 def payload_dict(event):
     payload = event.get("payload", {})
     return payload if isinstance(payload, dict) else {}
+
+def otlp_attr_value(attrs, key):
+    for attr in attrs or []:
+        if attr.get("key") != key:
+            continue
+        value = attr.get("value", {})
+        for field in ("stringValue", "intValue", "doubleValue", "boolValue"):
+            if field in value:
+                return str(value[field])
+    return ""
+
+def trace_service_names(trace_doc):
+    names = set()
+    for batch in trace_doc.get("batches", []):
+        name = otlp_attr_value(batch.get("resource", {}).get("attributes", []), "service.name")
+        if name:
+            names.add(name)
+    for trace in trace_doc.get("data", []):
+        for process in trace.get("processes", {}).values():
+            name = process.get("serviceName")
+            if name:
+                names.add(name)
+    return names
+
+def datasource_uid(datasources, ds_type):
+    for datasource in datasources:
+        if datasource.get("type") == ds_type:
+            uid = datasource.get("uid")
+            if uid:
+                return uid
+    fail(f"Grafana datasource of type {ds_type!r} not found: {datasources}")
+
+def wait_for_tempo_service(base_url, service_name, *, headers=None, description):
+    tag = urllib.parse.quote(f"service.name={service_name}")
+    doc = wait_for_json(
+        f"{base_url}/api/search?limit=20&tags={tag}",
+        lambda payload: bool(payload.get("traces", [])),
+        headers=headers,
+        retries=90,
+        delay=2,
+        description=description,
+    )
+    traces_for_service = doc.get("traces", [])
+    trace_id = traces_for_service[0].get("traceID") if traces_for_service else ""
+    check(
+        bool(trace_id),
+        f"{description} returned a trace id",
+        f"{description} missing trace id: {doc}",
+    )
+    trace_doc = wait_for_json(
+        f"{base_url}/api/traces/{urllib.parse.quote(trace_id)}",
+        lambda payload: service_name in trace_service_names(payload),
+        headers=headers,
+        retries=30,
+        delay=2,
+        description=f"{description} payload",
+    )
+    names = trace_service_names(trace_doc)
+    check(
+        service_name in names,
+        f"{description} payload includes service.name={service_name}",
+        f"{description} payload missing {service_name}; services={names}",
+    )
+    return len(traces_for_service), names
+
+def wait_for_prometheus_up(base_url, *, headers=None, description):
+    doc = wait_for_json(
+        f"{base_url}/api/v1/query?query={urllib.parse.quote('up')}",
+        lambda payload: payload.get("status") == "success"
+        and bool(payload.get("data", {}).get("result", [])),
+        headers=headers,
+        retries=60,
+        delay=2,
+        description=description,
+    )
+    jobs = {}
+    for result in doc.get("data", {}).get("result", []):
+        metric = result.get("metric", {})
+        value = result.get("value", [])
+        if len(value) >= 2 and metric.get("job"):
+            jobs[metric["job"]] = str(value[1])
+    for job in ("mcp-sentinel-api", "mcp-sentinel-ingest"):
+        check(
+            jobs.get(job) == "1",
+            f"{description} reports {job}=1",
+            f"{description} missing healthy {job}: {jobs}",
+        )
+    return jobs
 
 
 expected_gateway_rpc_methods = (
@@ -4410,6 +4524,54 @@ tempo = wait_for_json(
 )
 traces = tempo.get("traces", [])
 
+tempo_gateway_counts = {}
+tempo_gateway_services = set()
+for service_name in gateway_trace_services:
+    count, names = wait_for_tempo_service(
+        tempo_base,
+        service_name,
+        description=f"tempo traces for {service_name}",
+    )
+    tempo_gateway_counts[service_name] = count
+    tempo_gateway_services.update(names)
+
+grafana_headers = basic_auth_headers(grafana_user, grafana_password)
+grafana_datasources = wait_for_json(
+    f"{grafana_base}/api/datasources",
+    lambda doc: isinstance(doc, list)
+    and any(item.get("type") == "tempo" for item in doc)
+    and any(item.get("type") == "prometheus" for item in doc),
+    headers=grafana_headers,
+    retries=60,
+    delay=2,
+    description="grafana datasources",
+)
+tempo_uid = datasource_uid(grafana_datasources, "tempo")
+prometheus_uid = datasource_uid(grafana_datasources, "prometheus")
+
+grafana_gateway_counts = {}
+grafana_gateway_services = set()
+grafana_tempo_base = f"{grafana_base}/api/datasources/proxy/uid/{tempo_uid}"
+for service_name in gateway_trace_services:
+    count, names = wait_for_tempo_service(
+        grafana_tempo_base,
+        service_name,
+        headers=grafana_headers,
+        description=f"grafana tempo traces for {service_name}",
+    )
+    grafana_gateway_counts[service_name] = count
+    grafana_gateway_services.update(names)
+
+prometheus_jobs = wait_for_prometheus_up(
+    prometheus_base,
+    description="prometheus up query",
+)
+grafana_prometheus_jobs = wait_for_prometheus_up(
+    f"{grafana_base}/api/datasources/proxy/uid/{prometheus_uid}/prometheus",
+    headers=grafana_headers,
+    description="grafana prometheus up query",
+)
+
 end_ns = int(time.time() * 1e9)
 start_ns = end_ns - int(10 * 60 * 1e9)
 params = urllib.parse.urlencode(
@@ -4447,6 +4609,13 @@ rows = [
     ("analytics.type.pii.check", str(event_type_counts.get("pii.check", 0))),
     ("analytics.type.service.route.check", str(event_type_counts.get("service.route.check", 0))),
     ("traces.tempo_found", str(len(traces))),
+    ("traces.tempo_gateway", ",".join(f"{k}:{v}" for k, v in sorted(tempo_gateway_counts.items()))),
+    ("traces.tempo_services", ",".join(sorted(tempo_gateway_services))),
+    ("traces.grafana_gateway", ",".join(f"{k}:{v}" for k, v in sorted(grafana_gateway_counts.items()))),
+    ("traces.grafana_services", ",".join(sorted(grafana_gateway_services))),
+    ("grafana.datasources", str(len(grafana_datasources))),
+    ("prometheus.jobs", ",".join(f"{k}:{v}" for k, v in sorted(prometheus_jobs.items()))),
+    ("grafana.prometheus.jobs", ",".join(f"{k}:{v}" for k, v in sorted(grafana_prometheus_jobs.items()))),
     ("logs.loki_streams", str(len(streams))),
 ]
 width = max(len(k) for k, _ in rows)

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -1597,11 +1597,13 @@ prepare_example_metadata() {
   local ingress_host="$3"
   local route_path="$4"
   local image_repo="$5"
+  local image_tag="$6"
 
   SERVER_NAME_OVERRIDE="${server_name}" \
   SERVER_HOST_OVERRIDE="${ingress_host}" \
   SERVER_ROUTE_OVERRIDE="${route_path}" \
   SERVER_IMAGE_OVERRIDE="${image_repo}" \
+  SERVER_IMAGE_TAG_OVERRIDE="${image_tag}" \
   METADATA_DIR_OVERRIDE="${metadata_dir}" \
   python3 <<'PY'
 from pathlib import Path
@@ -1613,11 +1615,13 @@ lines = path.read_text(encoding="utf-8").splitlines()
 updated = []
 server_name_updated = False
 server_image_updated = False
+server_image_tag_updated = False
 mcp_path_updated = False
 public_path_prefix_updated = False
 in_env_vars = False
 current_env_name = None
 resources_present = any(line.startswith("    resources:") for line in lines)
+image_tag_present = any(line.lstrip().startswith("imageTag: ") for line in lines)
 
 route_override = os.environ["SERVER_ROUTE_OVERRIDE"].strip()
 route_prefix = route_override.strip("/")
@@ -1642,6 +1646,12 @@ for line in lines:
     elif not server_image_updated and indent == "    " and stripped.startswith("image: "):
         updated.append(f"{indent}image: {os.environ['SERVER_IMAGE_OVERRIDE']}")
         server_image_updated = True
+        if not image_tag_present:
+            updated.append(f"{indent}imageTag: {os.environ['SERVER_IMAGE_TAG_OVERRIDE']}")
+            server_image_tag_updated = True
+    elif indent == "    " and stripped.startswith("imageTag: "):
+        updated.append(f"{indent}imageTag: {os.environ['SERVER_IMAGE_TAG_OVERRIDE']}")
+        server_image_tag_updated = True
     elif indent == "    " and stripped == "envVars:":
         in_env_vars = True
         current_env_name = None
@@ -1666,9 +1676,11 @@ if not server_image_updated:
         indent = line[: len(line) - len(stripped)]
         if not inserted and indent == "  " and stripped.startswith("- name: "):
             final.append(f"{indent}  image: {os.environ['SERVER_IMAGE_OVERRIDE']}")
+            final.append(f"{indent}  imageTag: {os.environ['SERVER_IMAGE_TAG_OVERRIDE']}")
             inserted = True
     updated = final
     server_image_updated = inserted
+    server_image_tag_updated = inserted
 if not mcp_path_updated:
     final = []
     inserted = False
@@ -1717,6 +1729,8 @@ if not server_name_updated:
     raise SystemExit(f"prepare_example_metadata: no '- name:' entry found to replace in {path}")
 if not server_image_updated:
     raise SystemExit(f"prepare_example_metadata: image field was not updated in {path}")
+if not server_image_tag_updated:
+    raise SystemExit(f"prepare_example_metadata: imageTag field was not updated in {path}")
 if not mcp_path_updated:
     raise SystemExit(f"prepare_example_metadata: MCP_PATH env var was not updated in {path}")
 if not public_path_prefix_updated:
@@ -1741,7 +1755,7 @@ deploy_example_server_via_pipeline() {
 
   image_repo="registry.registry.svc.cluster.local:5000/${server_name}"
   image_ref="${image_repo}:${E2E_WORKLOAD_TAG}"
-  prepare_example_metadata "${example_workspace_dir}/.mcp" "${server_name}" "${ingress_host}" "${route_path}" "${image_repo}"
+  prepare_example_metadata "${example_workspace_dir}/.mcp" "${server_name}" "${ingress_host}" "${route_path}" "${image_repo}" "${E2E_WORKLOAD_TAG}"
 
   if cache_mode_enabled && docker image inspect "${image_ref}" >/dev/null 2>&1; then
     echo "[cache] skipping example image build for ${image_ref}"
@@ -4178,7 +4192,7 @@ def wait_for_prometheus_up(base_url, *, headers=None, description):
         value = result.get("value", [])
         if len(value) >= 2 and metric.get("job"):
             jobs[metric["job"]] = str(value[1])
-    for job in ("mcp-sentinel-api", "mcp-sentinel-ingest", "mcp-sentinel-processor"):
+    for job in ("mcp-sentinel-api", "mcp-sentinel-ingest", "mcp-sentinel-processor", "clickhouse"):
         check(
             jobs.get(job) == "1",
             f"{description} reports {job}=1",

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -4115,15 +4115,39 @@ def otlp_attr_value(attrs, key):
                 return str(value[field])
     return ""
 
+def trace_resource_batches(trace_doc):
+    batches = []
+    batches.extend(trace_doc.get("batches", []) or [])
+    batches.extend(trace_doc.get("resourceSpans", []) or [])
+    return batches
+
 def trace_service_names(trace_doc):
     names = set()
-    for batch in trace_doc.get("batches", []):
+    for batch in trace_resource_batches(trace_doc):
         name = otlp_attr_value(batch.get("resource", {}).get("attributes", []), "service.name")
         if name:
             names.add(name)
     for trace in trace_doc.get("data", []):
         for process in trace.get("processes", {}).values():
             name = process.get("serviceName")
+            if name:
+                names.add(name)
+    return names
+
+def trace_span_names(trace_doc):
+    names = set()
+    for batch in trace_resource_batches(trace_doc):
+        scope_spans = []
+        scope_spans.extend(batch.get("scopeSpans", []) or [])
+        scope_spans.extend(batch.get("instrumentationLibrarySpans", []) or [])
+        for scope_span in scope_spans:
+            for span in scope_span.get("spans", []) or []:
+                name = span.get("name")
+                if name:
+                    names.add(name)
+    for trace in trace_doc.get("data", []):
+        for span in trace.get("spans", []) or []:
+            name = span.get("operationName") or span.get("name")
             if name:
                 names.add(name)
     return names
@@ -4175,6 +4199,45 @@ def wait_for_tempo_service(base_url, service_name, *, headers=None, description)
         f"{description} payload missing {service_name}; services={names}",
     )
     return len(traces_for_service), names
+
+def wait_for_tempo_trace_path(base_url, gateway_service, required_services, required_spans, *, headers=None, description):
+    end = int(time.time())
+    start = end - 3600
+    tag = urllib.parse.quote(f"service.name={gateway_service}")
+    search_url = f"{base_url}/api/search?limit=100&start={start}&end={end}&tags={tag}"
+    last_summary = {}
+    last_error = None
+    for _ in range(90):
+        try:
+            search_doc = get_json(search_url, headers=headers, retries=1, delay=2)
+            for item in search_doc.get("traces", []) or []:
+                trace_id = item.get("traceID")
+                if not trace_id:
+                    continue
+                trace_doc = get_json(
+                    f"{base_url}/api/traces/{urllib.parse.quote(trace_id)}",
+                    headers=headers,
+                    retries=1,
+                    delay=2,
+                )
+                services = trace_service_names(trace_doc)
+                spans = trace_span_names(trace_doc)
+                last_summary = {
+                    "trace_id": trace_id,
+                    "services": sorted(services),
+                    "spans": sorted(spans),
+                }
+                if required_services <= services and required_spans <= spans:
+                    ok(f"waited for {description}")
+                    return trace_id, services, spans
+        except Exception as exc:
+            last_error = exc
+        time.sleep(2)
+    if last_summary:
+        fail(f"timed out waiting for {description}: {json.dumps(last_summary, indent=2)}")
+    if last_error is not None:
+        raise last_error
+    fail(f"timed out waiting for {description}")
 
 def wait_for_prometheus_up(base_url, *, headers=None, description):
     doc = wait_for_json(
@@ -4556,6 +4619,16 @@ for service_name in gateway_trace_services:
     tempo_gateway_counts[service_name] = count
     tempo_gateway_services.update(names)
 
+required_trace_services = {gateway_trace_services[0], "mcp-sentinel-ingest", "mcp-sentinel-processor"}
+required_trace_spans = {"kafka.produce", "kafka.consume", "clickhouse.insert_event"}
+tempo_full_trace_id, tempo_full_trace_services, tempo_full_trace_spans = wait_for_tempo_trace_path(
+    tempo_base,
+    gateway_trace_services[0],
+    required_trace_services,
+    required_trace_spans,
+    description="tempo full gateway analytics trace path",
+)
+
 grafana_headers = basic_auth_headers(grafana_user, grafana_password)
 grafana_datasources = wait_for_json(
     f"{grafana_base}/api/datasources",
@@ -4589,6 +4662,15 @@ for service_name in gateway_trace_services:
     )
     grafana_gateway_counts[service_name] = count
     grafana_gateway_services.update(names)
+
+grafana_full_trace_id, grafana_full_trace_services, grafana_full_trace_spans = wait_for_tempo_trace_path(
+    grafana_tempo_base,
+    gateway_trace_services[0],
+    required_trace_services,
+    required_trace_spans,
+    headers=grafana_headers,
+    description="grafana tempo full gateway analytics trace path",
+)
 
 prometheus_jobs = wait_for_prometheus_up(
     prometheus_base,
@@ -4649,8 +4731,14 @@ rows = [
     ("traces.tempo_found", str(len(traces))),
     ("traces.tempo_gateway", ",".join(f"{k}:{v}" for k, v in sorted(tempo_gateway_counts.items()))),
     ("traces.tempo_services", ",".join(sorted(tempo_gateway_services))),
+    ("traces.tempo_full_path", tempo_full_trace_id),
+    ("traces.tempo_full_path_services", ",".join(sorted(tempo_full_trace_services))),
+    ("traces.tempo_full_path_spans", ",".join(sorted(tempo_full_trace_spans))),
     ("traces.grafana_gateway", ",".join(f"{k}:{v}" for k, v in sorted(grafana_gateway_counts.items()))),
     ("traces.grafana_services", ",".join(sorted(grafana_gateway_services))),
+    ("traces.grafana_full_path", grafana_full_trace_id),
+    ("traces.grafana_full_path_services", ",".join(sorted(grafana_full_trace_services))),
+    ("traces.grafana_full_path_spans", ",".join(sorted(grafana_full_trace_spans))),
     ("grafana.datasources", str(len(grafana_datasources))),
     ("prometheus.jobs", ",".join(f"{k}:{v}" for k, v in sorted(prometheus_jobs.items()))),
     ("grafana.prometheus.jobs", ",".join(f"{k}:{v}" for k, v in sorted(grafana_prometheus_jobs.items()))),

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -4114,18 +4114,25 @@ def trace_service_names(trace_doc):
                 names.add(name)
     return names
 
-def datasource_uid(datasources, ds_type):
+def datasource_by_type(datasources, ds_type):
     for datasource in datasources:
         if datasource.get("type") == ds_type:
-            uid = datasource.get("uid")
-            if uid:
-                return uid
+            return datasource
     fail(f"Grafana datasource of type {ds_type!r} not found: {datasources}")
 
+def datasource_uid(datasources, ds_type):
+    datasource = datasource_by_type(datasources, ds_type)
+    uid = datasource.get("uid")
+    if uid:
+        return uid
+    fail(f"Grafana datasource of type {ds_type!r} has no uid: {datasource}")
+
 def wait_for_tempo_service(base_url, service_name, *, headers=None, description):
+    end = int(time.time())
+    start = end - 3600
     tag = urllib.parse.quote(f"service.name={service_name}")
     doc = wait_for_json(
-        f"{base_url}/api/search?limit=20&tags={tag}",
+        f"{base_url}/api/search?limit=20&start={start}&end={end}&tags={tag}",
         lambda payload: bool(payload.get("traces", [])),
         headers=headers,
         retries=90,
@@ -4548,6 +4555,13 @@ grafana_datasources = wait_for_json(
 )
 tempo_uid = datasource_uid(grafana_datasources, "tempo")
 prometheus_uid = datasource_uid(grafana_datasources, "prometheus")
+loki_uid = datasource_uid(grafana_datasources, "loki")
+prometheus_datasource = datasource_by_type(grafana_datasources, "prometheus")
+check(
+    str(prometheus_datasource.get("url", "")).rstrip("/").endswith("/prometheus"),
+    "grafana Prometheus datasource includes route prefix",
+    f"grafana Prometheus datasource URL is missing /prometheus route prefix: {prometheus_datasource}",
+)
 
 grafana_gateway_counts = {}
 grafana_gateway_services = set()
@@ -4567,10 +4581,11 @@ prometheus_jobs = wait_for_prometheus_up(
     description="prometheus up query",
 )
 grafana_prometheus_jobs = wait_for_prometheus_up(
-    f"{grafana_base}/api/datasources/proxy/uid/{prometheus_uid}/prometheus",
+    f"{grafana_base}/api/datasources/proxy/uid/{prometheus_uid}",
     headers=grafana_headers,
     description="grafana prometheus up query",
 )
+grafana_loki_base = f"{grafana_base}/api/datasources/proxy/uid/{loki_uid}"
 
 end_ns = int(time.time() * 1e9)
 start_ns = end_ns - int(10 * 60 * 1e9)
@@ -4590,6 +4605,15 @@ loki = wait_for_json(
     description="loki log streams",
 )
 streams = loki.get("data", {}).get("result", [])
+grafana_loki = wait_for_json(
+    f"{grafana_loki_base}/loki/api/v1/query_range?{params}",
+    lambda doc: bool(doc.get("data", {}).get("result", [])),
+    headers=grafana_headers,
+    retries=60,
+    delay=2,
+    description="grafana loki log streams",
+)
+grafana_streams = grafana_loki.get("data", {}).get("result", [])
 
 rows = [
     ("audit.events_total", str(stats.get("events_total", "n/a"))),
@@ -4617,6 +4641,7 @@ rows = [
     ("prometheus.jobs", ",".join(f"{k}:{v}" for k, v in sorted(prometheus_jobs.items()))),
     ("grafana.prometheus.jobs", ",".join(f"{k}:{v}" for k, v in sorted(grafana_prometheus_jobs.items()))),
     ("logs.loki_streams", str(len(streams))),
+    ("grafana.loki_streams", str(len(grafana_streams))),
 ]
 width = max(len(k) for k, _ in rows)
 print(f"{'check':{width}}  value")

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -4178,7 +4178,7 @@ def wait_for_prometheus_up(base_url, *, headers=None, description):
         value = result.get("value", [])
         if len(value) >= 2 and metric.get("job"):
             jobs[metric["job"]] = str(value[1])
-    for job in ("mcp-sentinel-api", "mcp-sentinel-ingest"):
+    for job in ("mcp-sentinel-api", "mcp-sentinel-ingest", "mcp-sentinel-processor"):
         check(
             jobs.get(job) == "1",
             f"{description} reports {job}=1",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces end-to-end OpenTelemetry (OTLP) tracing for the gateway sidecar and integrates comprehensive observability checks into the e2e testing framework.

Key changes include:

*   **Gateway Tracing Configuration**: The operator now supports configuring an OTLP endpoint for gateway tracing via the `MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT` environment variable. This endpoint is injected into the gateway sidecar containers as `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME`.
*   **Enhanced E2E Observability Checks**:
    *   The Kind e2e script is updated to set the default OTLP endpoint and refresh operator environment variables in cache mode.
    *   New Python helper functions are added to the e2e test suite to query Tempo for gateway traces and Prometheus for service metrics, both directly and through Grafana.
    *   E2e tests now include assertions to verify that gateway traces are successfully collected by Tempo, that Grafana datasources (Tempo, Prometheus) are configured, and that Prometheus is collecting metrics from key services.
*   **Improved Setup Reliability**: The ClickHouse initialization job is now explicitly deleted and recreated during analytics manifest deployment, ensuring a fresh and reliable schema setup.
*   **Developer Experience Improvements**: Documentation for local Kind e2e testing is updated with better instructions for cluster reuse and context management. Build contexts for analytics services are standardized to the repository root.
<!-- kody-pr-summary:end -->