### PR TITLE
refactor(agentadapter): share outbound transport and split adapter config

### DIFF
--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -2006,8 +2006,8 @@ type RuntimeTransport struct {
 ```text
 func (t *RuntimeTransport) Client() *http.Client
     Client returns an *http.Client whose Transport is this RuntimeTransport.
-    The stdio shim uses this directly; the reverse proxy uses the underlying
-    round-tripper via Transport field assignment instead.
+    Both the stdio shim and the reverse proxy route outbound requests through
+    this wrapper so auth, OTel, and retry logic lives in one place.
 
 ```
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -1848,13 +1848,21 @@ forward MCP traffic to governed MCP Runtime routes.
 ### Index
 
 - [`Constants`](#agent-adapters-constants)
-- [`func NewHTTPProxyHandler(cfg Config) (http.Handler, error)`](#agent-adapters-func-newhttpproxyhandler-cfg-config-http-handler-error)
-- [`func RunHTTPProxy(ctx context.Context, cfg Config) error`](#agent-adapters-func-runhttpproxy-ctx-context-context-cfg-config-error)
-- [`func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error`](#agent-adapters-func-runstdioshim-ctx-context-context-cfg-config-opts-stdiooptions-error)
-- [`func ValidateConfig(cfg Config) error`](#agent-adapters-func-validateconfig-cfg-config-error)
-- [`type Config struct`](#agent-adapters-type-config-struct)
-- [`func LoadProxyConfigFromEnv() (Config, error)`](#agent-adapters-func-loadproxyconfigfromenv-config-error)
-- [`func LoadShimConfigFromEnv() (Config, error)`](#agent-adapters-func-loadshimconfigfromenv-config-error)
+- [`func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error)`](#agent-adapters-func-newhttpproxyhandler-cfg-proxyconfig-http-handler-error)
+- [`func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error`](#agent-adapters-func-runhttpproxy-ctx-context-context-cfg-proxyconfig-error)
+- [`func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error`](#agent-adapters-func-runstdioshim-ctx-context-context-cfg-shimconfig-opts-stdiooptions-error)
+- [`type Identity struct`](#agent-adapters-type-identity-struct)
+- [`func (id Identity) Apply(headers http.Header)`](#agent-adapters-func-id-identity-apply-headers-http-header)
+- [`type ProxyConfig struct`](#agent-adapters-type-proxyconfig-struct)
+- [`func LoadProxyConfigFromEnv() (ProxyConfig, error)`](#agent-adapters-func-loadproxyconfigfromenv-proxyconfig-error)
+- [`func (cfg ProxyConfig) Validate() error`](#agent-adapters-func-cfg-proxyconfig-validate-error)
+- [`type RuntimeTransport struct`](#agent-adapters-type-runtimetransport-struct)
+- [`func (t *RuntimeTransport) Client() *http.Client`](#agent-adapters-func-t-runtimetransport-client-http-client)
+- [`func (t *RuntimeTransport) CloseIdleConnections()`](#agent-adapters-func-t-runtimetransport-closeidleconnections)
+- [`func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error)`](#agent-adapters-func-t-runtimetransport-roundtrip-req-http-request-http-response-error)
+- [`type ShimConfig struct`](#agent-adapters-type-shimconfig-struct)
+- [`func LoadShimConfigFromEnv() (ShimConfig, error)`](#agent-adapters-func-loadshimconfigfromenv-shimconfig-error)
+- [`func (cfg ShimConfig) Validate() error`](#agent-adapters-func-cfg-shimconfig-validate-error)
 - [`type StdioOptions struct`](#agent-adapters-type-stdiooptions-struct)
 
 <a id="agent-adapters-constants"></a>
@@ -1889,75 +1897,164 @@ const (
 <a id="agent-adapters-functions"></a>
 ### Functions
 
-<a id="agent-adapters-func-newhttpproxyhandler-cfg-config-http-handler-error"></a>
+<a id="agent-adapters-func-newhttpproxyhandler-cfg-proxyconfig-http-handler-error"></a>
 ```text
-func NewHTTPProxyHandler(cfg Config) (http.Handler, error)
+func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error)
     NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic
     to the configured runtime route and injects issued governance identity
     headers.
 
 ```
 
-<a id="agent-adapters-func-runhttpproxy-ctx-context-context-cfg-config-error"></a>
+<a id="agent-adapters-func-runhttpproxy-ctx-context-context-cfg-proxyconfig-error"></a>
 ```text
-func RunHTTPProxy(ctx context.Context, cfg Config) error
+func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error
     RunHTTPProxy serves the local HTTP adapter until the context is cancelled.
 
 ```
 
-<a id="agent-adapters-func-runstdioshim-ctx-context-context-cfg-config-opts-stdiooptions-error"></a>
+<a id="agent-adapters-func-runstdioshim-ctx-context-context-cfg-shimconfig-opts-stdiooptions-error"></a>
 ```text
-func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error
+func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error
     RunStdioShim reads newline-delimited stdio MCP JSON-RPC messages, forwards
     them to the configured Streamable HTTP route, and writes JSON-RPC responses
     back to stdout.
-
-```
-
-<a id="agent-adapters-func-validateconfig-cfg-config-error"></a>
-```text
-func ValidateConfig(cfg Config) error
-    ValidateConfig checks the common adapter invariants without reading process
-    state.
 ```
 
 <a id="agent-adapters-types"></a>
 ### Types
 
-<a id="agent-adapters-type-config-struct"></a>
+<a id="agent-adapters-type-identity-struct"></a>
 ```text
-type Config struct {
+type Identity struct {
+	HumanID   string
+	AgentID   string
+	TeamID    string
+	SessionID string
+}
+    Identity is the issued governance identity that adapters attach to every
+    runtime request. The platform issues these values out-of-band (or,
+    in a later phase, through the adapter session endpoint); the adapter only
+    forwards them.
+
+```
+
+<a id="agent-adapters-func-id-identity-apply-headers-http-header"></a>
+```text
+func (id Identity) Apply(headers http.Header)
+    Apply writes the governance identity onto an outbound request's headers,
+    replacing any caller-supplied values. TeamID is omitted when empty so the
+    gateway sees a missing header (the documented "any team" semantics) rather
+    than an empty value. SessionID is required by ValidateConfig today and is
+    always set; the anonymous-mode flow that may omit it is a Phase 3b change.
+
+```
+
+<a id="agent-adapters-type-proxyconfig-struct"></a>
+```text
+type ProxyConfig struct {
 	RuntimeURL        *url.URL
-	HumanID           string
-	AgentID           string
-	TeamID            string
-	SessionID         string
+	Identity          Identity
+	Transport         *RuntimeTransport
 	HostHeader        string
 	ListenAddr        string
 	ProtocolVersion   string
-	HTTPClient        *http.Client
-	RequestTimeout    time.Duration
 	LogLevel          string
 	LogWriter         io.Writer
 	DisableXForwarded bool
 }
-    Config is the shared configuration for agent-side adapters.
+    ProxyConfig configures the local HTTP reverse-proxy adapter that exposes
+    Streamable HTTP MCP to an agent SDK.
 
 ```
 
-<a id="agent-adapters-func-loadproxyconfigfromenv-config-error"></a>
+<a id="agent-adapters-func-loadproxyconfigfromenv-proxyconfig-error"></a>
 ```text
-func LoadProxyConfigFromEnv() (Config, error)
+func LoadProxyConfigFromEnv() (ProxyConfig, error)
     LoadProxyConfigFromEnv loads HTTP proxy configuration from environment
     variables.
 
 ```
 
-<a id="agent-adapters-func-loadshimconfigfromenv-config-error"></a>
+<a id="agent-adapters-func-cfg-proxyconfig-validate-error"></a>
 ```text
-func LoadShimConfigFromEnv() (Config, error)
+func (cfg ProxyConfig) Validate() error
+    Validate enforces the runtime identity invariants for the HTTP proxy.
+
+```
+
+<a id="agent-adapters-type-runtimetransport-struct"></a>
+```text
+type RuntimeTransport struct {
+	// Base is the underlying round-tripper. nil means http.DefaultTransport
+	// (production); tests can swap in a mock by setting this field.
+	Base http.RoundTripper
+	// Timeout is the per-request timeout applied to the *http.Client wrapper
+	// returned by Client(). Zero means no timeout (matches the previous
+	// "unbounded by default" behavior).
+	Timeout time.Duration
+}
+    RuntimeTransport is the shared outbound HTTP transport used by both the
+    reverse proxy and the stdio shim when forwarding to the runtime. It owns the
+    base round-tripper and the per-request timeout so production gates (mTLS,
+    bearer auth, retries, OTel) get implemented in a single place and behave
+    identically for both adapters.
+
+```
+
+<a id="agent-adapters-func-t-runtimetransport-client-http-client"></a>
+```text
+func (t *RuntimeTransport) Client() *http.Client
+    Client returns an *http.Client whose Transport is this RuntimeTransport.
+    The stdio shim uses this directly; the reverse proxy uses the underlying
+    round-tripper via Transport field assignment instead.
+
+```
+
+<a id="agent-adapters-func-t-runtimetransport-closeidleconnections"></a>
+```text
+func (t *RuntimeTransport) CloseIdleConnections()
+    CloseIdleConnections drains idle connections on the base round-tripper if it
+    supports the optional interface, matching net/http's contract.
+
+```
+
+<a id="agent-adapters-func-t-runtimetransport-roundtrip-req-http-request-http-response-error"></a>
+```text
+func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error)
+    RoundTrip implements http.RoundTripper so the transport can plug directly
+    into httputil.ReverseProxy.Transport.
+
+```
+
+<a id="agent-adapters-type-shimconfig-struct"></a>
+```text
+type ShimConfig struct {
+	RuntimeURL      *url.URL
+	Identity        Identity
+	Transport       *RuntimeTransport
+	HostHeader      string
+	ProtocolVersion string
+	LogLevel        string
+	LogWriter       io.Writer
+}
+    ShimConfig configures the stdio adapter that bridges newline-delimited
+    JSON-RPC MCP traffic to the runtime over HTTP.
+
+```
+
+<a id="agent-adapters-func-loadshimconfigfromenv-shimconfig-error"></a>
+```text
+func LoadShimConfigFromEnv() (ShimConfig, error)
     LoadShimConfigFromEnv loads stdio shim configuration from environment
     variables.
+
+```
+
+<a id="agent-adapters-func-cfg-shimconfig-validate-error"></a>
+```text
+func (cfg ShimConfig) Validate() error
+    Validate enforces the runtime identity invariants for the stdio shim.
 
 ```
 

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -3,7 +3,6 @@ package agentadapter
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -36,104 +35,171 @@ const (
 
 type envLookup func(string) string
 
-// Config is the shared configuration for agent-side adapters.
-type Config struct {
+// ProxyConfig configures the local HTTP reverse-proxy adapter that exposes
+// Streamable HTTP MCP to an agent SDK.
+type ProxyConfig struct {
 	RuntimeURL        *url.URL
-	HumanID           string
-	AgentID           string
-	TeamID            string
-	SessionID         string
+	Identity          Identity
+	Transport         *RuntimeTransport
 	HostHeader        string
 	ListenAddr        string
 	ProtocolVersion   string
-	HTTPClient        *http.Client
-	RequestTimeout    time.Duration
 	LogLevel          string
 	LogWriter         io.Writer
 	DisableXForwarded bool
 }
 
-// LoadProxyConfigFromEnv loads HTTP proxy configuration from environment variables.
-func LoadProxyConfigFromEnv() (Config, error) {
-	return loadConfig(os.Getenv, true)
+// ShimConfig configures the stdio adapter that bridges newline-delimited
+// JSON-RPC MCP traffic to the runtime over HTTP.
+type ShimConfig struct {
+	RuntimeURL      *url.URL
+	Identity        Identity
+	Transport       *RuntimeTransport
+	HostHeader      string
+	ProtocolVersion string
+	LogLevel        string
+	LogWriter       io.Writer
 }
 
-// LoadShimConfigFromEnv loads stdio shim configuration from environment variables.
-func LoadShimConfigFromEnv() (Config, error) {
-	return loadConfig(os.Getenv, false)
-}
+// LoadProxyConfigFromEnv loads HTTP proxy configuration from environment
+// variables.
+func LoadProxyConfigFromEnv() (ProxyConfig, error) { return loadProxyConfig(os.Getenv) }
 
-func loadConfig(lookup envLookup, includeListen bool) (Config, error) {
-	cfg := Config{
-		HumanID:         strings.TrimSpace(lookup(EnvHumanID)),
-		AgentID:         strings.TrimSpace(lookup(EnvAgentID)),
-		TeamID:          strings.TrimSpace(lookup(EnvTeamID)),
-		SessionID:       strings.TrimSpace(lookup(EnvSessionID)),
-		HostHeader:      strings.TrimSpace(lookup(EnvHostHeader)),
-		ProtocolVersion: strings.TrimSpace(lookup(EnvProtocolVersion)),
-		LogLevel:        strings.TrimSpace(lookup(EnvLogLevel)),
-	}
-	if cfg.ProtocolVersion == "" {
-		cfg.ProtocolVersion = DefaultProtocolVersion
-	}
-	if includeListen {
-		cfg.ListenAddr = strings.TrimSpace(lookup(EnvListenAddr))
-		if cfg.ListenAddr == "" {
-			cfg.ListenAddr = DefaultListenAddr
-		}
-	}
+// LoadShimConfigFromEnv loads stdio shim configuration from environment
+// variables.
+func LoadShimConfigFromEnv() (ShimConfig, error) { return loadShimConfig(os.Getenv) }
 
-	rawRuntimeURL := strings.TrimSpace(lookup(EnvRuntimeURL))
-	if rawRuntimeURL != "" {
-		parsed, err := url.Parse(rawRuntimeURL)
-		if err != nil {
-			return Config{}, fmt.Errorf("%s is invalid: %w", EnvRuntimeURL, err)
-		}
-		if parsed.Scheme == "" || parsed.Host == "" {
-			return Config{}, fmt.Errorf("%s must be an absolute HTTP URL", EnvRuntimeURL)
-		}
-		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			return Config{}, fmt.Errorf("%s must use http or https", EnvRuntimeURL)
-		}
-		cfg.RuntimeURL = parsed
+func loadProxyConfig(lookup envLookup) (ProxyConfig, error) {
+	parsed, err := parseSharedEnv(lookup)
+	if err != nil {
+		return ProxyConfig{}, err
 	}
-	if rawSetXForwarded := strings.TrimSpace(lookup(EnvSetXForwarded)); rawSetXForwarded != "" {
-		setXForwarded, err := parseAdapterBool(rawSetXForwarded)
+	cfg := ProxyConfig{
+		RuntimeURL:      parsed.runtimeURL,
+		Identity:        parsed.identity,
+		Transport:       parsed.transport,
+		HostHeader:      parsed.hostHeader,
+		ProtocolVersion: parsed.protocolVersion,
+		LogLevel:        parsed.logLevel,
+		ListenAddr:      strings.TrimSpace(lookup(EnvListenAddr)),
+	}
+	if cfg.ListenAddr == "" {
+		cfg.ListenAddr = DefaultListenAddr
+	}
+	if raw := strings.TrimSpace(lookup(EnvSetXForwarded)); raw != "" {
+		setXForwarded, err := parseAdapterBool(raw)
 		if err != nil {
-			return Config{}, fmt.Errorf("%s is invalid: %w", EnvSetXForwarded, err)
+			return ProxyConfig{}, fmt.Errorf("%s is invalid: %w", EnvSetXForwarded, err)
 		}
 		cfg.DisableXForwarded = !setXForwarded
 	}
-	if rawRequestTimeout := strings.TrimSpace(lookup(EnvRequestTimeout)); rawRequestTimeout != "" {
-		requestTimeout, err := time.ParseDuration(rawRequestTimeout)
-		if err != nil {
-			return Config{}, fmt.Errorf("%s is invalid: %w", EnvRequestTimeout, err)
-		}
-		if requestTimeout <= 0 {
-			return Config{}, fmt.Errorf("%s must be greater than zero", EnvRequestTimeout)
-		}
-		cfg.RequestTimeout = requestTimeout
-	}
-
-	if err := ValidateConfig(cfg); err != nil {
-		return Config{}, err
+	if err := cfg.Validate(); err != nil {
+		return ProxyConfig{}, err
 	}
 	return cfg, nil
 }
 
-// ValidateConfig checks the common adapter invariants without reading process state.
-func ValidateConfig(cfg Config) error {
+func loadShimConfig(lookup envLookup) (ShimConfig, error) {
+	parsed, err := parseSharedEnv(lookup)
+	if err != nil {
+		return ShimConfig{}, err
+	}
+	cfg := ShimConfig{
+		RuntimeURL:      parsed.runtimeURL,
+		Identity:        parsed.identity,
+		Transport:       parsed.transport,
+		HostHeader:      parsed.hostHeader,
+		ProtocolVersion: parsed.protocolVersion,
+		LogLevel:        parsed.logLevel,
+	}
+	if err := cfg.Validate(); err != nil {
+		return ShimConfig{}, err
+	}
+	return cfg, nil
+}
+
+// Validate enforces the runtime identity invariants for the HTTP proxy.
+func (cfg ProxyConfig) Validate() error {
+	return validateRequiredIdentity(cfg.RuntimeURL, cfg.Identity)
+}
+
+// Validate enforces the runtime identity invariants for the stdio shim.
+func (cfg ShimConfig) Validate() error {
+	return validateRequiredIdentity(cfg.RuntimeURL, cfg.Identity)
+}
+
+// transportOrDefault returns the configured transport, allocating a default
+// (no base, no timeout) when the caller did not provide one.
+func (cfg ProxyConfig) transportOrDefault() *RuntimeTransport {
+	if cfg.Transport != nil {
+		return cfg.Transport
+	}
+	return &RuntimeTransport{}
+}
+
+type sharedEnv struct {
+	runtimeURL      *url.URL
+	identity        Identity
+	transport       *RuntimeTransport
+	hostHeader      string
+	protocolVersion string
+	logLevel        string
+}
+
+func parseSharedEnv(lookup envLookup) (sharedEnv, error) {
+	out := sharedEnv{
+		identity: Identity{
+			HumanID:   strings.TrimSpace(lookup(EnvHumanID)),
+			AgentID:   strings.TrimSpace(lookup(EnvAgentID)),
+			TeamID:    strings.TrimSpace(lookup(EnvTeamID)),
+			SessionID: strings.TrimSpace(lookup(EnvSessionID)),
+		},
+		hostHeader:      strings.TrimSpace(lookup(EnvHostHeader)),
+		protocolVersion: strings.TrimSpace(lookup(EnvProtocolVersion)),
+		logLevel:        strings.TrimSpace(lookup(EnvLogLevel)),
+	}
+	if out.protocolVersion == "" {
+		out.protocolVersion = DefaultProtocolVersion
+	}
+
+	if raw := strings.TrimSpace(lookup(EnvRuntimeURL)); raw != "" {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			return sharedEnv{}, fmt.Errorf("%s is invalid: %w", EnvRuntimeURL, err)
+		}
+		if parsed.Scheme == "" || parsed.Host == "" {
+			return sharedEnv{}, fmt.Errorf("%s must be an absolute HTTP URL", EnvRuntimeURL)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return sharedEnv{}, fmt.Errorf("%s must use http or https", EnvRuntimeURL)
+		}
+		out.runtimeURL = parsed
+	}
+	if raw := strings.TrimSpace(lookup(EnvRequestTimeout)); raw != "" {
+		timeout, err := time.ParseDuration(raw)
+		if err != nil {
+			return sharedEnv{}, fmt.Errorf("%s is invalid: %w", EnvRequestTimeout, err)
+		}
+		if timeout <= 0 {
+			return sharedEnv{}, fmt.Errorf("%s must be greater than zero", EnvRequestTimeout)
+		}
+		out.transport = &RuntimeTransport{Timeout: timeout}
+	}
+	return out, nil
+}
+
+func validateRequiredIdentity(runtimeURL *url.URL, id Identity) error {
 	var missing []string
-	if cfg.RuntimeURL == nil {
+	if runtimeURL == nil {
 		missing = append(missing, EnvRuntimeURL)
 	}
-	if strings.TrimSpace(cfg.HumanID) == "" {
+	if strings.TrimSpace(id.HumanID) == "" {
 		missing = append(missing, EnvHumanID)
 	}
-	if strings.TrimSpace(cfg.AgentID) == "" {
+	if strings.TrimSpace(id.AgentID) == "" {
 		missing = append(missing, EnvAgentID)
 	}
-	if strings.TrimSpace(cfg.SessionID) == "" {
+	if strings.TrimSpace(id.SessionID) == "" {
 		missing = append(missing, EnvSessionID)
 	}
 	if len(missing) > 0 {
@@ -159,17 +225,4 @@ func cloneURL(in *url.URL) *url.URL {
 	}
 	out := *in
 	return &out
-}
-
-func applyGovernanceHeaders(headers http.Header, cfg Config) {
-	headers.Del(HumanIDHeader)
-	headers.Del(AgentIDHeader)
-	headers.Del(TeamIDHeader)
-	headers.Del(AgentSessionHeader)
-	headers.Set(HumanIDHeader, cfg.HumanID)
-	headers.Set(AgentIDHeader, cfg.AgentID)
-	if cfg.TeamID != "" {
-		headers.Set(TeamIDHeader, cfg.TeamID)
-	}
-	headers.Set(AgentSessionHeader, cfg.SessionID)
 }

--- a/internal/agentadapter/config_test.go
+++ b/internal/agentadapter/config_test.go
@@ -9,13 +9,13 @@ import (
 func TestLoadProxyConfigRequiresRuntimeIdentityAndSession(t *testing.T) {
 	t.Parallel()
 
-	_, err := loadConfig(func(string) string { return "" }, true)
+	_, err := loadProxyConfig(func(string) string { return "" })
 	if err == nil {
-		t.Fatal("loadConfig() error = nil, want missing environment error")
+		t.Fatal("loadProxyConfig() error = nil, want missing environment error")
 	}
 	for _, name := range []string{EnvRuntimeURL, EnvHumanID, EnvAgentID, EnvSessionID} {
 		if !strings.Contains(err.Error(), name) {
-			t.Fatalf("loadConfig() error = %q, missing %s", err, name)
+			t.Fatalf("loadProxyConfig() error = %q, missing %s", err, name)
 		}
 	}
 }
@@ -29,12 +29,12 @@ func TestLoadShimConfigRejectsNonHTTPRuntimeURL(t *testing.T) {
 		EnvAgentID:    "agent-1",
 		EnvSessionID:  "session-1",
 	}
-	_, err := loadConfig(func(key string) string { return env[key] }, false)
+	_, err := loadShimConfig(func(key string) string { return env[key] })
 	if err == nil {
-		t.Fatal("loadConfig() error = nil, want URL scheme error")
+		t.Fatal("loadShimConfig() error = nil, want URL scheme error")
 	}
 	if !strings.Contains(err.Error(), "must be an absolute HTTP URL") && !strings.Contains(err.Error(), "must use http or https") {
-		t.Fatalf("loadConfig() error = %q, want HTTP URL error", err)
+		t.Fatalf("loadShimConfig() error = %q, want HTTP URL error", err)
 	}
 }
 
@@ -47,9 +47,9 @@ func TestLoadProxyConfigAppliesDefaults(t *testing.T) {
 		EnvAgentID:    "agent-1",
 		EnvSessionID:  "session-1",
 	}
-	cfg, err := loadConfig(func(key string) string { return env[key] }, true)
+	cfg, err := loadProxyConfig(func(key string) string { return env[key] })
 	if err != nil {
-		t.Fatalf("loadConfig() error = %v", err)
+		t.Fatalf("loadProxyConfig() error = %v", err)
 	}
 	if cfg.ListenAddr != DefaultListenAddr {
 		t.Fatalf("ListenAddr = %q, want %q", cfg.ListenAddr, DefaultListenAddr)
@@ -60,15 +60,15 @@ func TestLoadProxyConfigAppliesDefaults(t *testing.T) {
 	if cfg.DisableXForwarded {
 		t.Fatal("DisableXForwarded = true, want default proxy X-Forwarded headers enabled")
 	}
-	if cfg.RequestTimeout != 0 {
-		t.Fatalf("RequestTimeout = %s, want unbounded default", cfg.RequestTimeout)
+	if cfg.Transport != nil {
+		t.Fatalf("Transport = %#v, want nil so adapters get the default RuntimeTransport", cfg.Transport)
 	}
 	if cfg.LogLevel != "" {
 		t.Fatalf("LogLevel = %q, want empty default", cfg.LogLevel)
 	}
 }
 
-func TestLoadShimConfigDoesNotSetDefaultHTTPTimeout(t *testing.T) {
+func TestLoadShimConfigDoesNotSetDefaultTransport(t *testing.T) {
 	t.Parallel()
 
 	env := map[string]string{
@@ -77,12 +77,12 @@ func TestLoadShimConfigDoesNotSetDefaultHTTPTimeout(t *testing.T) {
 		EnvAgentID:    "agent-1",
 		EnvSessionID:  "session-1",
 	}
-	cfg, err := loadConfig(func(key string) string { return env[key] }, false)
+	cfg, err := loadShimConfig(func(key string) string { return env[key] })
 	if err != nil {
-		t.Fatalf("loadConfig() error = %v", err)
+		t.Fatalf("loadShimConfig() error = %v", err)
 	}
-	if cfg.HTTPClient != nil {
-		t.Fatalf("HTTPClient = %#v, want nil so stdio shim uses an unbounded default client", cfg.HTTPClient)
+	if cfg.Transport != nil {
+		t.Fatalf("Transport = %#v, want nil so stdio shim allocates a default RuntimeTransport", cfg.Transport)
 	}
 }
 
@@ -96,12 +96,12 @@ func TestLoadConfigParsesOptionalTeamID(t *testing.T) {
 		EnvTeamID:     "team-acme",
 		EnvSessionID:  "session-1",
 	}
-	cfg, err := loadConfig(func(key string) string { return env[key] }, false)
+	cfg, err := loadShimConfig(func(key string) string { return env[key] })
 	if err != nil {
-		t.Fatalf("loadConfig() error = %v", err)
+		t.Fatalf("loadShimConfig() error = %v", err)
 	}
-	if cfg.TeamID != "team-acme" {
-		t.Fatalf("TeamID = %q, want team-acme", cfg.TeamID)
+	if cfg.Identity.TeamID != "team-acme" {
+		t.Fatalf("Identity.TeamID = %q, want team-acme", cfg.Identity.TeamID)
 	}
 }
 
@@ -114,12 +114,12 @@ func TestLoadConfigTeamIDIsOptional(t *testing.T) {
 		EnvAgentID:    "agent-1",
 		EnvSessionID:  "session-1",
 	}
-	cfg, err := loadConfig(func(key string) string { return env[key] }, false)
+	cfg, err := loadShimConfig(func(key string) string { return env[key] })
 	if err != nil {
-		t.Fatalf("loadConfig() error = %v", err)
+		t.Fatalf("loadShimConfig() error = %v", err)
 	}
-	if cfg.TeamID != "" {
-		t.Fatalf("TeamID = %q, want empty default", cfg.TeamID)
+	if cfg.Identity.TeamID != "" {
+		t.Fatalf("Identity.TeamID = %q, want empty default", cfg.Identity.TeamID)
 	}
 }
 
@@ -135,15 +135,15 @@ func TestLoadConfigParsesOptionalRuntimeControls(t *testing.T) {
 		EnvRequestTimeout: "300s",
 		EnvLogLevel:       "info",
 	}
-	cfg, err := loadConfig(func(key string) string { return env[key] }, true)
+	cfg, err := loadProxyConfig(func(key string) string { return env[key] })
 	if err != nil {
-		t.Fatalf("loadConfig() error = %v", err)
+		t.Fatalf("loadProxyConfig() error = %v", err)
 	}
 	if !cfg.DisableXForwarded {
 		t.Fatal("DisableXForwarded = false, want true when MCP_RUNTIME_SET_XFF=false")
 	}
-	if cfg.RequestTimeout != 300*time.Second {
-		t.Fatalf("RequestTimeout = %s, want 300s", cfg.RequestTimeout)
+	if cfg.Transport == nil || cfg.Transport.Timeout != 300*time.Second {
+		t.Fatalf("Transport.Timeout = %v, want 300s", cfg.Transport)
 	}
 	if cfg.LogLevel != "info" {
 		t.Fatalf("LogLevel = %q, want info", cfg.LogLevel)
@@ -168,6 +168,7 @@ func TestLoadConfigRejectsInvalidRuntimeControls(t *testing.T) {
 		{name: "request timeout", key: EnvRequestTimeout, val: "0s"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			env := map[string]string{}
@@ -175,12 +176,12 @@ func TestLoadConfigRejectsInvalidRuntimeControls(t *testing.T) {
 				env[key] = val
 			}
 			env[tt.key] = tt.val
-			_, err := loadConfig(func(key string) string { return env[key] }, true)
+			_, err := loadProxyConfig(func(key string) string { return env[key] })
 			if err == nil {
-				t.Fatal("loadConfig() error = nil, want invalid runtime control error")
+				t.Fatal("loadProxyConfig() error = nil, want invalid runtime control error")
 			}
 			if !strings.Contains(err.Error(), tt.key) {
-				t.Fatalf("loadConfig() error = %q, want %s", err, tt.key)
+				t.Fatalf("loadProxyConfig() error = %q, want %s", err, tt.key)
 			}
 		})
 	}

--- a/internal/agentadapter/identity.go
+++ b/internal/agentadapter/identity.go
@@ -1,0 +1,32 @@
+package agentadapter
+
+import "net/http"
+
+// Identity is the issued governance identity that adapters attach to every
+// runtime request. The platform issues these values out-of-band (or, in a
+// later phase, through the adapter session endpoint); the adapter only
+// forwards them.
+type Identity struct {
+	HumanID   string
+	AgentID   string
+	TeamID    string
+	SessionID string
+}
+
+// Apply writes the governance identity onto an outbound request's headers,
+// replacing any caller-supplied values. TeamID is omitted when empty so the
+// gateway sees a missing header (the documented "any team" semantics) rather
+// than an empty value. SessionID is required by ValidateConfig today and is
+// always set; the anonymous-mode flow that may omit it is a Phase 3b change.
+func (id Identity) Apply(headers http.Header) {
+	headers.Del(HumanIDHeader)
+	headers.Del(AgentIDHeader)
+	headers.Del(TeamIDHeader)
+	headers.Del(AgentSessionHeader)
+	headers.Set(HumanIDHeader, id.HumanID)
+	headers.Set(AgentIDHeader, id.AgentID)
+	if id.TeamID != "" {
+		headers.Set(TeamIDHeader, id.TeamID)
+	}
+	headers.Set(AgentSessionHeader, id.SessionID)
+}

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -22,23 +22,31 @@ type rpcRequestMetadataContextKey struct{}
 
 // NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic to
 // the configured runtime route and injects issued governance identity headers.
-func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
-	if err := ValidateConfig(cfg); err != nil {
+func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error) {
+	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 	target := cloneURL(cfg.RuntimeURL)
+	transport := cfg.transportOrDefault()
+	identity := cfg.Identity
+	logLevel := cfg.LogLevel
+	logWriter := cfg.LogWriter
+	hostHeader := cfg.HostHeader
+	disableXFF := cfg.DisableXForwarded
+
 	proxy := &httputil.ReverseProxy{
 		FlushInterval: -1,
+		Transport:     transport,
 		Rewrite: func(req *httputil.ProxyRequest) {
 			rewriteToRuntimeRoute(req.Out.URL, target, req.In.URL.RawQuery)
 			req.Out.Host = target.Host
-			if cfg.HostHeader != "" {
-				req.Out.Host = cfg.HostHeader
+			if hostHeader != "" {
+				req.Out.Host = hostHeader
 			}
-			if !cfg.DisableXForwarded {
+			if !disableXFF {
 				req.SetXForwarded()
 			}
-			applyGovernanceHeaders(req.Out.Header, cfg)
+			identity.Apply(req.Out.Header)
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			if resp.StatusCode < http.StatusBadRequest || resp.StatusCode >= http.StatusInternalServerError {
@@ -53,7 +61,7 @@ func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
 			resp.ContentLength = int64(len(body))
 			resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
 			meta := rpcRequestMetadataFromContext(resp.Request.Context())
-			logRuntimeDenial(cfg, "mcp-runtime-agent-proxy", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
+			logRuntimeDenial(logLevel, logWriter, "mcp-runtime-agent-proxy", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
@@ -80,7 +88,7 @@ func NewHTTPProxyHandler(cfg Config) (http.Handler, error) {
 }
 
 // RunHTTPProxy serves the local HTTP adapter until the context is cancelled.
-func RunHTTPProxy(ctx context.Context, cfg Config) error {
+func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error {
 	if strings.TrimSpace(cfg.ListenAddr) == "" {
 		cfg.ListenAddr = DefaultListenAddr
 	}

--- a/internal/agentadapter/proxy_test.go
+++ b/internal/agentadapter/proxy_test.go
@@ -35,12 +35,14 @@ func TestHTTPProxyInjectsGovernanceHeadersAndPreservesMCPHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("url.Parse() error = %v", err)
 	}
-	handler, err := NewHTTPProxyHandler(Config{
+	handler, err := NewHTTPProxyHandler(ProxyConfig{
 		RuntimeURL: target,
-		HumanID:    "support-lead",
-		AgentID:    "ticket-triage-agent",
-		TeamID:     "team-acme",
-		SessionID:  "sess-ticket-triage-agent",
+		Identity: Identity{
+			HumanID:   "support-lead",
+			AgentID:   "ticket-triage-agent",
+			TeamID:    "team-acme",
+			SessionID: "sess-ticket-triage-agent",
+		},
 		HostHeader: "mcp.example.local",
 	})
 	if err != nil {
@@ -335,12 +337,48 @@ func TestHTTPProxyFlushesStreamableHTTPEventFrames(t *testing.T) {
 	}
 }
 
-func testConfig(runtimeURL *url.URL) Config {
-	return Config{
+func TestHTTPProxyRoutesThroughSharedTransport(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	cfg := testConfig(&url.URL{Scheme: "http", Host: "ignored.example", Path: "/demo/mcp"})
+	cfg.Transport = &RuntimeTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			body := io.NopCloser(strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       body,
+				Request:    req,
+			}, nil
+		}),
+	}
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	if !called {
+		t.Fatal("shared transport was not invoked; proxy still uses the default RoundTripper")
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func testConfig(runtimeURL *url.URL) ProxyConfig {
+	return ProxyConfig{
 		RuntimeURL: runtimeURL,
-		HumanID:    "human-1",
-		AgentID:    "agent-1",
-		SessionID:  "session-1",
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
 	}
 }
 

--- a/internal/agentadapter/rpc_metadata.go
+++ b/internal/agentadapter/rpc_metadata.go
@@ -54,14 +54,14 @@ func toolNameFromRPCParams(method string, params json.RawMessage) string {
 	return strings.TrimSpace(toolCall.Name)
 }
 
-func logRuntimeDenial(cfg Config, component string, status int, message string, meta rpcRequestMetadata) {
+func logRuntimeDenial(logLevel string, logWriter io.Writer, component string, status int, message string, meta rpcRequestMetadata) {
 	if status < http.StatusBadRequest || status >= http.StatusInternalServerError {
 		return
 	}
-	if !strings.EqualFold(strings.TrimSpace(cfg.LogLevel), "info") {
+	if !strings.EqualFold(strings.TrimSpace(logLevel), "info") {
 		return
 	}
-	writer := cfg.LogWriter
+	writer := logWriter
 	if writer == nil {
 		writer = os.Stderr
 	}

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -25,7 +25,7 @@ type StdioOptions struct {
 }
 
 type stdioShim struct {
-	cfg             Config
+	cfg             ShimConfig
 	client          *http.Client
 	mu              sync.Mutex
 	sessionID       string
@@ -65,8 +65,8 @@ type rpcError struct {
 // RunStdioShim reads newline-delimited stdio MCP JSON-RPC messages, forwards
 // them to the configured Streamable HTTP route, and writes JSON-RPC responses
 // back to stdout.
-func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
-	if err := ValidateConfig(cfg); err != nil {
+func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error {
+	if err := cfg.Validate(); err != nil {
 		return err
 	}
 	if opts.Stdin == nil {
@@ -75,16 +75,16 @@ func RunStdioShim(ctx context.Context, cfg Config, opts StdioOptions) error {
 	if opts.Stdout == nil {
 		return fmt.Errorf("stdout is required")
 	}
-	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = &http.Client{Timeout: cfg.RequestTimeout}
-	}
 	if strings.TrimSpace(cfg.ProtocolVersion) == "" {
 		cfg.ProtocolVersion = DefaultProtocolVersion
+	}
+	if cfg.Transport == nil {
+		cfg.Transport = &RuntimeTransport{}
 	}
 
 	shim := &stdioShim{
 		cfg:             cfg,
-		client:          cfg.HTTPClient,
+		client:          cfg.Transport.Client(),
 		protocolVersion: cfg.ProtocolVersion,
 	}
 
@@ -202,7 +202,7 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	if sessionID != "" {
 		req.Header.Set(MCPSessionHeader, sessionID)
 	}
-	applyGovernanceHeaders(req.Header, s.cfg)
+	s.cfg.Identity.Apply(req.Header)
 	if s.cfg.HostHeader != "" {
 		req.Host = s.cfg.HostHeader
 	}
@@ -240,7 +240,7 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	body = bytes.TrimSpace(body)
 
 	if resp.StatusCode >= http.StatusBadRequest {
-		logRuntimeDenial(s.cfg, "mcp-runtime-mcp-shim", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
+		logRuntimeDenial(s.cfg.LogLevel, s.cfg.LogWriter, "mcp-runtime-mcp-shim", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
 		if len(body) > 0 && looksLikeJSONRPC(body) {
 			return emit(body)
 		}

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -61,15 +61,17 @@ func TestRunStdioShimInjectsHeadersAndMaintainsRuntimeMCPSession(t *testing.T) {
 	}, "\n") + "\n"
 	var output bytes.Buffer
 
-	err = RunStdioShim(context.Background(), Config{
-		RuntimeURL:      runtimeURL,
-		HumanID:         "support-lead",
-		AgentID:         "ticket-triage-agent",
-		TeamID:          "team-acme",
-		SessionID:       "sess-ticket-triage-agent",
+	err = RunStdioShim(context.Background(), ShimConfig{
+		RuntimeURL: runtimeURL,
+		Identity: Identity{
+			HumanID:   "support-lead",
+			AgentID:   "ticket-triage-agent",
+			TeamID:    "team-acme",
+			SessionID: "sess-ticket-triage-agent",
+		},
 		HostHeader:      "mcp.example.local",
 		ProtocolVersion: "2025-01-01",
-		HTTPClient:      upstream.Client(),
+		Transport:       &RuntimeTransport{Base: upstream.Client().Transport},
 	}, StdioOptions{
 		Stdin:  strings.NewReader(input),
 		Stdout: &output,
@@ -116,12 +118,14 @@ func TestRunStdioShimConvertsHTTPDenialToJSONRPCError(t *testing.T) {
 		t.Fatalf("url.Parse() error = %v", err)
 	}
 	var output bytes.Buffer
-	err = RunStdioShim(context.Background(), Config{
+	err = RunStdioShim(context.Background(), ShimConfig{
 		RuntimeURL: runtimeURL,
-		HumanID:    "human-1",
-		AgentID:    "agent-1",
-		SessionID:  "session-1",
-		HTTPClient: upstream.Client(),
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Base: upstream.Client().Transport},
 	}, StdioOptions{
 		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
 		Stdout: &output,
@@ -161,14 +165,16 @@ func TestRunStdioShimLogsRuntimeDenialWhenInfoEnabled(t *testing.T) {
 	}
 	var output bytes.Buffer
 	var logs bytes.Buffer
-	err = RunStdioShim(context.Background(), Config{
+	err = RunStdioShim(context.Background(), ShimConfig{
 		RuntimeURL: runtimeURL,
-		HumanID:    "human-1",
-		AgentID:    "agent-1",
-		SessionID:  "session-1",
-		HTTPClient: upstream.Client(),
-		LogLevel:   "info",
-		LogWriter:  &logs,
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Base: upstream.Client().Transport},
+		LogLevel:  "info",
+		LogWriter: &logs,
 	}, StdioOptions{
 		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
 		Stdout: &output,
@@ -202,12 +208,14 @@ func TestRunStdioShimAppliesRequestTimeout(t *testing.T) {
 		t.Fatalf("url.Parse() error = %v", err)
 	}
 	var output bytes.Buffer
-	err = RunStdioShim(context.Background(), Config{
-		RuntimeURL:     runtimeURL,
-		HumanID:        "human-1",
-		AgentID:        "agent-1",
-		SessionID:      "session-1",
-		RequestTimeout: 10 * time.Millisecond,
+	err = RunStdioShim(context.Background(), ShimConfig{
+		RuntimeURL: runtimeURL,
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Timeout: 10 * time.Millisecond},
 	}, StdioOptions{
 		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
 		Stdout: &output,
@@ -248,12 +256,14 @@ func TestRunStdioShimSuppressesHTTPRequestErrorAfterContextCancellation(t *testi
 		}),
 	}
 	var output bytes.Buffer
-	err = RunStdioShim(ctx, Config{
+	err = RunStdioShim(ctx, ShimConfig{
 		RuntimeURL: runtimeURL,
-		HumanID:    "human-1",
-		AgentID:    "agent-1",
-		SessionID:  "session-1",
-		HTTPClient: client,
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Base: client.Transport},
 	}, StdioOptions{
 		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"call-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
 		Stdout: &output,
@@ -320,12 +330,14 @@ func TestRunStdioShimStreamsEventsAndContinuesReadingStdin(t *testing.T) {
 	done := make(chan error, 1)
 	go func() {
 		defer stdout.Close()
-		done <- RunStdioShim(ctx, Config{
+		done <- RunStdioShim(ctx, ShimConfig{
 			RuntimeURL: runtimeURL,
-			HumanID:    "human-1",
-			AgentID:    "agent-1",
-			SessionID:  "session-1",
-			HTTPClient: upstream.Client(),
+			Identity: Identity{
+				HumanID:   "human-1",
+				AgentID:   "agent-1",
+				SessionID: "session-1",
+			},
+			Transport: &RuntimeTransport{Base: upstream.Client().Transport},
 		}, StdioOptions{
 			Stdin:  stdin,
 			Stdout: stdout,
@@ -382,12 +394,14 @@ func TestRunStdioShimDoesNotWriteResponseForNotificationAcceptedByHTTP(t *testin
 		t.Fatalf("url.Parse() error = %v", err)
 	}
 	var output bytes.Buffer
-	err = RunStdioShim(context.Background(), Config{
+	err = RunStdioShim(context.Background(), ShimConfig{
 		RuntimeURL: runtimeURL,
-		HumanID:    "human-1",
-		AgentID:    "agent-1",
-		SessionID:  "session-1",
-		HTTPClient: upstream.Client(),
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Base: upstream.Client().Transport},
 	}, StdioOptions{
 		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n"),
 		Stdout: &output,
@@ -415,12 +429,14 @@ func TestRunStdioShimReturnsParseErrorForMalformedJSON(t *testing.T) {
 		t.Fatalf("url.Parse() error = %v", err)
 	}
 	var output bytes.Buffer
-	err = RunStdioShim(context.Background(), Config{
+	err = RunStdioShim(context.Background(), ShimConfig{
 		RuntimeURL: runtimeURL,
-		HumanID:    "human-1",
-		AgentID:    "agent-1",
-		SessionID:  "session-1",
-		HTTPClient: upstream.Client(),
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Base: upstream.Client().Transport},
 	}, StdioOptions{
 		Stdin:  strings.NewReader("{not-json\n"),
 		Stdout: &output,
@@ -460,11 +476,13 @@ func TestRunStdioShimReturnsWhenContextCancelledWhileIdle(t *testing.T) {
 	done := make(chan error, 1)
 
 	go func() {
-		done <- RunStdioShim(ctx, Config{
+		done <- RunStdioShim(ctx, ShimConfig{
 			RuntimeURL: runtimeURL,
-			HumanID:    "human-1",
-			AgentID:    "agent-1",
-			SessionID:  "session-1",
+			Identity: Identity{
+				HumanID:   "human-1",
+				AgentID:   "agent-1",
+				SessionID: "session-1",
+			},
 		}, StdioOptions{
 			Stdin:  stdin,
 			Stdout: io.Discard,

--- a/internal/agentadapter/transport.go
+++ b/internal/agentadapter/transport.go
@@ -1,0 +1,53 @@
+package agentadapter
+
+import (
+	"net/http"
+	"time"
+)
+
+// RuntimeTransport is the shared outbound HTTP transport used by both the
+// reverse proxy and the stdio shim when forwarding to the runtime. It owns
+// the base round-tripper and the per-request timeout so production gates
+// (mTLS, bearer auth, retries, OTel) get implemented in a single place and
+// behave identically for both adapters.
+type RuntimeTransport struct {
+	// Base is the underlying round-tripper. nil means http.DefaultTransport
+	// (production); tests can swap in a mock by setting this field.
+	Base http.RoundTripper
+	// Timeout is the per-request timeout applied to the *http.Client wrapper
+	// returned by Client(). Zero means no timeout (matches the previous
+	// "unbounded by default" behavior).
+	Timeout time.Duration
+}
+
+// RoundTrip implements http.RoundTripper so the transport can plug directly
+// into httputil.ReverseProxy.Transport.
+func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base()
+	return base.RoundTrip(req)
+}
+
+// Client returns an *http.Client whose Transport is this RuntimeTransport.
+// The stdio shim uses this directly; the reverse proxy uses the underlying
+// round-tripper via Transport field assignment instead.
+func (t *RuntimeTransport) Client() *http.Client {
+	return &http.Client{
+		Transport: t,
+		Timeout:   t.Timeout,
+	}
+}
+
+// CloseIdleConnections drains idle connections on the base round-tripper if
+// it supports the optional interface, matching net/http's contract.
+func (t *RuntimeTransport) CloseIdleConnections() {
+	if closer, ok := t.base().(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
+}
+
+func (t *RuntimeTransport) base() http.RoundTripper {
+	if t == nil || t.Base == nil {
+		return http.DefaultTransport
+	}
+	return t.Base
+}

--- a/internal/agentadapter/transport.go
+++ b/internal/agentadapter/transport.go
@@ -28,13 +28,14 @@ func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 // Client returns an *http.Client whose Transport is this RuntimeTransport.
-// The stdio shim uses this directly; the reverse proxy uses the underlying
-// round-tripper via Transport field assignment instead.
+// Both the stdio shim and the reverse proxy route outbound requests through
+// this wrapper so auth, OTel, and retry logic lives in one place.
 func (t *RuntimeTransport) Client() *http.Client {
-	return &http.Client{
-		Transport: t,
-		Timeout:   t.Timeout,
+	var timeout time.Duration
+	if t != nil {
+		timeout = t.Timeout
 	}
+	return &http.Client{Transport: t, Timeout: timeout}
 }
 
 // CloseIdleConnections drains idle connections on the base round-tripper if

--- a/internal/agentadapter/transport_test.go
+++ b/internal/agentadapter/transport_test.go
@@ -1,0 +1,56 @@
+package agentadapter
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRuntimeTransportRoutesThroughBase(t *testing.T) {
+	t.Parallel()
+
+	var called bool
+	transport := &RuntimeTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			return &http.Response{StatusCode: http.StatusTeapot, Body: http.NoBody, Header: http.Header{}, Request: req}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	if !called {
+		t.Fatal("base round-tripper was not invoked")
+	}
+	if resp.StatusCode != http.StatusTeapot {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusTeapot)
+	}
+}
+
+func TestRuntimeTransportClientAppliesTimeout(t *testing.T) {
+	t.Parallel()
+
+	transport := &RuntimeTransport{Timeout: 7 * time.Second}
+	client := transport.Client()
+	if client.Timeout != 7*time.Second {
+		t.Fatalf("client.Timeout = %s, want 7s", client.Timeout)
+	}
+	if client.Transport != transport {
+		t.Fatalf("client.Transport = %#v, want transport", client.Transport)
+	}
+}
+
+func TestRuntimeTransportNilBaseUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	transport := &RuntimeTransport{}
+	if got := transport.base(); got != http.DefaultTransport {
+		t.Fatalf("base() = %#v, want http.DefaultTransport", got)
+	}
+}

--- a/internal/agentadapter/transport_test.go
+++ b/internal/agentadapter/transport_test.go
@@ -54,3 +54,16 @@ func TestRuntimeTransportNilBaseUsesDefault(t *testing.T) {
 		t.Fatalf("base() = %#v, want http.DefaultTransport", got)
 	}
 }
+
+func TestRuntimeTransportNilReceiverClientDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	var transport *RuntimeTransport
+	client := transport.Client()
+	if client == nil {
+		t.Fatal("Client() returned nil")
+	}
+	if client.Timeout != 0 {
+		t.Fatalf("client.Timeout = %s, want 0 for nil receiver", client.Timeout)
+	}
+}

--- a/internal/cli/adapter/adapter_test.go
+++ b/internal/cli/adapter/adapter_test.go
@@ -60,7 +60,7 @@ func TestProxyCommandRejectsBadRuntimeURL(t *testing.T) {
 	}
 }
 
-func TestIdentityFlagsToConfigParsesTeamAndTimeout(t *testing.T) {
+func TestIdentityFlagsToProxyConfigParsesTeamAndTimeout(t *testing.T) {
 	t.Parallel()
 
 	flags := identityFlags{
@@ -71,15 +71,15 @@ func TestIdentityFlagsToConfigParsesTeamAndTimeout(t *testing.T) {
 		sessionID:      "sess-1",
 		requestTimeout: "45s",
 	}
-	cfg, err := flags.toConfig()
+	cfg, err := flags.toProxyConfig("")
 	if err != nil {
-		t.Fatalf("toConfig() error = %v", err)
+		t.Fatalf("toProxyConfig() error = %v", err)
 	}
-	if cfg.TeamID != "team-acme" {
-		t.Fatalf("TeamID = %q, want team-acme", cfg.TeamID)
+	if cfg.Identity.TeamID != "team-acme" {
+		t.Fatalf("Identity.TeamID = %q, want team-acme", cfg.Identity.TeamID)
 	}
-	if cfg.RequestTimeout != 45*time.Second {
-		t.Fatalf("RequestTimeout = %s, want 45s", cfg.RequestTimeout)
+	if cfg.Transport == nil || cfg.Transport.Timeout != 45*time.Second {
+		t.Fatalf("Transport = %v, want timeout 45s", cfg.Transport)
 	}
 	if cfg.RuntimeURL == nil || cfg.RuntimeURL.Host != "localhost:18080" {
 		t.Fatalf("RuntimeURL = %v, want parsed localhost:18080", cfg.RuntimeURL)
@@ -110,12 +110,12 @@ func TestIdentityFlagsToConfigRejectsBadTimeout(t *testing.T) {
 				sessionID:      "s",
 				requestTimeout: tt.value,
 			}
-			_, err := flags.toConfig()
+			_, err := flags.toProxyConfig("")
 			if err == nil {
-				t.Fatalf("toConfig() error = nil, want %s", tt.want)
+				t.Fatalf("toProxyConfig() error = nil, want %s", tt.want)
 			}
 			if !strings.Contains(err.Error(), "request-timeout") || !strings.Contains(err.Error(), tt.want) {
-				t.Fatalf("toConfig() error = %q, want request-timeout/%s", err, tt.want)
+				t.Fatalf("toProxyConfig() error = %q, want request-timeout/%s", err, tt.want)
 			}
 		})
 	}

--- a/internal/cli/adapter/flags.go
+++ b/internal/cli/adapter/flags.go
@@ -51,50 +51,101 @@ func bindIdentityFlags(cmd *cobra.Command, f *identityFlags) {
 		"HTTP request timeout for adapter→runtime calls, e.g. 30s (default: $"+agentadapter.EnvRequestTimeout+")")
 }
 
-// toConfig converts the parsed flags into an agentadapter.Config, validating
-// the runtime URL and request timeout on the CLI side so error messages are
-// user-readable and stay consistent with agentadapter.loadConfig.
-func (f identityFlags) toConfig() (agentadapter.Config, error) {
-	cfg := agentadapter.Config{
-		HumanID:           strings.TrimSpace(f.humanID),
-		AgentID:           strings.TrimSpace(f.agentID),
-		TeamID:            strings.TrimSpace(f.teamID),
-		SessionID:         strings.TrimSpace(f.sessionID),
-		HostHeader:        strings.TrimSpace(f.hostHeader),
-		ProtocolVersion:   strings.TrimSpace(f.protocolVersion),
-		LogLevel:          strings.TrimSpace(f.logLevel),
-		DisableXForwarded: f.disableXFF,
+// resolved holds the validated cross-cutting pieces of an adapter config —
+// identity, runtime URL, transport, and the shared display fields — that
+// every subcommand needs before building its transport-specific config.
+type resolved struct {
+	runtimeURL      *url.URL
+	identity        agentadapter.Identity
+	transport       *agentadapter.RuntimeTransport
+	hostHeader      string
+	protocolVersion string
+	logLevel        string
+}
+
+// resolve parses and validates the shared adapter fields on the CLI side so
+// error messages reference the user-facing flag name instead of the env var.
+func (f identityFlags) resolve() (resolved, error) {
+	out := resolved{
+		identity: agentadapter.Identity{
+			HumanID:   strings.TrimSpace(f.humanID),
+			AgentID:   strings.TrimSpace(f.agentID),
+			TeamID:    strings.TrimSpace(f.teamID),
+			SessionID: strings.TrimSpace(f.sessionID),
+		},
+		hostHeader:      strings.TrimSpace(f.hostHeader),
+		protocolVersion: strings.TrimSpace(f.protocolVersion),
+		logLevel:        strings.TrimSpace(f.logLevel),
 	}
-	if cfg.ProtocolVersion == "" {
-		cfg.ProtocolVersion = agentadapter.DefaultProtocolVersion
+	if out.protocolVersion == "" {
+		out.protocolVersion = agentadapter.DefaultProtocolVersion
 	}
 
 	if raw := strings.TrimSpace(f.requestTimeout); raw != "" {
 		timeout, err := time.ParseDuration(raw)
 		if err != nil {
-			return agentadapter.Config{}, fmt.Errorf("--request-timeout (or $%s) is invalid: %w", agentadapter.EnvRequestTimeout, err)
+			return resolved{}, fmt.Errorf("--request-timeout (or $%s) is invalid: %w", agentadapter.EnvRequestTimeout, err)
 		}
 		if timeout <= 0 {
-			return agentadapter.Config{}, fmt.Errorf("--request-timeout (or $%s) must be greater than zero", agentadapter.EnvRequestTimeout)
+			return resolved{}, fmt.Errorf("--request-timeout (or $%s) must be greater than zero", agentadapter.EnvRequestTimeout)
 		}
-		cfg.RequestTimeout = timeout
+		out.transport = &agentadapter.RuntimeTransport{Timeout: timeout}
 	}
 
-	rawURL := strings.TrimSpace(f.runtimeURL)
-	if rawURL != "" {
-		parsed, err := url.Parse(rawURL)
+	if raw := strings.TrimSpace(f.runtimeURL); raw != "" {
+		parsed, err := url.Parse(raw)
 		if err != nil {
-			return agentadapter.Config{}, fmt.Errorf("--runtime-url is invalid: %w", err)
+			return resolved{}, fmt.Errorf("--runtime-url is invalid: %w", err)
 		}
 		if parsed.Scheme == "" || parsed.Host == "" {
-			return agentadapter.Config{}, fmt.Errorf("--runtime-url must be an absolute HTTP URL")
+			return resolved{}, fmt.Errorf("--runtime-url must be an absolute HTTP URL")
 		}
 		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			return agentadapter.Config{}, fmt.Errorf("--runtime-url must use http or https")
+			return resolved{}, fmt.Errorf("--runtime-url must use http or https")
 		}
-		cfg.RuntimeURL = parsed
+		out.runtimeURL = parsed
 	}
-	return cfg, nil
+	return out, nil
+}
+
+// toProxyConfig produces an agentadapter.ProxyConfig from the resolved
+// shared fields plus proxy-only listener/XFF settings.
+func (f identityFlags) toProxyConfig(listenAddr string) (agentadapter.ProxyConfig, error) {
+	r, err := f.resolve()
+	if err != nil {
+		return agentadapter.ProxyConfig{}, err
+	}
+	listen := strings.TrimSpace(listenAddr)
+	if listen == "" {
+		listen = agentadapter.DefaultListenAddr
+	}
+	return agentadapter.ProxyConfig{
+		RuntimeURL:        r.runtimeURL,
+		Identity:          r.identity,
+		Transport:         r.transport,
+		HostHeader:        r.hostHeader,
+		ListenAddr:        listen,
+		ProtocolVersion:   r.protocolVersion,
+		LogLevel:          r.logLevel,
+		DisableXForwarded: f.disableXFF,
+	}, nil
+}
+
+// toShimConfig produces an agentadapter.ShimConfig from the resolved shared
+// fields.
+func (f identityFlags) toShimConfig() (agentadapter.ShimConfig, error) {
+	r, err := f.resolve()
+	if err != nil {
+		return agentadapter.ShimConfig{}, err
+	}
+	return agentadapter.ShimConfig{
+		RuntimeURL:      r.runtimeURL,
+		Identity:        r.identity,
+		Transport:       r.transport,
+		HostHeader:      r.hostHeader,
+		ProtocolVersion: r.protocolVersion,
+		LogLevel:        r.logLevel,
+	}, nil
 }
 
 func parseEnvBool(name string, def bool) bool {

--- a/internal/cli/adapter/proxy.go
+++ b/internal/cli/adapter/proxy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -27,15 +26,11 @@ injecting the issued governance identity headers.
 Configure identity via flags or the matching MCP_RUNTIME_* environment
 variables. Flags win when both are set.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfg, err := flags.toConfig()
+			cfg, err := flags.toProxyConfig(listenAddr)
 			if err != nil {
 				return err
 			}
-			cfg.ListenAddr = strings.TrimSpace(listenAddr)
-			if cfg.ListenAddr == "" {
-				cfg.ListenAddr = agentadapter.DefaultListenAddr
-			}
-			if err := agentadapter.ValidateConfig(cfg); err != nil {
+			if err := cfg.Validate(); err != nil {
 				return err
 			}
 

--- a/internal/cli/adapter/stdio.go
+++ b/internal/cli/adapter/stdio.go
@@ -25,11 +25,11 @@ Claude Desktop) that launch an MCP server as a subprocess.
 Configure identity via flags or the matching MCP_RUNTIME_* environment
 variables. Flags win when both are set.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfg, err := flags.toConfig()
+			cfg, err := flags.toShimConfig()
 			if err != nil {
 				return err
 			}
-			if err := agentadapter.ValidateConfig(cfg); err != nil {
+			if err := cfg.Validate(); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
## Summary

- Introduces `Identity` type with `Apply(http.Header)` to centralise governance header injection across both adapters
- Introduces `RuntimeTransport` — a single `http.RoundTripper` used by both the HTTP proxy and stdio shim, providing a unified seam for future auth/TLS/OTel/retry (Phase 4)
- Splits the monolithic `Config` into `ProxyConfig` (proxy-specific: `ListenAddr`, `DisableXForwarded`) and `ShimConfig` (stdio-specific), both carrying `Identity` and `*RuntimeTransport`
- Fixes silent `http.DefaultTransport` use in `httputil.ReverseProxy` — proxy now routes through `cfg.Transport`, verified by `TestHTTPProxyRoutesThroughSharedTransport`
- Updates CLI `identityFlags` with `toProxyConfig` / `toShimConfig` replacing the old `toConfig`

## What changed

| File | Change |
|------|--------|
| `internal/agentadapter/identity.go` | NEW — `Identity` struct + `Apply` |
| `internal/agentadapter/transport.go` | NEW — `RuntimeTransport` RoundTripper |
| `internal/agentadapter/transport_test.go` | NEW — transport unit tests |
| `internal/agentadapter/config.go` | Rewritten: `Config` → `ProxyConfig` + `ShimConfig` |
| `internal/agentadapter/proxy.go` | `NewHTTPProxyHandler(ProxyConfig)`, sets `proxy.Transport` |
| `internal/agentadapter/stdio.go` | `RunStdioShim(ctx, ShimConfig, StdioOptions)` |
| `internal/agentadapter/config_test.go` | Updated for split config + transport |
| `internal/agentadapter/proxy_test.go` | Updated + transport routing regression test |
| `internal/agentadapter/stdio_test.go` | Updated all callsites |
| `internal/cli/adapter/flags.go` | `toProxyConfig` / `toShimConfig` |
| `internal/cli/adapter/adapter_test.go` | Updated flag tests |

## Test plan

- [x] `go test -race -count=1 ./internal/agentadapter/...` — all pass
- [x] `go test -race -count=1 ./internal/cli/adapter/...` — all pass
- [x] `go test -race -count=1 ./...` — full suite green
- [x] Pre-commit hooks pass (gitleaks, gofmt, staticcheck, go vet, generated-file drift)
- [x] `TestHTTPProxyRoutesThroughSharedTransport` verifies proxy uses `cfg.Transport.Base`

## Context

Part of issue #165 (Phase 3a). Prerequisite for Phase 4 (auth/TLS/OTel/retry) — those features now have a single injection point in `RuntimeTransport.RoundTrip` rather than needing to be duplicated across proxy and stdio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)