### PR TITLE
feat(cli): add parallel setup image builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,31 +105,31 @@ jobs:
         run: |
           set -euo pipefail
 
-          run_service_tests() {
-            local service="$1"
-            echo "::group::services/${service}"
-            local status=0
-            if (cd "services/${service}" && go test -v -race -count=1 ./...); then
-              status=0
-            else
-              status=$?
-            fi
-            echo "::endgroup::"
-            return "${status}"
-          }
-
+          log_dir="${RUNNER_TEMP:-/tmp}/sentinel-service-test-logs"
+          mkdir -p "${log_dir}"
           services=(api ingest processor mcp-proxy ui)
           pids=()
+          log_files=()
           for service in "${services[@]}"; do
-            run_service_tests "${service}" &
+            log_file="${log_dir}/${service}.log"
+            echo "[parallel][start] services/${service} (log: ${log_file})"
+            (cd "services/${service}" && go test -v -race -count=1 ./...) >"${log_file}" 2>&1 &
             pids+=("$!")
+            log_files+=("${log_file}")
           done
 
           failed=0
           for i in "${!services[@]}"; do
+            service="${services[$i]}"
+            log_file="${log_files[$i]}"
             if ! wait "${pids[$i]}"; then
-              echo "services/${services[$i]} tests failed" >&2
+              echo "[parallel][fail] services/${service} tests failed; log follows" >&2
+              echo "::group::services/${service} failure log"
+              cat "${log_file}" || true
+              echo "::endgroup::"
               failed=1
+            else
+              echo "[parallel][pass] services/${service} (log: ${log_file})"
             fi
           done
           exit "${failed}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          log_dir="${RUNNER_TEMP:-/tmp}/sentinel-service-test-logs"
+          log_dir="${SENTINEL_SERVICE_TEST_LOG_DIR}"
           mkdir -p "${log_dir}"
           services=(api ingest processor mcp-proxy ui)
           pids=()
@@ -133,6 +133,16 @@ jobs:
             fi
           done
           exit "${failed}"
+        env:
+          SENTINEL_SERVICE_TEST_LOG_DIR: ${{ runner.temp }}/sentinel-service-test-logs
+
+      - name: Upload Sentinel service test logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sentinel-service-test-logs
+          path: ${{ runner.temp }}/sentinel-service-test-logs
+          if-no-files-found: ignore
 
       - name: Run integration tests with coverage
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,11 +103,36 @@ jobs:
 
       - name: Test Sentinel service modules
         run: |
-          (cd services/api && go test -v -race -count=1 ./...)
-          (cd services/ingest && go test -v -race -count=1 ./...)
-          (cd services/processor && go test -v -race -count=1 ./...)
-          (cd services/mcp-proxy && go test -v -race -count=1 ./...)
-          (cd services/ui && go test -v -race -count=1 ./...)
+          set -euo pipefail
+
+          run_service_tests() {
+            local service="$1"
+            echo "::group::services/${service}"
+            local status=0
+            if (cd "services/${service}" && go test -v -race -count=1 ./...); then
+              status=0
+            else
+              status=$?
+            fi
+            echo "::endgroup::"
+            return "${status}"
+          }
+
+          services=(api ingest processor mcp-proxy ui)
+          pids=()
+          for service in "${services[@]}"; do
+            run_service_tests "${service}" &
+            pids+=("$!")
+          done
+
+          failed=0
+          for i in "${!services[@]}"; do
+            if ! wait "${pids[$i]}"; then
+              echo "services/${services[$i]} tests failed" >&2
+              failed=1
+            fi
+          done
+          exit "${failed}"
 
       - name: Run integration tests with coverage
         run: |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,9 +83,10 @@ mcp-runtime setup --with-tls                   # cert-manager TLS for registry
 mcp-runtime setup --platform-mode public       # anonymous public preview catalog
 mcp-runtime setup --without-sentinel           # skip request-path stack
 mcp-runtime setup --test-mode                  # local Kind/dev build+push path
+mcp-runtime setup --parallel-builds            # build/publish setup images concurrently
 ```
 
-Flags: `--registry-type`, `--registry-storage`, `--platform-mode`, `--ingress`, `--ingress-manifest`, `--force-ingress-install`, `--with-tls`, `--test-mode`, `--without-sentinel`, plus operator overrides `--operator-leader-elect`, `--operator-metrics-addr`, `--operator-probe-addr`.
+Flags: `--registry-type`, `--registry-storage`, `--platform-mode`, `--ingress`, `--ingress-manifest`, `--force-ingress-install`, `--with-tls`, `--test-mode`, `--parallel-builds`, `--without-sentinel`, plus operator overrides `--operator-leader-elect`, `--operator-metrics-addr`, `--operator-probe-addr`.
 
 `--platform-mode` selects the namespace model. `tenant` is the default and
 scopes signed-in users to their own user/team tenant namespace; `org` uses
@@ -99,6 +100,10 @@ operator, gateway proxy, and Sentinel images with `latest` tags to the
 configured or bundled registry. With the bundled plain HTTP registry, cluster
 nodes still need containerd/Docker trust for the exact image host they pull
 from.
+
+`--parallel-builds` keeps cluster, registry, TLS, and rollout sequencing
+unchanged, but builds and publishes the runtime and Sentinel setup images
+concurrently.
 
 Setup is reconcile-oriented and refuses known control-plane conflicts before
 applying more state. Registry TLS is owned by the explicit

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -97,3 +97,8 @@ Kind setup step to exercise a non-default catalog mode.
 
 Use `E2E_CACHE_MODE=1` only for repeated local debugging. Omit it when you want
 a CI-equivalent fresh cluster.
+
+Image mirroring and local image builds run concurrently during fresh e2e setup.
+Set `E2E_IMAGE_PREP_PARALLELISM=1` to force sequential prep on constrained
+machines, or raise it above the default `3` only when Docker has enough CPU,
+network, and disk headroom.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -99,9 +99,10 @@ Use `E2E_CACHE_MODE=1` only for repeated local debugging. Omit it when you want
 a CI-equivalent fresh cluster.
 
 Image mirroring and local image builds run concurrently during fresh e2e setup.
-Set `E2E_IMAGE_PREP_PARALLELISM=1` to force sequential prep on constrained
-machines, or raise it above the default `3` only when Docker has enough CPU,
-network, and disk headroom.
+`E2E_IMAGE_PREP_PARALLELISM` still tunes the default prep concurrency, while
+`E2E_IMAGE_MIRROR_PARALLELISM` and `E2E_IMAGE_BUILD_PARALLELISM` can split
+pull/push concurrency from heavier Docker builds. CI defaults to three mirror
+workers and two build workers; set either value to `1` on constrained machines.
 Independent official SDK example deployments also run in parallel; the scenario
 checks themselves stay ordered because they share runtime state.
 Parallel worker logs are buffered in the e2e workdir under `stage-logs/` and

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -105,3 +105,6 @@ network, and disk headroom.
 Core rollout waits and independent official SDK example deployments also run in
 parallel; the scenario checks themselves stay ordered because they share runtime
 state.
+Parallel worker logs are buffered in the e2e workdir under `parallel-logs/` and
+copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Successful workers
+print only start/pass lines; failed workers dump their captured log inline.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -102,3 +102,6 @@ Image mirroring and local image builds run concurrently during fresh e2e setup.
 Set `E2E_IMAGE_PREP_PARALLELISM=1` to force sequential prep on constrained
 machines, or raise it above the default `3` only when Docker has enough CPU,
 network, and disk headroom.
+Core rollout waits and independent official SDK example deployments also run in
+parallel; the scenario checks themselves stay ordered because they share runtime
+state.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -102,11 +102,11 @@ Image mirroring and local image builds run concurrently during fresh e2e setup.
 Set `E2E_IMAGE_PREP_PARALLELISM=1` to force sequential prep on constrained
 machines, or raise it above the default `3` only when Docker has enough CPU,
 network, and disk headroom.
-Core rollout waits and independent official SDK example deployments also run in
-parallel; the scenario checks themselves stay ordered because they share runtime
-state.
+Independent official SDK example deployments also run in parallel; the scenario
+checks themselves stay ordered because they share runtime state.
 Parallel worker logs are buffered in the e2e workdir under `stage-logs/` and
-copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Successful workers
-print only start/pass lines; failed workers dump their captured log inline.
-Major sequential stages such as setup, cluster doctor, CLI rebuilds, and server
+copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Live CI output uses
+colored `START`, `RUNNING`, `DONE`, and `FAILED` lifecycle lines plus short
+stdout/stderr previews, while the full logs stay in the artifact. Major
+sequential stages such as setup, cluster doctor, CLI rebuilds, and server
 deploys are mirrored under `stage-logs/` in the same artifact.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -108,3 +108,5 @@ state.
 Parallel worker logs are buffered in the e2e workdir under `parallel-logs/` and
 copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Successful workers
 print only start/pass lines; failed workers dump their captured log inline.
+Major sequential stages such as setup, cluster doctor, CLI rebuilds, and server
+deploys are mirrored under `stage-logs/` in the same artifact.

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -5237,6 +5237,7 @@ type Input struct {
 	ForceIngressInstall    bool
 	TLSEnabled             bool
 	TestMode               bool
+	ParallelBuilds         bool
 	StrictProd             bool
 	DeployAnalytics        bool
 	OperatorArgs           []string
@@ -5264,6 +5265,7 @@ type Plan struct {
 	RegistryManifest    string
 	TLSEnabled          bool
 	TestMode            bool
+	ParallelBuilds      bool
 	StrictProd          bool
 	DeployAnalytics     bool
 	OperatorArgs        []string

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -63,8 +63,11 @@ present, skips platform setup if the core platform is already ready, and reuses
 image tags already published to the local registry.
 
 Image mirroring and local runtime/Sentinel image builds run with bounded
-parallelism. Set `E2E_IMAGE_PREP_PARALLELISM=<n>` to tune the default of `3`
-when your workstation or CI runner needs less or more Docker concurrency.
+parallelism. `E2E_IMAGE_PREP_PARALLELISM=<n>` tunes the shared prep default,
+`E2E_IMAGE_MIRROR_PARALLELISM=<n>` tunes pull/push mirroring, and
+`E2E_IMAGE_BUILD_PARALLELISM=<n>` tunes local Docker builds. CI keeps mirroring
+at three workers but defaults builds to two workers because those builds are
+heavier on runner CPU, memory, and Docker.
 The script also deploys the independent official SDK example servers
 concurrently; scenario assertions remain ordered because they share policy,
 session, and analytics state.

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -68,6 +68,9 @@ when your workstation or CI runner needs less or more Docker concurrency.
 The script also waits on independent core rollouts and deploys the official SDK
 example servers concurrently; scenario assertions remain ordered because they
 share policy, session, and analytics state.
+Parallel worker output is buffered under `parallel-logs/` in the e2e workdir
+and copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Green workers
+print start/pass lines only; failed workers dump their captured log inline.
 
 E2E output uses ANSI color only for an interactive terminal by default. Set
 `E2E_COLOR=always` or `E2E_COLOR=never` to override auto-detection; `NO_COLOR`

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -65,19 +65,20 @@ image tags already published to the local registry.
 Image mirroring and local runtime/Sentinel image builds run with bounded
 parallelism. Set `E2E_IMAGE_PREP_PARALLELISM=<n>` to tune the default of `3`
 when your workstation or CI runner needs less or more Docker concurrency.
-The script also waits on independent core rollouts and deploys the official SDK
-example servers concurrently; scenario assertions remain ordered because they
-share policy, session, and analytics state.
+The script also deploys the independent official SDK example servers
+concurrently; scenario assertions remain ordered because they share policy,
+session, and analytics state.
 Parallel worker output is buffered under `stage-logs/` in the e2e workdir and
-copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Green workers print
-start/pass lines only; failed workers dump their captured log inline.
-Major sequential stages such as local registry startup, Kind cluster creation,
-CLI rebuilds, setup, cluster doctor, and MCP server deploys are also mirrored to
-`stage-logs/` in the same artifact.
+copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Live output prints
+colored `START`, `RUNNING`, `DONE`, and `FAILED` lifecycle lines plus short
+stdout/stderr previews; tune those previews with `E2E_LOG_PREVIEW_LINES` and
+`E2E_LOG_FAILURE_LINES`. Major sequential stages such as local registry startup,
+Kind cluster creation, CLI rebuilds, setup, cluster doctor, and MCP server
+deploys are also mirrored to `stage-logs/` in the same artifact.
 
-E2E output uses ANSI color only for an interactive terminal by default. Set
-`E2E_COLOR=always` or `E2E_COLOR=never` to override auto-detection; `NO_COLOR`
-disables color.
+E2E output uses ANSI color for interactive terminals and GitHub Actions by
+default. Set `E2E_COLOR=always` or `E2E_COLOR=never` to override
+auto-detection; `NO_COLOR` disables color.
 
 Kind e2e traffic uses deterministic curl-based MCP requests. The previous
 real-client agent prompts are disabled so CI and local runs do not consume

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -71,6 +71,9 @@ share policy, session, and analytics state.
 Parallel worker output is buffered under `parallel-logs/` in the e2e workdir
 and copied into `E2E_ARTIFACT_DIR` when artifacts are enabled. Green workers
 print start/pass lines only; failed workers dump their captured log inline.
+Major sequential stages such as local registry startup, Kind cluster creation,
+CLI rebuilds, setup, cluster doctor, and MCP server deploys are also mirrored to
+`stage-logs/` in the same artifact.
 
 E2E output uses ANSI color only for an interactive terminal by default. Set
 `E2E_COLOR=always` or `E2E_COLOR=never` to override auto-detection; `NO_COLOR`

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -65,6 +65,9 @@ image tags already published to the local registry.
 Image mirroring and local runtime/Sentinel image builds run with bounded
 parallelism. Set `E2E_IMAGE_PREP_PARALLELISM=<n>` to tune the default of `3`
 when your workstation or CI runner needs less or more Docker concurrency.
+The script also waits on independent core rollouts and deploys the official SDK
+example servers concurrently; scenario assertions remain ordered because they
+share policy, session, and analytics state.
 
 E2E output uses ANSI color only for an interactive terminal by default. Set
 `E2E_COLOR=always` or `E2E_COLOR=never` to override auto-detection; `NO_COLOR`

--- a/docs/internals/tests.md
+++ b/docs/internals/tests.md
@@ -62,6 +62,10 @@ E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth bash test/e2e/kind.sh
 present, skips platform setup if the core platform is already ready, and reuses
 image tags already published to the local registry.
 
+Image mirroring and local runtime/Sentinel image builds run with bounded
+parallelism. Set `E2E_IMAGE_PREP_PARALLELISM=<n>` to tune the default of `3`
+when your workstation or CI runner needs less or more Docker concurrency.
+
 E2E output uses ANSI color only for an interactive terminal by default. Set
 `E2E_COLOR=always` or `E2E_COLOR=never` to override auto-detection; `NO_COLOR`
 disables color.

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -938,6 +938,51 @@ func TestPrepareDeploymentImagesParallelBuildsStartsBothBuilds(t *testing.T) {
 	}
 }
 
+func TestPrepareDeploymentImagesParallelBuildsPreparesInternalRegistryOnce(t *testing.T) {
+	var ensureCalls int32
+	var resolveCalls int32
+
+	deps := SetupDeps{
+		OperatorImageFor: func(_ *config.ExternalRegistryConfig) string {
+			return "registry.example.com/mcp-runtime-operator:latest"
+		},
+		GatewayProxyImageFor: func(_ *config.ExternalRegistryConfig) string {
+			return "registry.example.com/mcp-sentinel-mcp-proxy:latest"
+		},
+		BuildOperatorImage:     func(string) error { return nil },
+		BuildGatewayProxyImage: func(string) error { return nil },
+		EnsureNamespace: func(string) error {
+			atomic.AddInt32(&ensureCalls, 1)
+			return nil
+		},
+		ResolvePlatformRegistryURL: func(*zap.Logger) string {
+			atomic.AddInt32(&resolveCalls, 1)
+			return "registry.local:5000"
+		},
+		PushOperatorImageToInternal: func(*zap.Logger, string, string, string) error { return nil },
+		PushGatewayProxyImageToInternal: func(*zap.Logger, string, string, string) error {
+			return nil
+		},
+	}
+
+	operatorImage, gatewayProxyImage, err := prepareDeploymentImages(zap.NewNop(), &config.ExternalRegistryConfig{URL: "registry.example.com"}, false, true, true, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if operatorImage != "registry.local:5000/mcp-runtime-operator:latest" {
+		t.Fatalf("operator image = %q, want internal registry image", operatorImage)
+	}
+	if gatewayProxyImage != "registry.local:5000/mcp-sentinel-mcp-proxy:latest" {
+		t.Fatalf("gateway proxy image = %q, want internal registry image", gatewayProxyImage)
+	}
+	if got := atomic.LoadInt32(&ensureCalls); got != 1 {
+		t.Fatalf("expected one registry namespace ensure, got %d", got)
+	}
+	if got := atomic.LoadInt32(&resolveCalls); got != 1 {
+		t.Fatalf("expected one registry URL resolve, got %d", got)
+	}
+}
+
 func TestPrepareAnalyticsImagesParallelBuildsStartsAllBuilds(t *testing.T) {
 	started := make(chan string, len(analyticsComponents))
 	release := make(chan struct{})
@@ -971,6 +1016,46 @@ func TestPrepareAnalyticsImagesParallelBuildsStartsAllBuilds(t *testing.T) {
 	close(release)
 	if err := <-errCh; err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareAnalyticsImagesParallelBuildsPreparesInternalRegistryOnce(t *testing.T) {
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "1")
+
+	var ensureCalls int32
+	var resolveCalls int32
+	deps := SetupDeps{
+		BuildAnalyticsImage: func(string, string, string) error { return nil },
+		EnsureNamespace: func(string) error {
+			atomic.AddInt32(&ensureCalls, 1)
+			return nil
+		},
+		ResolvePlatformRegistryURL: func(*zap.Logger) string {
+			atomic.AddInt32(&resolveCalls, 1)
+			return "registry.local:5000"
+		},
+		PushAnalyticsImageToInternal: func(*zap.Logger, string, string, string) error { return nil },
+	}
+
+	got, err := prepareAnalyticsImages(zap.NewNop(), &config.ExternalRegistryConfig{URL: "registry.example.com"}, false, true, true, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := AnalyticsImageSet{
+		Ingest:    "registry.local:5000/mcp-sentinel-ingest:latest",
+		API:       "registry.local:5000/mcp-sentinel-api:latest",
+		Processor: "registry.local:5000/mcp-sentinel-processor:latest",
+		UI:        "registry.local:5000/mcp-sentinel-ui:latest",
+	}
+	if got != want {
+		t.Fatalf("prepareAnalyticsImages() = %+v, want %+v", got, want)
+	}
+	if got := atomic.LoadInt32(&ensureCalls); got != 1 {
+		t.Fatalf("expected one registry namespace ensure, got %d", got)
+	}
+	if got := atomic.LoadInt32(&resolveCalls); got != 1 {
+		t.Fatalf("expected one registry URL resolve, got %d", got)
 	}
 }
 

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -868,7 +868,7 @@ func TestPrepareAnalyticsImagesUsesTestModeImageSet(t *testing.T) {
 		},
 	}
 
-	got, err := prepareAnalyticsImages(zap.NewNop(), &config.ExternalRegistryConfig{URL: "registry.example.com"}, true, true, deps)
+	got, err := prepareAnalyticsImages(zap.NewNop(), &config.ExternalRegistryConfig{URL: "registry.example.com"}, true, true, false, deps)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -887,6 +887,90 @@ func TestPrepareAnalyticsImagesUsesTestModeImageSet(t *testing.T) {
 	}
 	if atomic.LoadInt32(&pushCalls) != int32(len(analyticsComponents)) {
 		t.Fatalf("expected %d pushes in test mode, got %d", len(analyticsComponents), pushCalls)
+	}
+}
+
+func TestPrepareDeploymentImagesParallelBuildsStartsBothBuilds(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	deps := SetupDeps{
+		OperatorImageFor: func(_ *config.ExternalRegistryConfig) string {
+			return "registry.example.com/mcp-runtime-operator:latest"
+		},
+		GatewayProxyImageFor: func(_ *config.ExternalRegistryConfig) string {
+			return "registry.example.com/mcp-sentinel-mcp-proxy:latest"
+		},
+		BuildOperatorImage: func(string) error {
+			started <- "operator"
+			<-release
+			return nil
+		},
+		PushOperatorImage: func(string) error { return nil },
+		BuildGatewayProxyImage: func(string) error {
+			started <- "gateway"
+			<-release
+			return nil
+		},
+		PushGatewayProxyImage: func(string) error { return nil },
+	}
+
+	go func() {
+		_, _, err := prepareDeploymentImages(zap.NewNop(), &config.ExternalRegistryConfig{URL: "registry.example.com"}, true, true, true, deps)
+		errCh <- err
+	}()
+
+	seen := map[string]bool{}
+	timeout := time.After(2 * time.Second)
+	for len(seen) < 2 {
+		select {
+		case name := <-started:
+			seen[name] = true
+		case <-timeout:
+			t.Fatalf("timed out waiting for parallel runtime image builds, saw %v", seen)
+		}
+	}
+
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareAnalyticsImagesParallelBuildsStartsAllBuilds(t *testing.T) {
+	started := make(chan string, len(analyticsComponents))
+	release := make(chan struct{})
+	errCh := make(chan error, 1)
+
+	deps := SetupDeps{
+		BuildAnalyticsImage: func(image, _, _ string) error {
+			started <- image
+			<-release
+			return nil
+		},
+		PushAnalyticsImage: func(string) error { return nil },
+	}
+
+	go func() {
+		_, err := prepareAnalyticsImages(zap.NewNop(), &config.ExternalRegistryConfig{URL: "registry.example.com"}, true, true, true, deps)
+		errCh <- err
+	}()
+
+	seen := map[string]bool{}
+	timeout := time.After(2 * time.Second)
+	for len(seen) < len(analyticsComponents) {
+		select {
+		case image := <-started:
+			seen[image] = true
+		case <-timeout:
+			t.Fatalf("timed out waiting for parallel analytics image builds, saw %d of %d", len(seen), len(analyticsComponents))
+		}
+	}
+
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cli/setup/plan/plan.go
+++ b/internal/cli/setup/plan/plan.go
@@ -37,6 +37,7 @@ type Input struct {
 	ForceIngressInstall    bool
 	TLSEnabled             bool
 	TestMode               bool
+	ParallelBuilds         bool
 	StrictProd             bool
 	DeployAnalytics        bool
 	OperatorArgs           []string
@@ -60,6 +61,7 @@ type Plan struct {
 	RegistryManifest    string
 	TLSEnabled          bool
 	TestMode            bool
+	ParallelBuilds      bool
 	StrictProd          bool
 	DeployAnalytics     bool
 	OperatorArgs        []string
@@ -145,6 +147,7 @@ func Build(input Input) Plan {
 		RegistryManifest:   registryManifest,
 		TLSEnabled:         input.TLSEnabled,
 		TestMode:           input.TestMode,
+		ParallelBuilds:     input.ParallelBuilds,
 		StrictProd:         input.StrictProd,
 		DeployAnalytics:    input.DeployAnalytics,
 		OperatorArgs:       input.OperatorArgs,

--- a/internal/cli/setup/plan_flow_test.go
+++ b/internal/cli/setup/plan_flow_test.go
@@ -124,12 +124,16 @@ func TestBuildSetupPlan_PreservesTestModeAndOperatorArgs(t *testing.T) {
 		ForceIngressInstall:    false,
 		TLSEnabled:             false,
 		TestMode:               true,
+		ParallelBuilds:         true,
 		StrictProd:             true,
 		OperatorArgs:           operatorArgs,
 	})
 
 	if !plan.TestMode {
 		t.Fatal("expected test mode to be preserved")
+	}
+	if !plan.ParallelBuilds {
+		t.Fatal("expected parallel builds to be preserved")
 	}
 	if !plan.StrictProd {
 		t.Fatal("expected strict prod to be preserved")

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -455,6 +455,13 @@ func prepareDeploymentImages(logger *zap.Logger, extRegistry *config.ExternalReg
 	if parallelBuilds {
 		core.Info("Parallel image publishing enabled for setup runtime images")
 
+		parallelDeps, err := prepareParallelImagePublishDeps(logger, usingExternalRegistry, deps, "setup")
+		if err != nil {
+			core.Error("Failed to prepare internal registry image publishing")
+			core.LogStructuredError(logger, err, "Failed to prepare internal registry image publishing")
+			return "", "", err
+		}
+
 		type imageResult struct {
 			kind  string
 			image string
@@ -466,12 +473,12 @@ func prepareDeploymentImages(logger *zap.Logger, extRegistry *config.ExternalReg
 
 		go func() {
 			defer wg.Done()
-			image, err := prepareOperatorImage(logger, extRegistry, usingExternalRegistry, testMode, deps)
+			image, err := prepareOperatorImage(logger, extRegistry, usingExternalRegistry, testMode, parallelDeps)
 			results <- imageResult{kind: "operator", image: image, err: err}
 		}()
 		go func() {
 			defer wg.Done()
-			image, err := prepareGatewayProxyImage(logger, extRegistry, usingExternalRegistry, testMode, deps)
+			image, err := prepareGatewayProxyImage(logger, extRegistry, usingExternalRegistry, testMode, parallelDeps)
 			results <- imageResult{kind: "gateway", image: image, err: err}
 		}()
 
@@ -544,16 +551,10 @@ func prepareOperatorImage(logger *zap.Logger, extRegistry *config.ExternalRegist
 	}
 	internalOperatorImage := fmt.Sprintf("%s/mcp-runtime-operator:%s", internalRegistryURL, operatorTag)
 
-	if err := deps.EnsureNamespace("registry"); err != nil {
-		wrappedErr := core.WrapWithSentinelAndContext(
-			core.ErrEnsureRegistryNamespaceFailed,
-			err,
-			fmt.Sprintf("failed to ensure registry namespace: %v", err),
-			map[string]any{"namespace": "registry", "component": "setup"},
-		)
+	if err := ensureRegistryNamespaceForImagePush(deps, "setup"); err != nil {
 		core.Error("Failed to ensure registry namespace")
-		core.LogStructuredError(logger, wrappedErr, "Failed to ensure registry namespace")
-		return "", wrappedErr
+		core.LogStructuredError(logger, err, "Failed to ensure registry namespace")
+		return "", err
 	}
 
 	if err := deps.PushOperatorImageToInternal(logger, operatorImage, internalOperatorImage, "registry"); err != nil {
@@ -616,16 +617,10 @@ func prepareGatewayProxyImage(logger *zap.Logger, extRegistry *config.ExternalRe
 	}
 	internalGatewayProxyImage := fmt.Sprintf("%s/%s:%s", internalRegistryURL, defaultGatewayProxyRepository, gatewayTag)
 
-	if err := deps.EnsureNamespace("registry"); err != nil {
-		wrappedErr := core.WrapWithSentinelAndContext(
-			core.ErrEnsureRegistryNamespaceFailed,
-			err,
-			fmt.Sprintf("failed to ensure registry namespace: %v", err),
-			map[string]any{"namespace": "registry", "component": "setup"},
-		)
+	if err := ensureRegistryNamespaceForImagePush(deps, "setup"); err != nil {
 		core.Error("Failed to ensure registry namespace")
-		core.LogStructuredError(logger, wrappedErr, "Failed to ensure registry namespace")
-		return "", wrappedErr
+		core.LogStructuredError(logger, err, "Failed to ensure registry namespace")
+		return "", err
 	}
 
 	if err := deps.PushGatewayProxyImageToInternal(logger, gatewayProxyImage, internalGatewayProxyImage, "registry"); err != nil {
@@ -665,84 +660,20 @@ func prepareAnalyticsImages(logger *zap.Logger, extRegistry *config.ExternalRegi
 	}
 
 	for _, component := range analyticsComponents {
-		image := analyticsImageFor(extRegistry, component.Repository)
-		if testMode {
-			core.Info(fmt.Sprintf("Test mode: building analytics %s image: %s", component.Name, image))
-		} else {
-			core.Info(fmt.Sprintf("Building analytics %s image: %s", component.Name, image))
+		image, err := buildAndPublishAnalyticsComponent(logger, extRegistry, usingExternalRegistry, testMode, deps, component)
+		if err != nil {
+			return AnalyticsImageSet{}, err
 		}
-		if err := deps.BuildAnalyticsImage(image, component.Dockerfile, component.BuildContext); err != nil {
-			return AnalyticsImageSet{}, core.WrapWithSentinelAndContext(
-				core.ErrBuildImageFailed,
-				err,
-				fmt.Sprintf("failed to build analytics %s image %q: %v", component.Name, image, err),
-				map[string]any{"image": image, "component": component.Name},
-			)
-		}
-		if usingExternalRegistry {
-			if testMode {
-				core.Info(fmt.Sprintf("Test mode: pushing analytics %s image to external registry", component.Name))
-			} else {
-				core.Info(fmt.Sprintf("Pushing analytics %s image to external registry", component.Name))
-			}
-			if err := deps.PushAnalyticsImage(image); err != nil {
-				core.Warn(fmt.Sprintf("Could not push analytics %s image to external registry: %v", component.Name, err))
-			}
-			continue
-		}
-
-		if testMode {
-			core.Info(fmt.Sprintf("Test mode: pushing analytics %s image to internal registry", component.Name))
-		} else {
-			core.Info(fmt.Sprintf("Pushing analytics %s image to internal registry", component.Name))
-		}
-		internalRegistryURL := deps.ResolvePlatformRegistryURL(logger)
-		_, imageTag := ref.SplitImage(image)
-		if imageTag == "" {
-			imageTag = setupImageTag()
-		}
-		internalImage := fmt.Sprintf("%s/%s:%s", internalRegistryURL, component.Repository, imageTag)
-		if err := deps.EnsureNamespace("registry"); err != nil {
-			return AnalyticsImageSet{}, core.WrapWithSentinelAndContext(
-				core.ErrEnsureRegistryNamespaceFailed,
-				err,
-				fmt.Sprintf("failed to ensure registry namespace: %v", err),
-				map[string]any{"namespace": "registry", "component": component.Name},
-			)
-		}
-		if err := deps.PushAnalyticsImageToInternal(logger, image, internalImage, "registry"); err != nil {
-			return AnalyticsImageSet{}, core.WrapWithSentinelAndContext(
-				core.ErrPushImageInClusterFailed,
-				err,
-				fmt.Sprintf("failed to push analytics %s image %q to internal registry %q: %v", component.Name, image, internalImage, err),
-				map[string]any{"source_image": image, "target_image": internalImage, "component": component.Name},
-			)
-		}
-		switch component.Repository {
-		case "mcp-sentinel-ingest":
-			images.Ingest = internalImage
-		case "mcp-sentinel-api":
-			images.API = internalImage
-		case "mcp-sentinel-processor":
-			images.Processor = internalImage
-		case "mcp-sentinel-ui":
-			images.UI = internalImage
-		}
+		assignAnalyticsImage(&images, component.Repository, image)
 	}
 
 	return images, nil
 }
 
 func prepareAnalyticsImagesParallel(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode bool, deps SetupDeps, images AnalyticsImageSet) (AnalyticsImageSet, error) {
-	if !usingExternalRegistry {
-		if err := deps.EnsureNamespace("registry"); err != nil {
-			return AnalyticsImageSet{}, core.WrapWithSentinelAndContext(
-				core.ErrEnsureRegistryNamespaceFailed,
-				err,
-				fmt.Sprintf("failed to ensure registry namespace: %v", err),
-				map[string]any{"namespace": "registry", "component": "analytics"},
-			)
-		}
+	parallelDeps, err := prepareParallelImagePublishDeps(logger, usingExternalRegistry, deps, "analytics")
+	if err != nil {
+		return AnalyticsImageSet{}, err
 	}
 
 	type analyticsResult struct {
@@ -759,7 +690,7 @@ func prepareAnalyticsImagesParallel(logger *zap.Logger, extRegistry *config.Exte
 		component := component
 		go func() {
 			defer wg.Done()
-			finalImage, err := buildAndPublishAnalyticsComponent(logger, extRegistry, usingExternalRegistry, testMode, deps, component)
+			finalImage, err := buildAndPublishAnalyticsComponent(logger, extRegistry, usingExternalRegistry, testMode, parallelDeps, component)
 			results <- analyticsResult{repository: component.Repository, image: finalImage, err: err}
 		}()
 	}
@@ -771,16 +702,7 @@ func prepareAnalyticsImagesParallel(logger *zap.Logger, extRegistry *config.Exte
 		if result.err != nil {
 			return AnalyticsImageSet{}, result.err
 		}
-		switch result.repository {
-		case "mcp-sentinel-ingest":
-			images.Ingest = result.image
-		case "mcp-sentinel-api":
-			images.API = result.image
-		case "mcp-sentinel-processor":
-			images.Processor = result.image
-		case "mcp-sentinel-ui":
-			images.UI = result.image
-		}
+		assignAnalyticsImage(&images, result.repository, result.image)
 	}
 
 	return images, nil
@@ -818,6 +740,9 @@ func buildAndPublishAnalyticsComponent(logger *zap.Logger, extRegistry *config.E
 	} else {
 		core.Info(fmt.Sprintf("Pushing analytics %s image to internal registry", component.Name))
 	}
+	if err := ensureRegistryNamespaceForImagePush(deps, component.Name); err != nil {
+		return "", err
+	}
 	internalRegistryURL := deps.ResolvePlatformRegistryURL(logger)
 	_, imageTag := ref.SplitImage(image)
 	if imageTag == "" {
@@ -833,6 +758,45 @@ func buildAndPublishAnalyticsComponent(logger *zap.Logger, extRegistry *config.E
 		)
 	}
 	return internalImage, nil
+}
+
+func prepareParallelImagePublishDeps(logger *zap.Logger, usingExternalRegistry bool, deps SetupDeps, component string) (SetupDeps, error) {
+	if usingExternalRegistry {
+		return deps, nil
+	}
+	if err := ensureRegistryNamespaceForImagePush(deps, component); err != nil {
+		return SetupDeps{}, err
+	}
+	internalRegistryURL := deps.ResolvePlatformRegistryURL(logger)
+	parallelDeps := deps
+	parallelDeps.EnsureNamespace = func(string) error { return nil }
+	parallelDeps.ResolvePlatformRegistryURL = func(*zap.Logger) string { return internalRegistryURL }
+	return parallelDeps, nil
+}
+
+func ensureRegistryNamespaceForImagePush(deps SetupDeps, component string) error {
+	if err := deps.EnsureNamespace("registry"); err != nil {
+		return core.WrapWithSentinelAndContext(
+			core.ErrEnsureRegistryNamespaceFailed,
+			err,
+			fmt.Sprintf("failed to ensure registry namespace: %v", err),
+			map[string]any{"namespace": "registry", "component": component},
+		)
+	}
+	return nil
+}
+
+func assignAnalyticsImage(images *AnalyticsImageSet, repository, image string) {
+	switch repository {
+	case "mcp-sentinel-ingest":
+		images.Ingest = image
+	case "mcp-sentinel-api":
+		images.API = image
+	case "mcp-sentinel-processor":
+		images.Processor = image
+	case "mcp-sentinel-ui":
+		images.UI = image
+	}
 }
 
 func deployAnalyticsStepCmd(logger *zap.Logger, images AnalyticsImageSet, storageMode, platformMode string, deps SetupDeps) error {

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -448,8 +449,49 @@ func setupRegistryStep(logger *zap.Logger, extRegistry *config.ExternalRegistryC
 	return nil
 }
 
-func prepareDeploymentImages(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode bool, deps SetupDeps) (string, string, error) {
+func prepareDeploymentImages(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode, parallelBuilds bool, deps SetupDeps) (string, string, error) {
 	core.Step("Step 5: Publish runtime images")
+
+	if parallelBuilds {
+		core.Info("Parallel image publishing enabled for setup runtime images")
+
+		type imageResult struct {
+			kind  string
+			image string
+			err   error
+		}
+		results := make(chan imageResult, 2)
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			image, err := prepareOperatorImage(logger, extRegistry, usingExternalRegistry, testMode, deps)
+			results <- imageResult{kind: "operator", image: image, err: err}
+		}()
+		go func() {
+			defer wg.Done()
+			image, err := prepareGatewayProxyImage(logger, extRegistry, usingExternalRegistry, testMode, deps)
+			results <- imageResult{kind: "gateway", image: image, err: err}
+		}()
+
+		wg.Wait()
+		close(results)
+
+		var operatorImage, gatewayProxyImage string
+		for result := range results {
+			if result.err != nil {
+				return "", "", result.err
+			}
+			switch result.kind {
+			case "operator":
+				operatorImage = result.image
+			case "gateway":
+				gatewayProxyImage = result.image
+			}
+		}
+		return operatorImage, gatewayProxyImage, nil
+	}
 
 	operatorImage, err := prepareOperatorImage(logger, extRegistry, usingExternalRegistry, testMode, deps)
 	if err != nil {
@@ -607,7 +649,7 @@ func prepareGatewayProxyImage(logger *zap.Logger, extRegistry *config.ExternalRe
 	return internalGatewayProxyImage, nil
 }
 
-func prepareAnalyticsImages(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode bool, deps SetupDeps) (AnalyticsImageSet, error) {
+func prepareAnalyticsImages(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode, parallelBuilds bool, deps SetupDeps) (AnalyticsImageSet, error) {
 	core.Step("Step 5a: Publish analytics images")
 
 	images := AnalyticsImageSet{
@@ -615,6 +657,11 @@ func prepareAnalyticsImages(logger *zap.Logger, extRegistry *config.ExternalRegi
 		API:       analyticsImageFor(extRegistry, analyticsComponents[1].Repository),
 		Processor: analyticsImageFor(extRegistry, analyticsComponents[2].Repository),
 		UI:        analyticsImageFor(extRegistry, analyticsComponents[3].Repository),
+	}
+
+	if parallelBuilds {
+		core.Info("Parallel image publishing enabled for setup analytics images")
+		return prepareAnalyticsImagesParallel(logger, extRegistry, usingExternalRegistry, testMode, deps, images)
 	}
 
 	for _, component := range analyticsComponents {
@@ -684,6 +731,108 @@ func prepareAnalyticsImages(logger *zap.Logger, extRegistry *config.ExternalRegi
 	}
 
 	return images, nil
+}
+
+func prepareAnalyticsImagesParallel(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode bool, deps SetupDeps, images AnalyticsImageSet) (AnalyticsImageSet, error) {
+	if !usingExternalRegistry {
+		if err := deps.EnsureNamespace("registry"); err != nil {
+			return AnalyticsImageSet{}, core.WrapWithSentinelAndContext(
+				core.ErrEnsureRegistryNamespaceFailed,
+				err,
+				fmt.Sprintf("failed to ensure registry namespace: %v", err),
+				map[string]any{"namespace": "registry", "component": "analytics"},
+			)
+		}
+	}
+
+	type analyticsResult struct {
+		repository string
+		image      string
+		err        error
+	}
+
+	results := make(chan analyticsResult, len(analyticsComponents))
+	var wg sync.WaitGroup
+	wg.Add(len(analyticsComponents))
+
+	for _, component := range analyticsComponents {
+		component := component
+		go func() {
+			defer wg.Done()
+			finalImage, err := buildAndPublishAnalyticsComponent(logger, extRegistry, usingExternalRegistry, testMode, deps, component)
+			results <- analyticsResult{repository: component.Repository, image: finalImage, err: err}
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		if result.err != nil {
+			return AnalyticsImageSet{}, result.err
+		}
+		switch result.repository {
+		case "mcp-sentinel-ingest":
+			images.Ingest = result.image
+		case "mcp-sentinel-api":
+			images.API = result.image
+		case "mcp-sentinel-processor":
+			images.Processor = result.image
+		case "mcp-sentinel-ui":
+			images.UI = result.image
+		}
+	}
+
+	return images, nil
+}
+
+func buildAndPublishAnalyticsComponent(logger *zap.Logger, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry, testMode bool, deps SetupDeps, component analyticsComponent) (string, error) {
+	image := analyticsImageFor(extRegistry, component.Repository)
+	if testMode {
+		core.Info(fmt.Sprintf("Test mode: building analytics %s image: %s", component.Name, image))
+	} else {
+		core.Info(fmt.Sprintf("Building analytics %s image: %s", component.Name, image))
+	}
+	if err := deps.BuildAnalyticsImage(image, component.Dockerfile, component.BuildContext); err != nil {
+		return "", core.WrapWithSentinelAndContext(
+			core.ErrBuildImageFailed,
+			err,
+			fmt.Sprintf("failed to build analytics %s image %q: %v", component.Name, image, err),
+			map[string]any{"image": image, "component": component.Name},
+		)
+	}
+	if usingExternalRegistry {
+		if testMode {
+			core.Info(fmt.Sprintf("Test mode: pushing analytics %s image to external registry", component.Name))
+		} else {
+			core.Info(fmt.Sprintf("Pushing analytics %s image to external registry", component.Name))
+		}
+		if err := deps.PushAnalyticsImage(image); err != nil {
+			core.Warn(fmt.Sprintf("Could not push analytics %s image to external registry: %v", component.Name, err))
+		}
+		return image, nil
+	}
+
+	if testMode {
+		core.Info(fmt.Sprintf("Test mode: pushing analytics %s image to internal registry", component.Name))
+	} else {
+		core.Info(fmt.Sprintf("Pushing analytics %s image to internal registry", component.Name))
+	}
+	internalRegistryURL := deps.ResolvePlatformRegistryURL(logger)
+	_, imageTag := ref.SplitImage(image)
+	if imageTag == "" {
+		imageTag = setupImageTag()
+	}
+	internalImage := fmt.Sprintf("%s/%s:%s", internalRegistryURL, component.Repository, imageTag)
+	if err := deps.PushAnalyticsImageToInternal(logger, image, internalImage, "registry"); err != nil {
+		return "", core.WrapWithSentinelAndContext(
+			core.ErrPushImageInClusterFailed,
+			err,
+			fmt.Sprintf("failed to push analytics %s image %q to internal registry %q: %v", component.Name, image, internalImage, err),
+			map[string]any{"source_image": image, "target_image": internalImage, "component": component.Name},
+		)
+	}
+	return internalImage, nil
 }
 
 func deployAnalyticsStepCmd(logger *zap.Logger, images AnalyticsImageSet, storageMode, platformMode string, deps SetupDeps) error {

--- a/internal/cli/setup/setup.go
+++ b/internal/cli/setup/setup.go
@@ -36,6 +36,7 @@ func New(runtime *core.Runtime, clusterMgr ClusterManagerAPI) *cobra.Command {
 	var forceIngressInstall bool
 	var tlsEnabled bool
 	var testMode bool
+	var parallelBuilds bool
 	var strictProd bool
 	var withoutAnalytics bool
 	var operatorMetricsAddr string
@@ -108,6 +109,7 @@ will use to push and pull container images.`,
 				ForceIngressInstall:    forceIngressInstall,
 				TLSEnabled:             tlsEnabled,
 				TestMode:               testMode,
+				ParallelBuilds:         parallelBuilds,
 				StrictProd:             strictProd,
 				DeployAnalytics:        !withoutAnalytics,
 				OperatorArgs:           operatorArgs,
@@ -136,6 +138,7 @@ will use to push and pull container images.`,
 	cmd.Flags().BoolVar(&acmeStaging, "acme-staging", false, "Use Let's Encrypt staging CA (also set MCP_ACME_STAGING=1)")
 	cmd.Flags().BoolVar(&skipCertManagerInstall, "skip-cert-manager-install", false, "Do not install cert-manager; require CRDs to already exist")
 	cmd.Flags().BoolVar(&testMode, "test-mode", false, "Test mode for local Kind/dev installs; builds and pushes latest-tag runtime images while relaxing production guardrails")
+	cmd.Flags().BoolVar(&parallelBuilds, "parallel-builds", false, "Build and publish setup images in parallel; keeps cluster, registry, TLS, and rollout sequencing unchanged")
 	cmd.Flags().BoolVar(&strictProd, "strict-prod", false, "Require production-style registry and TLS validation for non-test setup")
 	cmd.Flags().BoolVar(&withoutAnalytics, "without-sentinel", false, "Skip deploying the bundled mcp-sentinel stack")
 	cmd.Flags().BoolVar(&withoutAnalytics, "without-analytics", false, "Deprecated alias for --without-sentinel")

--- a/internal/cli/setup/steps.go
+++ b/internal/cli/setup/steps.go
@@ -94,6 +94,7 @@ func (s operatorImageStep) Run(logger *zap.Logger, deps SetupDeps, ctx *SetupCon
 		ctx.ExternalRegistry,
 		ctx.UsingExternalRegistry,
 		ctx.Plan.TestMode,
+		ctx.Plan.ParallelBuilds,
 		deps,
 	)
 	if err != nil {
@@ -129,6 +130,7 @@ func (s analyticsImageStep) Run(logger *zap.Logger, deps SetupDeps, ctx *SetupCo
 		ctx.ExternalRegistry,
 		ctx.UsingExternalRegistry,
 		ctx.Plan.TestMode,
+		ctx.Plan.ParallelBuilds,
 		deps,
 	)
 	if err != nil {

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -37,7 +37,7 @@ e2e_color_enabled() {
       return 1
       ;;
     auto|"")
-      [[ -t 1 ]]
+      [[ -t 1 || "${GITHUB_ACTIONS:-}" == "true" ]]
       ;;
     *)
       [[ -t 1 ]]
@@ -51,6 +51,7 @@ E2E_COLOR_MCP=""
 E2E_COLOR_POLICY=""
 E2E_COLOR_WARN=""
 E2E_COLOR_DEBUG=""
+E2E_COLOR_SUCCESS=""
 if e2e_color_enabled; then
   E2E_COLOR_RESET=$'\033[0m'
   E2E_COLOR_INFO=$'\033[36m'
@@ -58,6 +59,7 @@ if e2e_color_enabled; then
   E2E_COLOR_POLICY=$'\033[33m'
   E2E_COLOR_WARN=$'\033[31m'
   E2E_COLOR_DEBUG=$'\033[2m'
+  E2E_COLOR_SUCCESS=$'\033[32m'
 fi
 
 log_line() {
@@ -173,12 +175,22 @@ E2E_VALIDATE_SCENARIOS_ONLY="${E2E_VALIDATE_SCENARIOS_ONLY:-0}"
 E2E_KEEP_CLUSTER="${E2E_KEEP_CLUSTER:-0}"
 E2E_CACHE_MODE="${E2E_CACHE_MODE:-0}"
 E2E_IMAGE_PREP_PARALLELISM="${E2E_IMAGE_PREP_PARALLELISM:-3}"
+E2E_LOG_PREVIEW_LINES="${E2E_LOG_PREVIEW_LINES:-4}"
+E2E_LOG_FAILURE_LINES="${E2E_LOG_FAILURE_LINES:-40}"
 if [[ "${E2E_CACHE_MODE}" == "1" ]]; then
   E2E_KEEP_CLUSTER=1
 fi
 
 if ! [[ "${E2E_IMAGE_PREP_PARALLELISM}" =~ ^[0-9]+$ ]] || [[ "${E2E_IMAGE_PREP_PARALLELISM}" -lt 1 ]]; then
   echo "E2E_IMAGE_PREP_PARALLELISM must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "${E2E_LOG_PREVIEW_LINES}" =~ ^[0-9]+$ ]]; then
+  echo "E2E_LOG_PREVIEW_LINES must be zero or a positive integer" >&2
+  exit 1
+fi
+if ! [[ "${E2E_LOG_FAILURE_LINES}" =~ ^[0-9]+$ ]]; then
+  echo "E2E_LOG_FAILURE_LINES must be zero or a positive integer" >&2
   exit 1
 fi
 
@@ -289,6 +301,9 @@ PIDS=()
 PARALLEL_PIDS=()
 PARALLEL_LABELS=()
 PARALLEL_LOGS=()
+PARALLEL_STDOUT_LOGS=()
+PARALLEL_STDERR_LOGS=()
+PARALLEL_STARTED_AT=()
 PARALLEL_FAILED=0
 PARALLEL_SEQ=0
 STAGE_SEQ=0
@@ -1943,11 +1958,99 @@ safe_log_label() {
   printf '%s' "${label}" | tr -c '[:alnum:]_.-' '_'
 }
 
+relative_log_path() {
+  local path="$1"
+  printf '%s' "${path#"${WORKDIR}/"}"
+}
+
+format_duration() {
+  local seconds="$1"
+  local minutes
+  if [[ "${seconds}" -lt 60 ]]; then
+    printf '%ss' "${seconds}"
+    return
+  fi
+  minutes=$((seconds / 60))
+  seconds=$((seconds % 60))
+  printf '%sm%02ss' "${minutes}" "${seconds}"
+}
+
+log_status() {
+  local state="$1"
+  local message="$2"
+  local color="${E2E_COLOR_INFO}"
+  case "${state}" in
+    DONE)
+      color="${E2E_COLOR_SUCCESS}"
+      ;;
+    FAILED|STDERR)
+      color="${E2E_COLOR_WARN}"
+      ;;
+    RUNNING|PLAN)
+      color="${E2E_COLOR_POLICY}"
+      ;;
+    STDOUT)
+      color="${E2E_COLOR_DEBUG}"
+      ;;
+  esac
+  printf '%b%-7s%b %s\n' "${color}" "${state}" "${E2E_COLOR_RESET}" "${message}"
+}
+
+log_status_err() {
+  local state="$1"
+  local message="$2"
+  log_status "${state}" "${message}" >&2
+}
+
+combine_stream_logs() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  local log_file="$3"
+
+  : >"${log_file}"
+  if [[ -s "${stdout_file}" ]]; then
+    {
+      echo "===== stdout ====="
+      cat "${stdout_file}"
+    } >>"${log_file}"
+  fi
+  if [[ -s "${stderr_file}" ]]; then
+    {
+      echo "===== stderr ====="
+      cat "${stderr_file}"
+    } >>"${log_file}"
+  fi
+  return 0
+}
+
+preview_log_stream() {
+  local state="$1"
+  local label="$2"
+  local log_file="$3"
+  local lines="$4"
+  local stream="${5:-stdout}"
+
+  if [[ "${lines}" -eq 0 || ! -s "${log_file}" ]]; then
+    return 0
+  fi
+
+  if [[ "${stream}" == "stderr" ]]; then
+    log_status_err "${state}" "${label}: last ${lines} stderr lines from $(relative_log_path "${log_file}")"
+    tail -n "${lines}" "${log_file}" | sed 's/^/        /' >&2
+  else
+    log_status "${state}" "${label}: last ${lines} stdout lines from $(relative_log_path "${log_file}")"
+    tail -n "${lines}" "${log_file}" | sed 's/^/        /'
+  fi
+}
+
 run_logged_stage() {
   local label="$1"
   local log_file
   local heartbeat_pid=""
   local safe_label
+  local started_at
+  local stdout_file
+  local stderr_file
   local status=0
   shift
 
@@ -1955,30 +2058,38 @@ run_logged_stage() {
   STAGE_SEQ=$((STAGE_SEQ + 1))
   safe_label="$(safe_log_label "${label}")"
   log_file="${STAGE_LOG_DIR}/stage-$(printf '%03d' "${STAGE_SEQ}")-${safe_label}.log"
-  echo "[stage][start] ${label} (log: ${log_file#"${WORKDIR}/"})"
+  stdout_file="${log_file%.log}.stdout.log"
+  stderr_file="${log_file%.log}.stderr.log"
+  started_at="$(date +%s)"
+  log_status "START" "${label} (full log: $(relative_log_path "${log_file}"))"
 
   (
     while true; do
       sleep 30
-      echo "[stage][wait] ${label} still running"
+      log_status "RUNNING" "${label} for $(format_duration "$(( $(date +%s) - started_at ))")"
     done
   ) &
   heartbeat_pid="$!"
   PIDS+=("${heartbeat_pid}")
 
-  if "$@" >"${log_file}" 2>&1; then
+  if "$@" >"${stdout_file}" 2>"${stderr_file}"; then
     kill "${heartbeat_pid}" >/dev/null 2>&1 || true
     wait "${heartbeat_pid}" 2>/dev/null || true
-    echo "[stage][pass] ${label} (log: ${log_file#"${WORKDIR}/"})"
+    combine_stream_logs "${stdout_file}" "${stderr_file}" "${log_file}"
+    log_status "DONE" "${label} in $(format_duration "$(( $(date +%s) - started_at ))") (full log: $(relative_log_path "${log_file}"))"
+    preview_log_stream "STDOUT" "${label}" "${stdout_file}" "${E2E_LOG_PREVIEW_LINES}" stdout
+    preview_log_stream "STDERR" "${label}" "${stderr_file}" "${E2E_LOG_PREVIEW_LINES}" stderr
   else
     status=$?
     kill "${heartbeat_pid}" >/dev/null 2>&1 || true
     wait "${heartbeat_pid}" 2>/dev/null || true
-    echo "[stage][fail] ${label} exited with status ${status}; log follows (${log_file#"${WORKDIR}/"})" >&2
-    if [[ -f "${log_file}" ]]; then
-      sed 's/^/[stage][log] /' "${log_file}" >&2
+    combine_stream_logs "${stdout_file}" "${stderr_file}" "${log_file}"
+    log_status_err "FAILED" "${label} after $(format_duration "$(( $(date +%s) - started_at ))") with exit ${status} (full log: $(relative_log_path "${log_file}"))"
+    if [[ -s "${stdout_file}" || -s "${stderr_file}" ]]; then
+      preview_log_stream "STDOUT" "${label}" "${stdout_file}" "${E2E_LOG_FAILURE_LINES}" stdout
+      preview_log_stream "STDERR" "${label}" "${stderr_file}" "${E2E_LOG_FAILURE_LINES}" stderr
     else
-      echo "[stage][log] no log file found for ${label}" >&2
+      log_status_err "FAILED" "${label}: command produced no captured stdout or stderr"
     fi
     return "${status}"
   fi
@@ -1988,6 +2099,9 @@ parallel_reset() {
   PARALLEL_PIDS=()
   PARALLEL_LABELS=()
   PARALLEL_LOGS=()
+  PARALLEL_STDOUT_LOGS=()
+  PARALLEL_STDERR_LOGS=()
+  PARALLEL_STARTED_AT=()
   PARALLEL_FAILED=0
 }
 
@@ -1995,13 +2109,16 @@ parallel_wait_next() {
   local pid="${PARALLEL_PIDS[0]}"
   local label="${PARALLEL_LABELS[0]}"
   local log_file="${PARALLEL_LOGS[0]}"
+  local stdout_file="${PARALLEL_STDOUT_LOGS[0]}"
+  local stderr_file="${PARALLEL_STDERR_LOGS[0]}"
+  local started_at="${PARALLEL_STARTED_AT[0]}"
   local heartbeat_pid=""
   local status=0
 
   (
     while true; do
       sleep 30
-      echo "[parallel][wait] ${label} still running"
+      log_status "RUNNING" "${label} for $(format_duration "$(( $(date +%s) - started_at ))")"
     done
   ) &
   heartbeat_pid="$!"
@@ -2010,16 +2127,21 @@ parallel_wait_next() {
   if wait "${pid}"; then
     kill "${heartbeat_pid}" >/dev/null 2>&1 || true
     wait "${heartbeat_pid}" 2>/dev/null || true
-    echo "[parallel][pass] ${label} (log: ${log_file#"${WORKDIR}/"})"
+    combine_stream_logs "${stdout_file}" "${stderr_file}" "${log_file}"
+    log_status "DONE" "${label} in $(format_duration "$(( $(date +%s) - started_at ))") (full log: $(relative_log_path "${log_file}"))"
+    preview_log_stream "STDOUT" "${label}" "${stdout_file}" "${E2E_LOG_PREVIEW_LINES}" stdout
+    preview_log_stream "STDERR" "${label}" "${stderr_file}" "${E2E_LOG_PREVIEW_LINES}" stderr
   else
     status=$?
     kill "${heartbeat_pid}" >/dev/null 2>&1 || true
     wait "${heartbeat_pid}" 2>/dev/null || true
-    echo "[parallel][fail] ${label} exited with status ${status}; log follows (${log_file#"${WORKDIR}/"})" >&2
-    if [[ -f "${log_file}" ]]; then
-      sed 's/^/[parallel][log] /' "${log_file}" >&2
+    combine_stream_logs "${stdout_file}" "${stderr_file}" "${log_file}"
+    log_status_err "FAILED" "${label} after $(format_duration "$(( $(date +%s) - started_at ))") with exit ${status} (full log: $(relative_log_path "${log_file}"))"
+    if [[ -s "${stdout_file}" || -s "${stderr_file}" ]]; then
+      preview_log_stream "STDOUT" "${label}" "${stdout_file}" "${E2E_LOG_FAILURE_LINES}" stdout
+      preview_log_stream "STDERR" "${label}" "${stderr_file}" "${E2E_LOG_FAILURE_LINES}" stderr
     else
-      echo "[parallel][log] no log file found for ${label}" >&2
+      log_status_err "FAILED" "${label}: command produced no captured stdout or stderr"
     fi
     PARALLEL_FAILED=1
   fi
@@ -2027,6 +2149,9 @@ parallel_wait_next() {
   PARALLEL_PIDS=("${PARALLEL_PIDS[@]:1}")
   PARALLEL_LABELS=("${PARALLEL_LABELS[@]:1}")
   PARALLEL_LOGS=("${PARALLEL_LOGS[@]:1}")
+  PARALLEL_STDOUT_LOGS=("${PARALLEL_STDOUT_LOGS[@]:1}")
+  PARALLEL_STDERR_LOGS=("${PARALLEL_STDERR_LOGS[@]:1}")
+  PARALLEL_STARTED_AT=("${PARALLEL_STARTED_AT[@]:1}")
 }
 
 parallel_start() {
@@ -2034,6 +2159,8 @@ parallel_start() {
   local label="$2"
   local log_file
   local safe_label
+  local stdout_file
+  local stderr_file
   shift 2
 
   while [[ ${#PARALLEL_PIDS[@]} -ge ${max_parallel} ]]; do
@@ -2044,12 +2171,17 @@ parallel_start() {
   PARALLEL_SEQ=$((PARALLEL_SEQ + 1))
   safe_label="$(safe_log_label "${label}")"
   log_file="${STAGE_LOG_DIR}/parallel-$(printf '%03d' "${PARALLEL_SEQ}")-${safe_label}.log"
-  echo "[parallel][start] ${label} (log: ${log_file#"${WORKDIR}/"})"
-  "$@" >"${log_file}" 2>&1 &
+  stdout_file="${log_file%.log}.stdout.log"
+  stderr_file="${log_file%.log}.stderr.log"
+  log_status "START" "${label} (parallel worker; full log: $(relative_log_path "${log_file}"))"
+  "$@" >"${stdout_file}" 2>"${stderr_file}" &
   local pid="$!"
   PARALLEL_PIDS+=("${pid}")
   PARALLEL_LABELS+=("${label}")
   PARALLEL_LOGS+=("${log_file}")
+  PARALLEL_STDOUT_LOGS+=("${stdout_file}")
+  PARALLEL_STDERR_LOGS+=("${stderr_file}")
+  PARALLEL_STARTED_AT+=("$(date +%s)")
   PIDS+=("${pid}")
 }
 
@@ -2088,15 +2220,45 @@ build_and_publish_image() {
   publish_image_to_local_registry "${image}"
 }
 
+image_build_label() {
+  local image="$1"
+  case "${image}" in
+    docker.io/library/mcp-runtime-operator:*)
+      echo "build operator image (${image})"
+      ;;
+    docker.io/library/mcp-runtime-registry:*)
+      echo "build test registry image (${image})"
+      ;;
+    docker.io/library/mcp-sentinel-mcp-proxy:*)
+      echo "build Sentinel MCP proxy image (${image})"
+      ;;
+    docker.io/library/mcp-sentinel-ingest:*)
+      echo "build Sentinel ingest image (${image})"
+      ;;
+    docker.io/library/mcp-sentinel-api:*)
+      echo "build Sentinel API image (${image})"
+      ;;
+    docker.io/library/mcp-sentinel-processor:*)
+      echo "build Sentinel processor image (${image})"
+      ;;
+    docker.io/library/mcp-sentinel-ui:*)
+      echo "build Sentinel UI image (${image})"
+      ;;
+    *)
+      echo "build image ${image}"
+      ;;
+  esac
+}
+
 build_and_publish_images_parallel() {
-  echo "[image] preparing local images with parallelism ${E2E_IMAGE_PREP_PARALLELISM}"
+  log_status "PLAN" "Building runtime and Sentinel images with ${E2E_IMAGE_PREP_PARALLELISM} parallel workers"
   parallel_reset
   while [[ $# -gt 0 ]]; do
     local image="$1"
     local dockerfile="$2"
     local context_dir="$3"
     shift 3
-    parallel_start "${E2E_IMAGE_PREP_PARALLELISM}" "build ${image}" build_and_publish_image "${image}" "${dockerfile}" "${context_dir}"
+    parallel_start "${E2E_IMAGE_PREP_PARALLELISM}" "$(image_build_label "${image}")" build_and_publish_image "${image}" "${dockerfile}" "${context_dir}"
   done
   parallel_wait_all
 }
@@ -2123,7 +2285,7 @@ mirror_upstream_image() {
 }
 
 mirror_upstream_images_parallel() {
-  echo "[image] mirroring upstream images with parallelism ${E2E_IMAGE_PREP_PARALLELISM}"
+  log_status "PLAN" "Mirroring upstream images into the local registry with ${E2E_IMAGE_PREP_PARALLELISM} parallel workers"
   parallel_reset
   local image
   for image in "$@"; do
@@ -2136,15 +2298,15 @@ wait_core_platform_rollouts() {
   echo "[verify] waiting for core platform components"
   kubectl get namespace mcp-servers mcp-servers-org mcp-servers-public >/dev/null
 
-  parallel_reset
-  parallel_start 3 "rollout registry/deploy/registry" rollout_status_with_logs registry deploy registry 180s
-  parallel_start 3 "rollout mcp-runtime/deploy/mcp-runtime-operator-controller-manager" rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
-  parallel_start 3 "rollout traefik/deploy/traefik" rollout_status_with_logs traefik deploy traefik 180s
-  parallel_start 3 "rollout mcp-sentinel/deploy/mcp-sentinel-api" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
-  parallel_start 3 "rollout mcp-sentinel/deploy/mcp-sentinel-gateway" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-gateway 180s
-  parallel_start 3 "rollout mcp-sentinel/statefulset/tempo" rollout_status_with_logs mcp-sentinel statefulset tempo 180s
-  parallel_start 3 "rollout mcp-sentinel/statefulset/loki" rollout_status_with_logs mcp-sentinel statefulset loki 300s
-  parallel_wait_all
+  # Setup already waits for these workloads. Keep the post-setup sanity check
+  # sequential so transient kubectl watch cancellation does not fail a healthy run.
+  run_logged_stage "verify registry rollout" rollout_status_with_logs registry deploy registry 180s
+  run_logged_stage "verify operator rollout" rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
+  run_logged_stage "verify traefik rollout" rollout_status_with_logs traefik deploy traefik 180s
+  run_logged_stage "verify sentinel api rollout" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
+  run_logged_stage "verify sentinel gateway rollout" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-gateway 180s
+  run_logged_stage "verify tempo rollout" rollout_status_with_logs mcp-sentinel statefulset tempo 180s
+  run_logged_stage "verify loki rollout" rollout_status_with_logs mcp-sentinel statefulset loki 300s
 }
 
 delete_mcp_server_and_wait() {

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -2041,6 +2041,30 @@ mirror_upstream_images_parallel() {
   parallel_wait_all
 }
 
+wait_core_platform_rollouts() {
+  echo "[verify] waiting for core platform components"
+  kubectl get namespace mcp-servers mcp-servers-org mcp-servers-public >/dev/null
+
+  parallel_reset
+  parallel_start 7 "rollout registry/deploy/registry" rollout_status_with_logs registry deploy registry 180s
+  parallel_start 7 "rollout mcp-runtime/deploy/mcp-runtime-operator-controller-manager" rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
+  parallel_start 7 "rollout traefik/deploy/traefik" rollout_status_with_logs traefik deploy traefik 180s
+  parallel_start 7 "rollout mcp-sentinel/deploy/mcp-sentinel-api" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
+  parallel_start 7 "rollout mcp-sentinel/deploy/mcp-sentinel-gateway" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-gateway 180s
+  parallel_start 7 "rollout mcp-sentinel/statefulset/tempo" rollout_status_with_logs mcp-sentinel statefulset tempo 180s
+  parallel_start 7 "rollout mcp-sentinel/statefulset/loki" rollout_status_with_logs mcp-sentinel statefulset loki 300s
+  parallel_wait_all
+}
+
+delete_mcp_server_and_wait() {
+  local server_name="$1"
+  local namespace="$2"
+  local timeout="${3:-120s}"
+
+  ./bin/mcp-runtime server --use-kube delete "${server_name}" --namespace "${namespace}"
+  kubectl wait --for=delete "mcpserver/${server_name}" -n "${namespace}" --timeout="${timeout}" || true
+}
+
 start_local_registry() {
   if docker ps -a --format '{{.Names}}' | grep -qx "${LOCAL_REGISTRY_NAME}"; then
     if cache_mode_enabled; then
@@ -2168,15 +2192,7 @@ else
   ./bin/mcp-runtime setup --test-mode --parallel-builds --platform-mode "${E2E_PLATFORM_MODE}" --ingress-manifest config/ingress/overlays/http
 fi
 
-echo "[verify] waiting for core platform components"
-kubectl get namespace mcp-servers mcp-servers-org mcp-servers-public >/dev/null
-rollout_status_with_logs registry deploy registry 180s
-rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
-rollout_status_with_logs traefik deploy traefik 180s
-rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
-rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-gateway 180s
-rollout_status_with_logs mcp-sentinel statefulset tempo 180s
-rollout_status_with_logs mcp-sentinel statefulset loki 300s
+wait_core_platform_rollouts
 
 echo "[cli] checking platform status commands"
 ./bin/mcp-runtime status
@@ -2407,24 +2423,26 @@ TEMP_CLI_SERVER="${SERVER_NAME}-cli-create"
 kubectl wait --for=delete "mcpserver/${TEMP_CLI_SERVER}" -n mcp-servers --timeout=120s || true
 
 echo "[deploy] deploying official SDK example MCP servers"
-deploy_example_server_via_pipeline \
+parallel_reset
+parallel_start 3 "deploy ${PYTHON_EXAMPLE_SERVER_NAME}" deploy_example_server_via_pipeline \
   "${PYTHON_EXAMPLE_SERVER_NAME}" \
   "${PYTHON_EXAMPLE_SERVER_HOST}" \
   "${PYTHON_EXAMPLE_SERVER_ROUTE}" \
   "${PYTHON_EXAMPLE_SOURCE_DIR}" \
   "${PYTHON_EXAMPLE_WORKDIR}"
-deploy_example_server_via_pipeline \
+parallel_start 3 "deploy ${RUST_EXAMPLE_SERVER_NAME}" deploy_example_server_via_pipeline \
   "${RUST_EXAMPLE_SERVER_NAME}" \
   "${RUST_EXAMPLE_SERVER_HOST}" \
   "${RUST_EXAMPLE_SERVER_ROUTE}" \
   "${RUST_EXAMPLE_SOURCE_DIR}" \
   "${RUST_EXAMPLE_WORKDIR}"
-deploy_example_server_via_pipeline \
+parallel_start 3 "deploy ${GO_EXAMPLE_SERVER_NAME}" deploy_example_server_via_pipeline \
   "${GO_EXAMPLE_SERVER_NAME}" \
   "${GO_EXAMPLE_SERVER_HOST}" \
   "${GO_EXAMPLE_SERVER_ROUTE}" \
   "${GO_EXAMPLE_SOURCE_DIR}" \
   "${GO_EXAMPLE_WORKDIR}"
+parallel_wait_all
 
 echo "[cli] checking server commands"
 
@@ -4811,10 +4829,10 @@ PY
   echo "[multitenancy] cleaning up tenant resources"
   kubectl delete mcpaccessgrant "alice-${MT_TENANT_A}" "bob-${MT_TENANT_B}" -n "${MT_NS}" --ignore-not-found --wait=false >/dev/null
   kubectl delete mcpagentsession "${MT_SESSION_A}" "${MT_SESSION_B}" -n "${MT_NS}" --ignore-not-found --wait=false >/dev/null
-  ./bin/mcp-runtime server --use-kube delete "${MT_TENANT_A}" --namespace "${MT_NS}" >/dev/null
-  ./bin/mcp-runtime server --use-kube delete "${MT_TENANT_B}" --namespace "${MT_NS}" >/dev/null
-  kubectl wait --for=delete "mcpserver/${MT_TENANT_A}" -n "${MT_NS}" --timeout=60s || true
-  kubectl wait --for=delete "mcpserver/${MT_TENANT_B}" -n "${MT_NS}" --timeout=60s || true
+  parallel_reset
+  parallel_start 2 "delete ${MT_TENANT_A}" delete_mcp_server_and_wait "${MT_TENANT_A}" "${MT_NS}" 60s
+  parallel_start 2 "delete ${MT_TENANT_B}" delete_mcp_server_and_wait "${MT_TENANT_B}" "${MT_NS}" 60s
+  parallel_wait_all
 fi
 
 echo "[cli] checking sentinel restart command"
@@ -4824,17 +4842,14 @@ kubectl patch deployment mcp-sentinel-api -n mcp-sentinel --type merge -p '{"spe
 rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
 
 echo "[cli] deleting deployed MCP servers"
+parallel_reset
 if scenario_selected "oauth"; then
-  ./bin/mcp-runtime server --use-kube delete "${OAUTH_SERVER_NAME}" --namespace mcp-servers
-  kubectl wait --for=delete "mcpserver/${OAUTH_SERVER_NAME}" -n mcp-servers --timeout=120s || true
+  parallel_start 5 "delete ${OAUTH_SERVER_NAME}" delete_mcp_server_and_wait "${OAUTH_SERVER_NAME}" mcp-servers 120s
 fi
-./bin/mcp-runtime server --use-kube delete "${PYTHON_EXAMPLE_SERVER_NAME}" --namespace mcp-servers
-kubectl wait --for=delete "mcpserver/${PYTHON_EXAMPLE_SERVER_NAME}" -n mcp-servers --timeout=120s || true
-./bin/mcp-runtime server --use-kube delete "${RUST_EXAMPLE_SERVER_NAME}" --namespace mcp-servers
-kubectl wait --for=delete "mcpserver/${RUST_EXAMPLE_SERVER_NAME}" -n mcp-servers --timeout=120s || true
-./bin/mcp-runtime server --use-kube delete "${GO_EXAMPLE_SERVER_NAME}" --namespace mcp-servers
-kubectl wait --for=delete "mcpserver/${GO_EXAMPLE_SERVER_NAME}" -n mcp-servers --timeout=120s || true
-./bin/mcp-runtime server --use-kube delete "${SERVER_NAME}" --namespace mcp-servers
-kubectl wait --for=delete "mcpserver/${SERVER_NAME}" -n mcp-servers --timeout=120s || true
+parallel_start 5 "delete ${PYTHON_EXAMPLE_SERVER_NAME}" delete_mcp_server_and_wait "${PYTHON_EXAMPLE_SERVER_NAME}" mcp-servers 120s
+parallel_start 5 "delete ${RUST_EXAMPLE_SERVER_NAME}" delete_mcp_server_and_wait "${RUST_EXAMPLE_SERVER_NAME}" mcp-servers 120s
+parallel_start 5 "delete ${GO_EXAMPLE_SERVER_NAME}" delete_mcp_server_and_wait "${GO_EXAMPLE_SERVER_NAME}" mcp-servers 120s
+parallel_start 5 "delete ${SERVER_NAME}" delete_mcp_server_and_wait "${SERVER_NAME}" mcp-servers 120s
+parallel_wait_all
 
 echo "[done] E2E completed successfully"

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -175,6 +175,8 @@ E2E_VALIDATE_SCENARIOS_ONLY="${E2E_VALIDATE_SCENARIOS_ONLY:-0}"
 E2E_KEEP_CLUSTER="${E2E_KEEP_CLUSTER:-0}"
 E2E_CACHE_MODE="${E2E_CACHE_MODE:-0}"
 E2E_IMAGE_PREP_PARALLELISM="${E2E_IMAGE_PREP_PARALLELISM:-3}"
+E2E_IMAGE_MIRROR_PARALLELISM="${E2E_IMAGE_MIRROR_PARALLELISM:-${E2E_IMAGE_PREP_PARALLELISM}}"
+E2E_IMAGE_BUILD_PARALLELISM="${E2E_IMAGE_BUILD_PARALLELISM:-}"
 E2E_LOG_PREVIEW_LINES="${E2E_LOG_PREVIEW_LINES:-4}"
 E2E_LOG_FAILURE_LINES="${E2E_LOG_FAILURE_LINES:-40}"
 if [[ "${E2E_CACHE_MODE}" == "1" ]]; then
@@ -183,6 +185,21 @@ fi
 
 if ! [[ "${E2E_IMAGE_PREP_PARALLELISM}" =~ ^[0-9]+$ ]] || [[ "${E2E_IMAGE_PREP_PARALLELISM}" -lt 1 ]]; then
   echo "E2E_IMAGE_PREP_PARALLELISM must be a positive integer" >&2
+  exit 1
+fi
+if [[ -z "${E2E_IMAGE_BUILD_PARALLELISM}" ]]; then
+  if [[ "${E2E_IMAGE_PREP_PARALLELISM}" -lt 2 ]]; then
+    E2E_IMAGE_BUILD_PARALLELISM="${E2E_IMAGE_PREP_PARALLELISM}"
+  else
+    E2E_IMAGE_BUILD_PARALLELISM=2
+  fi
+fi
+if ! [[ "${E2E_IMAGE_MIRROR_PARALLELISM}" =~ ^[0-9]+$ ]] || [[ "${E2E_IMAGE_MIRROR_PARALLELISM}" -lt 1 ]]; then
+  echo "E2E_IMAGE_MIRROR_PARALLELISM must be a positive integer" >&2
+  exit 1
+fi
+if ! [[ "${E2E_IMAGE_BUILD_PARALLELISM}" =~ ^[0-9]+$ ]] || [[ "${E2E_IMAGE_BUILD_PARALLELISM}" -lt 1 ]]; then
+  echo "E2E_IMAGE_BUILD_PARALLELISM must be a positive integer" >&2
   exit 1
 fi
 if ! [[ "${E2E_LOG_PREVIEW_LINES}" =~ ^[0-9]+$ ]]; then
@@ -2167,6 +2184,9 @@ parallel_start() {
 
   while [[ ${#PARALLEL_PIDS[@]} -ge ${max_parallel} ]]; do
     parallel_wait_next
+    if [[ "${PARALLEL_FAILED}" -ne 0 ]]; then
+      return 1
+    fi
   done
 
   mkdir -p "${STAGE_LOG_DIR}"
@@ -2253,16 +2273,26 @@ image_build_label() {
 }
 
 build_and_publish_images_parallel() {
-  log_status "PLAN" "Building runtime and Sentinel images with ${E2E_IMAGE_PREP_PARALLELISM} parallel workers"
+  local start_failed=0
+
+  log_status "PLAN" "Building runtime and Sentinel images with ${E2E_IMAGE_BUILD_PARALLELISM} parallel workers"
   parallel_reset
   while [[ $# -gt 0 ]]; do
     local image="$1"
     local dockerfile="$2"
     local context_dir="$3"
     shift 3
-    parallel_start "${E2E_IMAGE_PREP_PARALLELISM}" "$(image_build_label "${image}")" build_and_publish_image "${image}" "${dockerfile}" "${context_dir}"
+    if ! parallel_start "${E2E_IMAGE_BUILD_PARALLELISM}" "$(image_build_label "${image}")" build_and_publish_image "${image}" "${dockerfile}" "${context_dir}"; then
+      start_failed=1
+      break
+    fi
   done
-  parallel_wait_all
+  if ! parallel_wait_all; then
+    return 1
+  fi
+  if [[ "${start_failed}" -ne 0 ]]; then
+    return 1
+  fi
 }
 
 mirror_upstream_image() {
@@ -2287,13 +2317,23 @@ mirror_upstream_image() {
 }
 
 mirror_upstream_images_parallel() {
-  log_status "PLAN" "Mirroring upstream images into the local registry with ${E2E_IMAGE_PREP_PARALLELISM} parallel workers"
+  local start_failed=0
+
+  log_status "PLAN" "Mirroring upstream images into the local registry with ${E2E_IMAGE_MIRROR_PARALLELISM} parallel workers"
   parallel_reset
   local image
   for image in "$@"; do
-    parallel_start "${E2E_IMAGE_PREP_PARALLELISM}" "mirror ${image}" mirror_upstream_image "${image}"
+    if ! parallel_start "${E2E_IMAGE_MIRROR_PARALLELISM}" "mirror ${image}" mirror_upstream_image "${image}"; then
+      start_failed=1
+      break
+    fi
   done
-  parallel_wait_all
+  if ! parallel_wait_all; then
+    return 1
+  fi
+  if [[ "${start_failed}" -ne 0 ]]; then
+    return 1
+  fi
 }
 
 wait_core_platform_rollouts() {

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -171,8 +171,14 @@ E2E_PLATFORM_MODE="${E2E_PLATFORM_MODE//[[:space:]]/}"
 E2E_VALIDATE_SCENARIOS_ONLY="${E2E_VALIDATE_SCENARIOS_ONLY:-0}"
 E2E_KEEP_CLUSTER="${E2E_KEEP_CLUSTER:-0}"
 E2E_CACHE_MODE="${E2E_CACHE_MODE:-0}"
+E2E_IMAGE_PREP_PARALLELISM="${E2E_IMAGE_PREP_PARALLELISM:-3}"
 if [[ "${E2E_CACHE_MODE}" == "1" ]]; then
   E2E_KEEP_CLUSTER=1
+fi
+
+if ! [[ "${E2E_IMAGE_PREP_PARALLELISM}" =~ ^[0-9]+$ ]] || [[ "${E2E_IMAGE_PREP_PARALLELISM}" -lt 1 ]]; then
+  echo "E2E_IMAGE_PREP_PARALLELISM must be a positive integer" >&2
+  exit 1
 fi
 
 IFS=',' read -r -a E2E_SCENARIO_LIST <<< "${E2E_SCENARIOS}"
@@ -278,6 +284,9 @@ WORKDIR="$(mktemp -d)"
 KIND_CONFIG="$(mktemp)"
 ORIG_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
 PIDS=()
+PARALLEL_PIDS=()
+PARALLEL_LABELS=()
+PARALLEL_FAILED=0
 
 cleanup() {
   if [[ -n "${E2E_ARTIFACT_DIR}" ]]; then
@@ -1913,6 +1922,56 @@ run_with_retry() {
   return "${exit_code}"
 }
 
+parallel_reset() {
+  PARALLEL_PIDS=()
+  PARALLEL_LABELS=()
+  PARALLEL_FAILED=0
+}
+
+parallel_wait_next() {
+  local pid="${PARALLEL_PIDS[0]}"
+  local label="${PARALLEL_LABELS[0]}"
+  local status=0
+
+  if wait "${pid}"; then
+    echo "[parallel][pass] ${label}"
+  else
+    status=$?
+    echo "[parallel][fail] ${label} exited with status ${status}" >&2
+    PARALLEL_FAILED=1
+  fi
+
+  PARALLEL_PIDS=("${PARALLEL_PIDS[@]:1}")
+  PARALLEL_LABELS=("${PARALLEL_LABELS[@]:1}")
+}
+
+parallel_start() {
+  local max_parallel="$1"
+  local label="$2"
+  shift 2
+
+  while [[ ${#PARALLEL_PIDS[@]} -ge ${max_parallel} ]]; do
+    parallel_wait_next
+  done
+
+  echo "[parallel][start] ${label}"
+  "$@" &
+  local pid="$!"
+  PARALLEL_PIDS+=("${pid}")
+  PARALLEL_LABELS+=("${label}")
+  PIDS+=("${pid}")
+}
+
+parallel_wait_all() {
+  while [[ ${#PARALLEL_PIDS[@]} -gt 0 ]]; do
+    parallel_wait_next
+  done
+
+  if [[ "${PARALLEL_FAILED}" -ne 0 ]]; then
+    return 1
+  fi
+}
+
 publish_image_to_local_registry() {
   local image="$1"
   local target
@@ -1938,6 +1997,19 @@ build_and_publish_image() {
   publish_image_to_local_registry "${image}"
 }
 
+build_and_publish_images_parallel() {
+  echo "[image] preparing local images with parallelism ${E2E_IMAGE_PREP_PARALLELISM}"
+  parallel_reset
+  while [[ $# -gt 0 ]]; do
+    local image="$1"
+    local dockerfile="$2"
+    local context_dir="$3"
+    shift 3
+    parallel_start "${E2E_IMAGE_PREP_PARALLELISM}" "build ${image}" build_and_publish_image "${image}" "${dockerfile}" "${context_dir}"
+  done
+  parallel_wait_all
+}
+
 mirror_upstream_image() {
   local image="$1"
   local target
@@ -1957,6 +2029,16 @@ mirror_upstream_image() {
     run_with_retry "docker pull ${image}" docker pull "${image}"
   fi
   publish_image_to_local_registry "${image}"
+}
+
+mirror_upstream_images_parallel() {
+  echo "[image] mirroring upstream images with parallelism ${E2E_IMAGE_PREP_PARALLELISM}"
+  parallel_reset
+  local image
+  for image in "$@"; do
+    parallel_start "${E2E_IMAGE_PREP_PARALLELISM}" "mirror ${image}" mirror_upstream_image "${image}"
+  done
+  parallel_wait_all
 }
 
 start_local_registry() {
@@ -2050,26 +2132,28 @@ if platform_cache_ready; then
   PLATFORM_CACHE_READY=1
   echo "[cache] reusing ready platform in cluster ${CLUSTER_NAME}"
 else
-  mirror_upstream_image "registry:2.8.3"
-  mirror_upstream_image "traefik:v2.10"
-  mirror_upstream_image "traefik:v3.0"
-  mirror_upstream_image "clickhouse/clickhouse-server:23.8"
-  mirror_upstream_image "confluentinc/cp-zookeeper:7.5.1"
-  mirror_upstream_image "confluentinc/cp-kafka:7.5.1"
-  mirror_upstream_image "prom/prometheus:v2.49.1"
-  mirror_upstream_image "otel/opentelemetry-collector:0.92.0"
-  mirror_upstream_image "grafana/tempo:2.3.1"
-  mirror_upstream_image "grafana/loki:2.9.4"
-  mirror_upstream_image "grafana/promtail:2.9.4"
-  mirror_upstream_image "grafana/grafana:10.2.3"
-  mirror_upstream_image "nginx:1.27-alpine"
-  build_and_publish_image "docker.io/library/mcp-runtime-operator:latest" "Dockerfile.operator" "."
-  build_and_publish_image "${TEST_MODE_REGISTRY_IMAGE}" "test/e2e/registry.Dockerfile" "."
-  build_and_publish_image "docker.io/library/mcp-sentinel-mcp-proxy:latest" "${SENTINEL_ROOT}/services/mcp-proxy/Dockerfile" "${SENTINEL_ROOT}"
-  build_and_publish_image "docker.io/library/mcp-sentinel-ingest:latest" "${SENTINEL_ROOT}/services/ingest/Dockerfile" "${SENTINEL_ROOT}"
-  build_and_publish_image "docker.io/library/mcp-sentinel-api:latest" "${SENTINEL_ROOT}/services/api/Dockerfile" "${SENTINEL_ROOT}"
-  build_and_publish_image "docker.io/library/mcp-sentinel-processor:latest" "${SENTINEL_ROOT}/services/processor/Dockerfile" "${SENTINEL_ROOT}"
-  build_and_publish_image "docker.io/library/mcp-sentinel-ui:latest" "${SENTINEL_ROOT}/services/ui/Dockerfile" "${SENTINEL_ROOT}"
+  mirror_upstream_images_parallel \
+    "registry:2.8.3" \
+    "traefik:v2.10" \
+    "traefik:v3.0" \
+    "clickhouse/clickhouse-server:23.8" \
+    "confluentinc/cp-zookeeper:7.5.1" \
+    "confluentinc/cp-kafka:7.5.1" \
+    "prom/prometheus:v2.49.1" \
+    "otel/opentelemetry-collector:0.92.0" \
+    "grafana/tempo:2.3.1" \
+    "grafana/loki:2.9.4" \
+    "grafana/promtail:2.9.4" \
+    "grafana/grafana:10.2.3" \
+    "nginx:1.27-alpine"
+  build_and_publish_images_parallel \
+    "docker.io/library/mcp-runtime-operator:latest" "Dockerfile.operator" "." \
+    "${TEST_MODE_REGISTRY_IMAGE}" "test/e2e/registry.Dockerfile" "." \
+    "docker.io/library/mcp-sentinel-mcp-proxy:latest" "${SENTINEL_ROOT}/services/mcp-proxy/Dockerfile" "${SENTINEL_ROOT}" \
+    "docker.io/library/mcp-sentinel-ingest:latest" "${SENTINEL_ROOT}/services/ingest/Dockerfile" "${SENTINEL_ROOT}" \
+    "docker.io/library/mcp-sentinel-api:latest" "${SENTINEL_ROOT}/services/api/Dockerfile" "${SENTINEL_ROOT}" \
+    "docker.io/library/mcp-sentinel-processor:latest" "${SENTINEL_ROOT}/services/processor/Dockerfile" "${SENTINEL_ROOT}" \
+    "docker.io/library/mcp-sentinel-ui:latest" "${SENTINEL_ROOT}/services/ui/Dockerfile" "${SENTINEL_ROOT}"
 fi
 
 export MCP_SETUP_WAIT_TIMEOUT="${MCP_SETUP_WAIT_TIMEOUT:-900}"
@@ -2081,7 +2165,7 @@ if [[ "${PLATFORM_CACHE_READY}" == "1" ]]; then
 else
   echo "[setup] running platform setup in test mode (platform mode: ${E2E_PLATFORM_MODE})"
   MCP_RUNTIME_REGISTRY_IMAGE_OVERRIDE="${TEST_MODE_REGISTRY_IMAGE}" \
-  ./bin/mcp-runtime setup --test-mode --platform-mode "${E2E_PLATFORM_MODE}" --ingress-manifest config/ingress/overlays/http
+  ./bin/mcp-runtime setup --test-mode --parallel-builds --platform-mode "${E2E_PLATFORM_MODE}" --ingress-manifest config/ingress/overlays/http
 fi
 
 echo "[verify] waiting for core platform components"

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -2137,13 +2137,13 @@ wait_core_platform_rollouts() {
   kubectl get namespace mcp-servers mcp-servers-org mcp-servers-public >/dev/null
 
   parallel_reset
-  parallel_start 7 "rollout registry/deploy/registry" rollout_status_with_logs registry deploy registry 180s
-  parallel_start 7 "rollout mcp-runtime/deploy/mcp-runtime-operator-controller-manager" rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
-  parallel_start 7 "rollout traefik/deploy/traefik" rollout_status_with_logs traefik deploy traefik 180s
-  parallel_start 7 "rollout mcp-sentinel/deploy/mcp-sentinel-api" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
-  parallel_start 7 "rollout mcp-sentinel/deploy/mcp-sentinel-gateway" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-gateway 180s
-  parallel_start 7 "rollout mcp-sentinel/statefulset/tempo" rollout_status_with_logs mcp-sentinel statefulset tempo 180s
-  parallel_start 7 "rollout mcp-sentinel/statefulset/loki" rollout_status_with_logs mcp-sentinel statefulset loki 300s
+  parallel_start 3 "rollout registry/deploy/registry" rollout_status_with_logs registry deploy registry 180s
+  parallel_start 3 "rollout mcp-runtime/deploy/mcp-runtime-operator-controller-manager" rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
+  parallel_start 3 "rollout traefik/deploy/traefik" rollout_status_with_logs traefik deploy traefik 180s
+  parallel_start 3 "rollout mcp-sentinel/deploy/mcp-sentinel-api" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
+  parallel_start 3 "rollout mcp-sentinel/deploy/mcp-sentinel-gateway" rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-gateway 180s
+  parallel_start 3 "rollout mcp-sentinel/statefulset/tempo" rollout_status_with_logs mcp-sentinel statefulset tempo 180s
+  parallel_start 3 "rollout mcp-sentinel/statefulset/loki" rollout_status_with_logs mcp-sentinel statefulset loki 300s
   parallel_wait_all
 }
 

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -281,6 +281,7 @@ fi
 git config --global --add safe.directory "${PROJECT_ROOT}" >/dev/null 2>&1 || true
 
 WORKDIR="$(mktemp -d)"
+STAGE_LOG_DIR="${WORKDIR}/stage-logs"
 KIND_CONFIG="$(mktemp)"
 ORIG_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
 PIDS=()
@@ -289,6 +290,7 @@ PARALLEL_LABELS=()
 PARALLEL_LOGS=()
 PARALLEL_FAILED=0
 PARALLEL_SEQ=0
+STAGE_SEQ=0
 
 cleanup() {
   if [[ -n "${E2E_ARTIFACT_DIR}" ]]; then
@@ -1924,22 +1926,37 @@ run_with_retry() {
   return "${exit_code}"
 }
 
+safe_log_label() {
+  local label="$1"
+  printf '%s' "${label}" | tr -c '[:alnum:]_.-' '_'
+}
+
+run_logged_stage() {
+  local label="$1"
+  local log_file
+  local safe_label
+  local status=0
+  shift
+
+  mkdir -p "${STAGE_LOG_DIR}"
+  STAGE_SEQ=$((STAGE_SEQ + 1))
+  safe_label="$(safe_log_label "${label}")"
+  log_file="${STAGE_LOG_DIR}/$(printf '%03d' "${STAGE_SEQ}")-${safe_label}.log"
+  echo "[stage][start] ${label} (log: ${log_file#"${WORKDIR}/"})"
+  if "$@" > >(tee "${log_file}") 2> >(tee -a "${log_file}" >&2); then
+    echo "[stage][pass] ${label} (log: ${log_file#"${WORKDIR}/"})"
+  else
+    status=$?
+    echo "[stage][fail] ${label} exited with status ${status}; log: ${log_file#"${WORKDIR}/"}" >&2
+    return "${status}"
+  fi
+}
+
 parallel_reset() {
   PARALLEL_PIDS=()
   PARALLEL_LABELS=()
   PARALLEL_LOGS=()
   PARALLEL_FAILED=0
-}
-
-parallel_log_path() {
-  local label="$1"
-  local safe_label
-  local log_dir="${WORKDIR}/parallel-logs"
-
-  mkdir -p "${log_dir}"
-  PARALLEL_SEQ=$((PARALLEL_SEQ + 1))
-  safe_label="$(printf '%s' "${label}" | tr -c '[:alnum:]_.-' '_')"
-  printf '%s/%03d-%s.log' "${log_dir}" "${PARALLEL_SEQ}" "${safe_label}"
 }
 
 parallel_wait_next() {
@@ -1970,13 +1987,18 @@ parallel_start() {
   local max_parallel="$1"
   local label="$2"
   local log_file
+  local log_dir="${WORKDIR}/parallel-logs"
+  local safe_label
   shift 2
 
   while [[ ${#PARALLEL_PIDS[@]} -ge ${max_parallel} ]]; do
     parallel_wait_next
   done
 
-  log_file="$(parallel_log_path "${label}")"
+  mkdir -p "${log_dir}"
+  PARALLEL_SEQ=$((PARALLEL_SEQ + 1))
+  safe_label="$(safe_log_label "${label}")"
+  log_file="${log_dir}/$(printf '%03d' "${PARALLEL_SEQ}")-${safe_label}.log"
   echo "[parallel][start] ${label} (log: ${log_file#"${WORKDIR}/"})"
   "$@" >"${log_file}" 2>&1 &
   local pid="$!"
@@ -2089,6 +2111,16 @@ delete_mcp_server_and_wait() {
   kubectl wait --for=delete "mcpserver/${server_name}" -n "${namespace}" --timeout="${timeout}" || true
 }
 
+deploy_primary_server_manifests() {
+  ./bin/mcp-runtime pipeline generate --file "${METADATA_FILE}" --output "${MANIFEST_DIR}"
+  ./bin/mcp-runtime pipeline deploy --dir "${MANIFEST_DIR}"
+}
+
+deploy_oauth_server_manifests() {
+  ./bin/mcp-runtime pipeline generate --file "${OAUTH_METADATA_FILE}" --output "${OAUTH_MANIFEST_DIR}"
+  ./bin/mcp-runtime pipeline deploy --dir "${OAUTH_MANIFEST_DIR}"
+}
+
 start_local_registry() {
   if docker ps -a --format '{{.Names}}' | grep -qx "${LOCAL_REGISTRY_NAME}"; then
     if cache_mode_enabled; then
@@ -2151,13 +2183,13 @@ containerdConfigPatches:
     endpoint = ["http://127.0.0.1:32000"]
 EOF
 
-start_local_registry
+run_logged_stage "start local registry" start_local_registry
 
 if cache_mode_enabled && kind_cluster_exists; then
   echo "[kind] reusing cluster ${CLUSTER_NAME}"
 else
   echo "[kind] creating cluster ${CLUSTER_NAME}"
-  kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}" --wait 120s
+  run_logged_stage "kind create cluster" kind create cluster --name "${CLUSTER_NAME}" --config "${KIND_CONFIG}" --wait 120s
 fi
 connect_local_registry_to_kind_network
 KUBECONFIG_FILE="/tmp/kubeconfig-kind"
@@ -2168,7 +2200,7 @@ mkdir -p "${HOME}/.kube"
 cp "${KUBECONFIG_FILE}" "${HOME}/.kube/config"
 
 echo "[build] rebuilding CLI"
-GOCACHE="${PROJECT_ROOT}/.gocache" go build -o bin/mcp-runtime ./cmd/mcp-runtime
+run_logged_stage "build CLI" env GOCACHE="${PROJECT_ROOT}/.gocache" go build -o bin/mcp-runtime ./cmd/mcp-runtime
 
 echo "[cli] checking static command output"
 ./bin/mcp-runtime --version >/dev/null
@@ -2212,8 +2244,9 @@ if [[ "${PLATFORM_CACHE_READY}" == "1" ]]; then
   echo "[setup] skipping platform setup because E2E_CACHE_MODE=1 found a ready platform"
 else
   echo "[setup] running platform setup in test mode (platform mode: ${E2E_PLATFORM_MODE})"
-  MCP_RUNTIME_REGISTRY_IMAGE_OVERRIDE="${TEST_MODE_REGISTRY_IMAGE}" \
-  ./bin/mcp-runtime setup --test-mode --parallel-builds --platform-mode "${E2E_PLATFORM_MODE}" --ingress-manifest config/ingress/overlays/http
+  run_logged_stage "setup test mode" \
+    env MCP_RUNTIME_REGISTRY_IMAGE_OVERRIDE="${TEST_MODE_REGISTRY_IMAGE}" \
+    ./bin/mcp-runtime setup --test-mode --parallel-builds --platform-mode "${E2E_PLATFORM_MODE}" --ingress-manifest config/ingress/overlays/http
 fi
 
 wait_core_platform_rollouts
@@ -2271,9 +2304,9 @@ if cache_mode_enabled; then
   rollout_status_with_logs mcp-runtime deploy mcp-runtime-operator-controller-manager 180s
 fi
 if cache_mode_enabled; then
-  run_with_retry "cluster doctor" ./bin/mcp-runtime cluster doctor
+  run_logged_stage "cluster doctor" run_with_retry "cluster doctor" ./bin/mcp-runtime cluster doctor
 else
-  ./bin/mcp-runtime cluster doctor
+  run_logged_stage "cluster doctor" ./bin/mcp-runtime cluster doctor
 fi
 run_cli_allowing_cert_prereq_failure cluster-cert-status ./bin/mcp-runtime cluster cert status
 run_cli_allowing_cert_prereq_failure cluster-cert-apply-dry-run ./bin/mcp-runtime cluster cert apply --dry-run
@@ -2394,19 +2427,18 @@ if pull_cached_image "${SERVER_IMAGE}"; then
   echo "[cache] skipping MCP server image build/push for ${SERVER_IMAGE}"
 else
   echo "[cli] building MCP server image via CLI"
-  ./bin/mcp-runtime server build image "${SERVER_NAME}" \
+  run_logged_stage "build primary MCP server image" ./bin/mcp-runtime server build image "${SERVER_NAME}" \
     --metadata-file "${METADATA_FILE}" \
     --dockerfile "${GO_EXAMPLE_SOURCE_DIR}/Dockerfile" \
     --registry docker.io/library \
     --tag latest \
     --context "${GO_EXAMPLE_SOURCE_DIR}"
 
-  publish_image_to_local_registry "${SERVER_IMAGE}"
+  run_logged_stage "publish primary MCP server image" publish_image_to_local_registry "${SERVER_IMAGE}"
 fi
 
 echo "[cli] generating and deploying MCPServer manifests"
-./bin/mcp-runtime pipeline generate --file "${METADATA_FILE}" --output "${MANIFEST_DIR}"
-./bin/mcp-runtime pipeline deploy --dir "${MANIFEST_DIR}"
+run_logged_stage "deploy primary MCP server manifests" deploy_primary_server_manifests
 
 echo "[deploy] waiting for MCP server rollout"
 wait_for_deployment_exists mcp-servers "${SERVER_NAME}"
@@ -3349,8 +3381,7 @@ servers:
 EOF
 
   echo "[oauth] deploying OAuth-protected MCP server"
-  ./bin/mcp-runtime pipeline generate --file "${OAUTH_METADATA_FILE}" --output "${OAUTH_MANIFEST_DIR}"
-  ./bin/mcp-runtime pipeline deploy --dir "${OAUTH_MANIFEST_DIR}"
+  run_logged_stage "deploy OAuth MCP server manifests" deploy_oauth_server_manifests
   wait_for_deployment_exists mcp-servers "${OAUTH_SERVER_NAME}"
   if ! restart_deployment_pods mcp-servers "${OAUTH_SERVER_NAME}" 180s; then
     echo "[debug] OAuth MCP server rollout failed; collecting diagnostics" >&2

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -1983,13 +1983,13 @@ log_status() {
     DONE)
       color="${E2E_COLOR_SUCCESS}"
       ;;
-    FAILED|STDERR)
+    FAILED)
       color="${E2E_COLOR_WARN}"
       ;;
     RUNNING|PLAN)
       color="${E2E_COLOR_POLICY}"
       ;;
-    STDOUT)
+    STDOUT|STDERR)
       color="${E2E_COLOR_DEBUG}"
       ;;
   esac
@@ -2006,7 +2006,9 @@ combine_stream_logs() {
   local stdout_file="$1"
   local stderr_file="$2"
   local log_file="$3"
+  local log_dir="${log_file%/*}"
 
+  mkdir -p "${log_dir}"
   : >"${log_file}"
   if [[ -s "${stdout_file}" ]]; then
     {

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -286,7 +286,9 @@ ORIG_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
 PIDS=()
 PARALLEL_PIDS=()
 PARALLEL_LABELS=()
+PARALLEL_LOGS=()
 PARALLEL_FAILED=0
+PARALLEL_SEQ=0
 
 cleanup() {
   if [[ -n "${E2E_ARTIFACT_DIR}" ]]; then
@@ -1925,40 +1927,62 @@ run_with_retry() {
 parallel_reset() {
   PARALLEL_PIDS=()
   PARALLEL_LABELS=()
+  PARALLEL_LOGS=()
   PARALLEL_FAILED=0
+}
+
+parallel_log_path() {
+  local label="$1"
+  local safe_label
+  local log_dir="${WORKDIR}/parallel-logs"
+
+  mkdir -p "${log_dir}"
+  PARALLEL_SEQ=$((PARALLEL_SEQ + 1))
+  safe_label="$(printf '%s' "${label}" | tr -c '[:alnum:]_.-' '_')"
+  printf '%s/%03d-%s.log' "${log_dir}" "${PARALLEL_SEQ}" "${safe_label}"
 }
 
 parallel_wait_next() {
   local pid="${PARALLEL_PIDS[0]}"
   local label="${PARALLEL_LABELS[0]}"
+  local log_file="${PARALLEL_LOGS[0]}"
   local status=0
 
   if wait "${pid}"; then
-    echo "[parallel][pass] ${label}"
+    echo "[parallel][pass] ${label} (log: ${log_file#"${WORKDIR}/"})"
   else
     status=$?
-    echo "[parallel][fail] ${label} exited with status ${status}" >&2
+    echo "[parallel][fail] ${label} exited with status ${status}; log follows (${log_file#"${WORKDIR}/"})" >&2
+    if [[ -f "${log_file}" ]]; then
+      sed 's/^/[parallel][log] /' "${log_file}" >&2
+    else
+      echo "[parallel][log] no log file found for ${label}" >&2
+    fi
     PARALLEL_FAILED=1
   fi
 
   PARALLEL_PIDS=("${PARALLEL_PIDS[@]:1}")
   PARALLEL_LABELS=("${PARALLEL_LABELS[@]:1}")
+  PARALLEL_LOGS=("${PARALLEL_LOGS[@]:1}")
 }
 
 parallel_start() {
   local max_parallel="$1"
   local label="$2"
+  local log_file
   shift 2
 
   while [[ ${#PARALLEL_PIDS[@]} -ge ${max_parallel} ]]; do
     parallel_wait_next
   done
 
-  echo "[parallel][start] ${label}"
-  "$@" &
+  log_file="$(parallel_log_path "${label}")"
+  echo "[parallel][start] ${label} (log: ${log_file#"${WORKDIR}/"})"
+  "$@" >"${log_file}" 2>&1 &
   local pid="$!"
   PARALLEL_PIDS+=("${pid}")
   PARALLEL_LABELS+=("${label}")
+  PARALLEL_LOGS+=("${log_file}")
   PIDS+=("${pid}")
 }
 

--- a/test/golden/cli/testdata/mcp-runtime_setup_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_setup_help.golden
@@ -22,6 +22,7 @@ Flags:
       --operator-leader-elect          Override operator leader election when set
       --operator-metrics-addr string   Operator metrics bind address (default: :8080 from manager.yaml)
       --operator-probe-addr string     Operator health probe bind address (default: :8081 from manager.yaml)
+      --parallel-builds                Build and publish setup images in parallel; keeps cluster, registry, TLS, and rollout sequencing unchanged
       --platform-mode string           Platform access model (tenant|org|public). public exposes the catalog without login and lets signed-in users publish to the public preview namespace. (default "tenant")
       --registry-storage string        Registry storage size (default: 20Gi) (default "20Gi")
       --registry-type string           Registry type (docker; harbor coming soon) (default "docker")


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new `--parallel-builds` flag to the `mcp-runtime setup` command, enabling concurrent building and publishing of setup images.

Key changes include:

*   **New CLI Flag**: Adds `--parallel-builds` to the `mcp-runtime setup` command, allowing users to opt into parallel image builds.
*   **Concurrent Image Builds**: Modifies the setup process to build and publish runtime (operator and gateway proxy) and analytics (ingest, API, processor, UI) images concurrently when the `--parallel-builds` flag is used.
*   **Preserved Sequencing**: Ensures that other critical setup steps, such as cluster configuration, registry setup, TLS, and rollout sequencing, remain unchanged and sequential.
*   **Optimized Internal Registry Preparation**: Refactors image preparation logic to ensure that internal registry setup (e.g., ensuring namespaces and resolving registry URLs) is performed only once, even when multiple images are built and pushed in parallel.
*   **Documentation**: Updates the CLI documentation to include the new flag and its functional description.
*   **Test Coverage**: Adds new unit tests to verify the concurrent execution of image builds and the correct handling of internal registry preparation in parallel scenarios.
<!-- kody-pr-summary:end -->