### PR TITLE
fix(ingress): limit default Sentinel gateway routes to localhost

### DIFF
--- a/k8s/10-gateway.yaml
+++ b/k8s/10-gateway.yaml
@@ -545,7 +545,32 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - http:
+    - host: localhost
+      http:
+        paths:
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 3000
+          - path: /prometheus
+            pathType: Prefix
+            backend:
+              service:
+                name: prometheus
+                port:
+                  number: 9090
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-sentinel-ui
+                port:
+                  number: 8082
+    - host: 127.0.0.1
+      http:
         paths:
           - path: /grafana
             pathType: Prefix


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
The `mcp-sentinel-gateway` Ingress resource in `k8s/10-gateway.yaml` has been updated to restrict access to specific routes. Previously, the routes for `/grafana`, `/prometheus`, and the root path `/` (which serves the `mcp-sentinel-ui` service) were configured without a specific host, making them globally accessible.

This change explicitly assigns these routes to the `localhost` host. As a result, Grafana, Prometheus, and the MCP Sentinel UI will now only be accessible when the request's host header is `localhost`, in addition to the existing `127.0.0.1` rule for Grafana. This limits the exposure of these default gateway routes to local access only.
<!-- kody-pr-summary:end -->