### PR TITLE
feat(agentadapter): Phase 4 — production gates (shutdown, auth, OTel, retry, session-expiry)

### DIFF
--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -1852,6 +1852,7 @@ forward MCP traffic to governed MCP Runtime routes.
 - [`Variables`](#agent-adapters-variables)
 - [`func BuildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error)`](#agent-adapters-func-buildtlsconfig-certfile-keyfile-cafile-string-tls-config-error)
 - [`func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error)`](#agent-adapters-func-newhttpproxyhandler-cfg-proxyconfig-http-handler-error)
+- [`func NewHTTPTransportWithTLS(cfg *tls.Config) *http.Transport`](#agent-adapters-func-newhttptransportwithtls-cfg-tls-config-http-transport)
 - [`func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error`](#agent-adapters-func-runhttpproxy-ctx-context-context-cfg-proxyconfig-error)
 - [`func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error`](#agent-adapters-func-runstdioshim-ctx-context-context-cfg-shimconfig-opts-stdiooptions-error)
 - [`func SplitTrimmed(s, sep string) []string`](#agent-adapters-func-splittrimmed-s-sep-string-string)
@@ -1939,6 +1940,15 @@ func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error)
     NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic
     to the configured runtime route and injects issued governance identity
     headers.
+
+```
+
+<a id="agent-adapters-func-newhttptransportwithtls-cfg-tls-config-http-transport"></a>
+```text
+func NewHTTPTransportWithTLS(cfg *tls.Config) *http.Transport
+    NewHTTPTransportWithTLS returns an *http.Transport that uses the supplied
+    TLS config while preserving http.DefaultTransport's dial timeouts,
+    keep-alive settings, and ProxyFromEnvironment behaviour.
 
 ```
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -1850,6 +1850,7 @@ forward MCP traffic to governed MCP Runtime routes.
 
 - [`Constants`](#agent-adapters-constants)
 - [`Variables`](#agent-adapters-variables)
+- [`func BuildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error)`](#agent-adapters-func-buildtlsconfig-certfile-keyfile-cafile-string-tls-config-error)
 - [`func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error)`](#agent-adapters-func-newhttpproxyhandler-cfg-proxyconfig-http-handler-error)
 - [`func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error`](#agent-adapters-func-runhttpproxy-ctx-context-context-cfg-proxyconfig-error)
 - [`func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error`](#agent-adapters-func-runstdioshim-ctx-context-context-cfg-shimconfig-opts-stdiooptions-error)
@@ -1886,6 +1887,10 @@ const (
 	EnvLogLevel         = "MCP_RUNTIME_LOG_LEVEL"
 	EnvAnonymous        = "MCP_RUNTIME_ANONYMOUS"
 	EnvAnonymousMethods = "MCP_RUNTIME_ANONYMOUS_METHODS"
+	EnvAuthHeader       = "MCP_RUNTIME_AUTH_HEADER"
+	EnvTLSClientCert    = "MCP_RUNTIME_TLS_CLIENT_CERT"
+	EnvTLSClientKey     = "MCP_RUNTIME_TLS_CLIENT_KEY"
+	EnvTLSCABundle      = "MCP_RUNTIME_TLS_CA_BUNDLE"
 
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
@@ -1918,6 +1923,15 @@ var DefaultAnonymousMethods = []string{
 
 <a id="agent-adapters-functions"></a>
 ### Functions
+
+<a id="agent-adapters-func-buildtlsconfig-certfile-keyfile-cafile-string-tls-config-error"></a>
+```text
+func BuildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error)
+    BuildTLSConfig builds a *tls.Config for outbound runtime connections.
+    certFile and keyFile must both be set (or both empty) for mTLS. caFile,
+    when non-empty, replaces the default system CA pool.
+
+```
 
 <a id="agent-adapters-func-newhttpproxyhandler-cfg-proxyconfig-http-handler-error"></a>
 ```text
@@ -2014,19 +2028,28 @@ func (cfg ProxyConfig) Validate() error
 <a id="agent-adapters-type-runtimetransport-struct"></a>
 ```text
 type RuntimeTransport struct {
-	// Base is the underlying round-tripper. nil means http.DefaultTransport
-	// (production); tests can swap in a mock by setting this field.
+	// Base is the underlying round-tripper. nil means http.DefaultTransport.
+	// Tests swap in a mock by setting this field.
 	Base http.RoundTripper
 	// Timeout is the per-request timeout applied to the *http.Client wrapper
-	// returned by Client(). Zero means no timeout (matches the previous
-	// "unbounded by default" behavior).
+	// returned by Client(). Zero means no timeout.
 	Timeout time.Duration
+	// AuthHeader is a static Authorization header value injected into every
+	// outbound request (e.g. "Bearer <token>"). Empty means no header is set.
+	AuthHeader string
+	// Tracer is an optional OTel tracer. When non-nil, RoundTrip opens one
+	// client span per RPC labelled with the JSON-RPC method name.
+	Tracer trace.Tracer
+	// Meter is an optional OTel meter. When non-nil, RoundTrip records a
+	// latency histogram and a denial counter keyed by method name.
+	Meter metric.Meter
+
+	// Has unexported fields.
 }
     RuntimeTransport is the shared outbound HTTP transport used by both the
-    reverse proxy and the stdio shim when forwarding to the runtime. It owns the
-    base round-tripper and the per-request timeout so production gates (mTLS,
-    bearer auth, retries, OTel) get implemented in a single place and behave
-    identically for both adapters.
+    reverse proxy and the stdio shim when forwarding to the runtime. It owns
+    every production gate — auth, OTel instrumentation, and method-keyed retry —
+    so both adapters behave identically with a single implementation.
 
 ```
 
@@ -2034,8 +2057,8 @@ type RuntimeTransport struct {
 ```text
 func (t *RuntimeTransport) Client() *http.Client
     Client returns an *http.Client whose Transport is this RuntimeTransport.
-    Both the stdio shim and the reverse proxy route outbound requests through
-    this wrapper so auth, OTel, and retry logic lives in one place.
+    Both adapters route requests through this wrapper so every gate (auth, OTel,
+    retry) applies uniformly.
 
 ```
 
@@ -2050,8 +2073,12 @@ func (t *RuntimeTransport) CloseIdleConnections()
 <a id="agent-adapters-func-t-runtimetransport-roundtrip-req-http-request-http-response-error"></a>
 ```text
 func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error)
-    RoundTrip implements http.RoundTripper so the transport can plug directly
-    into httputil.ReverseProxy.Transport.
+    RoundTrip implements http.RoundTripper. Execution order per call:
+     1. Start OTel span (if Tracer is set).
+     2. Inject Authorization header (if AuthHeader is set).
+     3. Execute the request, retrying idempotent methods on gateway errors.
+     4. Record OTel latency histogram and denial counter (if Meter is set).
+     5. Set span outcome and end it.
 
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,9 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
+	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -74,8 +76,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
-	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -252,10 +253,19 @@ func parseSharedEnv(lookup envLookup) (sharedEnv, error) {
 		if out.transport == nil {
 			out.transport = &RuntimeTransport{}
 		}
-		out.transport.Base = &http.Transport{TLSClientConfig: tlsCfg}
+		out.transport.Base = NewHTTPTransportWithTLS(tlsCfg)
 	}
 
 	return out, nil
+}
+
+// NewHTTPTransportWithTLS returns an *http.Transport that uses the supplied
+// TLS config while preserving http.DefaultTransport's dial timeouts, keep-alive
+// settings, and ProxyFromEnvironment behaviour.
+func NewHTTPTransportWithTLS(cfg *tls.Config) *http.Transport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = cfg
+	return base
 }
 
 // BuildTLSConfig builds a *tls.Config for outbound runtime connections.
@@ -274,7 +284,7 @@ func BuildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
 		cfg.Certificates = []tls.Certificate{cert}
 	}
 	if caFile != "" {
-		pem, err := os.ReadFile(caFile)
+		pem, err := readRegularFile(caFile)
 		if err != nil {
 			return nil, fmt.Errorf("reading CA bundle %q: %w", caFile, err)
 		}
@@ -285,6 +295,34 @@ func BuildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
 		cfg.RootCAs = pool
 	}
 	return cfg, nil
+}
+
+func readRegularFile(path string) ([]byte, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve file path: %w", err)
+	}
+	root, err := os.OpenRoot(filepath.Dir(absPath))
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+
+	base := filepath.Base(absPath)
+	info, err := root.Stat(base)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file")
+	}
+	file, err := root.Open(base)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return io.ReadAll(file)
 }
 
 func validateRequiredIdentity(runtimeURL *url.URL, id Identity) error {

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -1,8 +1,11 @@
 package agentadapter
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -23,6 +26,10 @@ const (
 	EnvLogLevel         = "MCP_RUNTIME_LOG_LEVEL"
 	EnvAnonymous        = "MCP_RUNTIME_ANONYMOUS"
 	EnvAnonymousMethods = "MCP_RUNTIME_ANONYMOUS_METHODS"
+	EnvAuthHeader       = "MCP_RUNTIME_AUTH_HEADER"
+	EnvTLSClientCert    = "MCP_RUNTIME_TLS_CLIENT_CERT"
+	EnvTLSClientKey     = "MCP_RUNTIME_TLS_CLIENT_KEY"
+	EnvTLSCABundle      = "MCP_RUNTIME_TLS_CA_BUNDLE"
 
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
@@ -224,7 +231,60 @@ func parseSharedEnv(lookup envLookup) (sharedEnv, error) {
 		}
 		out.transport = &RuntimeTransport{Timeout: timeout}
 	}
+
+	// Auth header.
+	if raw := strings.TrimSpace(lookup(EnvAuthHeader)); raw != "" {
+		if out.transport == nil {
+			out.transport = &RuntimeTransport{}
+		}
+		out.transport.AuthHeader = raw
+	}
+
+	// Optional mTLS: client cert/key and/or custom CA bundle.
+	tlsCert := strings.TrimSpace(lookup(EnvTLSClientCert))
+	tlsKey := strings.TrimSpace(lookup(EnvTLSClientKey))
+	tlsCA := strings.TrimSpace(lookup(EnvTLSCABundle))
+	if tlsCert != "" || tlsKey != "" || tlsCA != "" {
+		tlsCfg, err := BuildTLSConfig(tlsCert, tlsKey, tlsCA)
+		if err != nil {
+			return sharedEnv{}, err
+		}
+		if out.transport == nil {
+			out.transport = &RuntimeTransport{}
+		}
+		out.transport.Base = &http.Transport{TLSClientConfig: tlsCfg}
+	}
+
 	return out, nil
+}
+
+// BuildTLSConfig builds a *tls.Config for outbound runtime connections.
+// certFile and keyFile must both be set (or both empty) for mTLS.
+// caFile, when non-empty, replaces the default system CA pool.
+func BuildTLSConfig(certFile, keyFile, caFile string) (*tls.Config, error) {
+	cfg := &tls.Config{}
+	if certFile != "" || keyFile != "" {
+		if certFile == "" || keyFile == "" {
+			return nil, fmt.Errorf("%s and %s must both be set for mTLS", EnvTLSClientCert, EnvTLSClientKey)
+		}
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("loading TLS client cert/key: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	if caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading CA bundle %q: %w", caFile, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("%s contains no valid PEM certificates", EnvTLSCABundle)
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg, nil
 }
 
 func validateRequiredIdentity(runtimeURL *url.URL, id Identity) error {

--- a/internal/agentadapter/config_test.go
+++ b/internal/agentadapter/config_test.go
@@ -1,6 +1,12 @@
 package agentadapter
 
 import (
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -243,4 +249,41 @@ func TestLoadConfigRejectsInvalidRuntimeControls(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildTLSConfigLoadsCABundle(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	caPEM := pemForCertificate(upstream.Certificate())
+	if err := os.WriteFile(caPath, caPEM, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cfg, err := BuildTLSConfig("", "", caPath)
+	if err != nil {
+		t.Fatalf("BuildTLSConfig() error = %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("RootCAs = nil, want custom CA pool")
+	}
+}
+
+func TestBuildTLSConfigRejectsDirectoryCABundle(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildTLSConfig("", "", t.TempDir())
+	if err == nil {
+		t.Fatal("BuildTLSConfig() error = nil, want directory rejection")
+	}
+	if !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("BuildTLSConfig() error = %q, want regular file message", err)
+	}
+}
+
+func pemForCertificate(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 }

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -23,8 +23,16 @@ type rpcRequestMetadataContextKey struct{}
 // NewHTTPProxyHandler returns a reverse proxy that forwards MCP HTTP traffic to
 // the configured runtime route and injects issued governance identity headers.
 func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error) {
+	h, _, err := newProxyHandlerAndTracker(cfg)
+	return h, err
+}
+
+// newProxyHandlerAndTracker builds the proxy handler together with the
+// requestTracker that tracks every in-flight request. RunHTTPProxy calls this
+// so it can cancel all tracked requests before draining the server.
+func newProxyHandlerAndTracker(cfg ProxyConfig) (http.Handler, *requestTracker, error) {
 	if err := cfg.Validate(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	target := cloneURL(cfg.RuntimeURL)
 	transport := cfg.transportOrDefault()
@@ -57,6 +65,9 @@ func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error) {
 				return err
 			}
 			_ = resp.Body.Close()
+			if isSessionExpiredBody(body) {
+				body = injectRuntimeStatus(body, "session_expired")
+			}
 			resp.Body = io.NopCloser(bytes.NewReader(body))
 			resp.ContentLength = int64(len(body))
 			resp.Header.Set("Content-Length", strconv.FormatInt(resp.ContentLength, 10))
@@ -72,19 +83,26 @@ func NewHTTPProxyHandler(cfg ProxyConfig) (http.Handler, error) {
 		},
 	}
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tracker := newRequestTracker()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+		// Track the request so shutdown can cancel it explicitly.
+		reqCtx, id := tracker.track(r.Context())
+		defer tracker.done(id)
+
 		meta, err := captureRPCRequestMetadata(r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		r = r.WithContext(context.WithValue(r.Context(), rpcRequestMetadataContextKey{}, meta))
-		proxy.ServeHTTP(w, r)
-	}), nil
+		ctx := context.WithValue(reqCtx, rpcRequestMetadataContextKey{}, meta)
+		ctx = withRPCMethod(ctx, meta.Method)
+		proxy.ServeHTTP(w, r.WithContext(ctx))
+	})
+	return handler, tracker, nil
 }
 
 // RunHTTPProxy serves the local HTTP adapter until the context is cancelled.
@@ -92,7 +110,7 @@ func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error {
 	if strings.TrimSpace(cfg.ListenAddr) == "" {
 		cfg.ListenAddr = DefaultListenAddr
 	}
-	handler, err := NewHTTPProxyHandler(cfg)
+	handler, tracker, err := newProxyHandlerAndTracker(cfg)
 	if err != nil {
 		return err
 	}
@@ -109,16 +127,19 @@ func RunHTTPProxy(ctx context.Context, cfg ProxyConfig) error {
 
 	select {
 	case <-ctx.Done():
+		// Cancel all in-flight runtime requests so client.Do returns quickly,
+		// then drain the HTTP server. Fall back to Close if Shutdown times out.
+		tracker.cancelAll(errors.New("adapter shutdown"))
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), proxyShutdownTimeout)
 		defer cancel()
-		if err := server.Shutdown(shutdownCtx); err != nil {
-			return err
+		if sErr := server.Shutdown(shutdownCtx); sErr != nil {
+			_ = server.Close()
 		}
-		err := <-errCh
-		if errors.Is(err, http.ErrServerClosed) {
+		svrErr := <-errCh
+		if errors.Is(svrErr, http.ErrServerClosed) {
 			return nil
 		}
-		return err
+		return svrErr
 	case err := <-errCh:
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil

--- a/internal/agentadapter/proxy_test.go
+++ b/internal/agentadapter/proxy_test.go
@@ -371,6 +371,42 @@ func TestHTTPProxyRoutesThroughSharedTransport(t *testing.T) {
 	}
 }
 
+func TestHTTPProxyInjectsRuntimeStatusOnSessionExpiredDenial(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":3,"error":{"code":-32000,"message":"session_not_found"}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, err := url.Parse(upstream.URL + "/mcp")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+	handler, err := NewHTTPProxyHandler(testConfig(target))
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"upper"}}`))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnauthorized)
+	}
+	body, _ := io.ReadAll(recorder.Result().Body)
+	var response rpcErrorResponse
+	if err := json.Unmarshal(bytes.TrimSpace(body), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v; body=%s", err, body)
+	}
+	if got, _ := response.Error.Data["runtime_status"].(string); got != "session_expired" {
+		t.Fatalf("runtime_status = %q, want session_expired", got)
+	}
+}
+
 func testConfig(runtimeURL *url.URL) ProxyConfig {
 	return ProxyConfig{
 		RuntimeURL: runtimeURL,

--- a/internal/agentadapter/rpc_metadata.go
+++ b/internal/agentadapter/rpc_metadata.go
@@ -1,6 +1,7 @@
 package agentadapter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,19 @@ import (
 )
 
 const maxLogFieldBytes = 120
+
+type rpcMethodContextKey struct{}
+
+// withRPCMethod stores the JSON-RPC method name on ctx so RuntimeTransport can
+// read it for method-keyed retry and OTel attribute labeling.
+func withRPCMethod(ctx context.Context, method string) context.Context {
+	return context.WithValue(ctx, rpcMethodContextKey{}, method)
+}
+
+func rpcMethodFromContext(ctx context.Context) string {
+	m, _ := ctx.Value(rpcMethodContextKey{}).(string)
+	return m
+}
 
 type rpcRequestMetadata struct {
 	ID       json.RawMessage
@@ -91,4 +105,64 @@ func closeIfPossible(reader io.Reader) {
 	if closer, ok := reader.(io.Closer); ok {
 		_ = closer.Close()
 	}
+}
+
+// isSessionExpiredBody returns true when the runtime denial body indicates
+// that the caller's session has expired or was not found — signals that the
+// agent should re-initialize rather than retry the current call.
+func isSessionExpiredBody(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	var obj struct {
+		Error any `json:"error"`
+	}
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return false
+	}
+	var msg string
+	switch v := obj.Error.(type) {
+	case string:
+		msg = v
+	case map[string]any:
+		if m, ok := v["message"].(string); ok {
+			msg = m
+		}
+		if c, ok := v["code"].(string); ok {
+			msg += " " + c
+		}
+	}
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "session_expired") || strings.Contains(lower, "session_not_found")
+}
+
+// injectRuntimeStatus adds runtime_status to the error.data field of a
+// JSON-RPC error body. Returns body unchanged when it is not a JSON-RPC error.
+func injectRuntimeStatus(body []byte, status string) []byte {
+	if !looksLikeJSONRPCError(body) {
+		return body
+	}
+	var response struct {
+		JSONRPC string             `json:"jsonrpc"`
+		ID      json.RawMessage    `json:"id,omitempty"`
+		Error   *rpcErrorForInject `json:"error"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil || response.Error == nil {
+		return body
+	}
+	if response.Error.Data == nil {
+		response.Error.Data = make(map[string]any)
+	}
+	response.Error.Data["runtime_status"] = status
+	out, err := json.Marshal(response)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+type rpcErrorForInject struct {
+	Code    int            `json:"code"`
+	Message string         `json:"message"`
+	Data    map[string]any `json:"data,omitempty"`
 }

--- a/internal/agentadapter/shutdown.go
+++ b/internal/agentadapter/shutdown.go
@@ -1,0 +1,61 @@
+package agentadapter
+
+import (
+	"context"
+	"sync"
+)
+
+// requestTracker tracks per-request context cancel functions so a graceful
+// shutdown can abort all in-flight runtime calls before the HTTP server drains
+// or the stdio shim's WaitGroup resolves.
+type requestTracker struct {
+	mu      sync.Mutex
+	cancels map[uint64]context.CancelCauseFunc
+	next    uint64
+}
+
+func newRequestTracker() *requestTracker {
+	return &requestTracker{cancels: make(map[uint64]context.CancelCauseFunc)}
+}
+
+// track derives a cancellable child context from parent and stores its cancel
+// func. The caller must call done(id) when the request finishes to release the
+// entry; omitting done leaks the entry until cancelAll is called.
+func (rt *requestTracker) track(parent context.Context) (context.Context, uint64) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	id := rt.next
+	rt.next++
+	ctx, cancel := context.WithCancelCause(parent)
+	rt.cancels[id] = cancel
+	return ctx, id
+}
+
+// done cancels the tracked context (no-op when already cancelled) and removes
+// the entry from the map.
+func (rt *requestTracker) done(id uint64) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if cancel, ok := rt.cancels[id]; ok {
+		cancel(nil)
+		delete(rt.cancels, id)
+	}
+}
+
+// cancelAll cancels every in-flight request with the supplied cause and clears
+// the map. Subsequent track calls are unaffected.
+func (rt *requestTracker) cancelAll(cause error) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for id, cancel := range rt.cancels {
+		cancel(cause)
+		delete(rt.cancels, id)
+	}
+}
+
+// size returns the number of currently tracked requests (used by tests).
+func (rt *requestTracker) size() int {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return len(rt.cancels)
+}

--- a/internal/agentadapter/shutdown_test.go
+++ b/internal/agentadapter/shutdown_test.go
@@ -1,0 +1,81 @@
+package agentadapter
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRequestTrackerTrackAndDone(t *testing.T) {
+	t.Parallel()
+
+	rt := newRequestTracker()
+	ctx := context.Background()
+
+	child, id := rt.track(ctx)
+	if rt.size() != 1 {
+		t.Fatalf("size = %d, want 1 after track", rt.size())
+	}
+	if child.Err() != nil {
+		t.Fatal("tracked context should not be cancelled after track")
+	}
+
+	rt.done(id)
+	if rt.size() != 0 {
+		t.Fatalf("size = %d, want 0 after done", rt.size())
+	}
+	// done cancels the context so any in-flight request unblocks.
+	if child.Err() == nil {
+		t.Fatal("tracked context should be cancelled after done")
+	}
+}
+
+func TestRequestTrackerCancelAllCancelsAllContexts(t *testing.T) {
+	t.Parallel()
+
+	rt := newRequestTracker()
+	ctx := context.Background()
+
+	child1, _ := rt.track(ctx)
+	child2, _ := rt.track(ctx)
+	if rt.size() != 2 {
+		t.Fatalf("size = %d, want 2", rt.size())
+	}
+
+	cause := errors.New("shutdown")
+	rt.cancelAll(cause)
+
+	if rt.size() != 0 {
+		t.Fatalf("size = %d, want 0 after cancelAll", rt.size())
+	}
+	if child1.Err() == nil {
+		t.Fatal("child1 should be cancelled after cancelAll")
+	}
+	if child2.Err() == nil {
+		t.Fatal("child2 should be cancelled after cancelAll")
+	}
+	if !errors.Is(context.Cause(child1), cause) {
+		t.Fatalf("child1 cause = %v, want %v", context.Cause(child1), cause)
+	}
+}
+
+func TestRequestTrackerDoneIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	rt := newRequestTracker()
+	_, id := rt.track(context.Background())
+	rt.done(id)
+	rt.done(id) // second call must not panic
+	if rt.size() != 0 {
+		t.Fatalf("size = %d, want 0", rt.size())
+	}
+}
+
+func TestRequestTrackerCancelAllIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	rt := newRequestTracker()
+	rt.track(context.Background())
+	rt.cancelAll(nil)
+	rt.cancelAll(nil) // second call must not panic
+}

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -126,6 +126,9 @@ func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error 
 		}
 		return nil
 	}
+	// tracker lets shutdown cancel every in-flight forward goroutine before
+	// the WaitGroup resolves, so client.Do calls unblock quickly.
+	tracker := newRequestTracker()
 	var forwards sync.WaitGroup
 	errCh := make(chan error, 1)
 	sendErr := func(err error) {
@@ -141,10 +144,12 @@ func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error 
 		select {
 		case <-ctx.Done():
 			closeIfPossible(opts.Stdin)
+			tracker.cancelAll(context.Cause(ctx))
 			forwards.Wait()
 			return nil
 		case err := <-errCh:
 			closeIfPossible(opts.Stdin)
+			tracker.cancelAll(err)
 			forwards.Wait()
 			return err
 		case result := <-scanResults:
@@ -180,7 +185,9 @@ func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error 
 			forwards.Add(1)
 			go func() {
 				defer forwards.Done()
-				if err := shim.forward(ctx, payload, emit); err != nil && ctx.Err() == nil {
+				fwdCtx, id := tracker.track(ctx)
+				defer tracker.done(id)
+				if err := shim.forward(fwdCtx, payload, emit); err != nil && ctx.Err() == nil {
 					sendErr(err)
 				}
 			}()
@@ -233,6 +240,9 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	}
 
 	protocolVersion, sessionID := s.prepareRequestState(envelope)
+
+	// Tag context with method so RuntimeTransport can key retry and OTel on it.
+	ctx = withRPCMethod(ctx, meta.Method)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.RuntimeURL.String(), bytes.NewReader(payload))
 	if err != nil {
@@ -289,6 +299,12 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 			s.setSessionState(sessionStateFailed)
 		}
 		logRuntimeDenial(s.cfg.LogLevel, s.cfg.LogWriter, "adapter/stdio", resp.StatusCode, extractHTTPErrorMessage(resp.StatusCode, body), meta)
+		if isSessionExpiredBody(body) {
+			if hasResponseID {
+				return emit(jsonRPCSessionExpiredError(envelope.ID, extractHTTPErrorMessage(resp.StatusCode, body)))
+			}
+			return nil
+		}
 		if len(body) > 0 && looksLikeJSONRPC(body) {
 			return emit(body)
 		}
@@ -505,6 +521,25 @@ func jsonRPCMethodNotAllowedError(id json.RawMessage, method string) []byte {
 	encoded, err := json.Marshal(response)
 	if err != nil {
 		return []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32601,"message":"method not allowed"}}`, string(id)))
+	}
+	return encoded
+}
+
+func jsonRPCSessionExpiredError(id json.RawMessage, message string) []byte {
+	response := rpcErrorResponse{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: rpcError{
+			Code:    -32000,
+			Message: message,
+			Data: map[string]any{
+				"runtime_status": "session_expired",
+			},
+		},
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return []byte(fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32000,"message":"session expired","data":{"runtime_status":"session_expired"}}}`, string(id)))
 	}
 	return encoded
 }

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -712,6 +712,46 @@ func TestIdentityApplyOmitsEmptyHeaders(t *testing.T) {
 	}
 }
 
+func TestRunStdioShimSurfacesSessionExpiredRuntimeStatus(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"session_not_found"}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, _ := url.Parse(upstream.URL + "/mcp")
+	var output bytes.Buffer
+	err := RunStdioShim(context.Background(), ShimConfig{
+		RuntimeURL: runtimeURL,
+		Identity: Identity{
+			HumanID:   "human-1",
+			AgentID:   "agent-1",
+			SessionID: "session-1",
+		},
+		Transport: &RuntimeTransport{Base: upstream.Client().Transport},
+	}, StdioOptions{
+		Stdin:  strings.NewReader(`{"jsonrpc":"2.0","id":"exp-1","method":"tools/call","params":{"name":"upper"}}` + "\n"),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+
+	var response rpcErrorResponse
+	if err := json.Unmarshal(bytes.TrimSpace(output.Bytes()), &response); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, output.String())
+	}
+	if string(response.ID) != `"exp-1"` {
+		t.Fatalf("id = %s, want exp-1", response.ID)
+	}
+	if got, _ := response.Error.Data["runtime_status"].(string); got != "session_expired" {
+		t.Fatalf("runtime_status = %q, want session_expired", got)
+	}
+}
+
 func readLineWithin(t *testing.T, reader *bufio.Reader, timeout time.Duration) string {
 	t.Helper()
 	type result struct {

--- a/internal/agentadapter/transport.go
+++ b/internal/agentadapter/transport.go
@@ -1,35 +1,163 @@
 package agentadapter
 
 import (
+	"errors"
+	"io"
+	"net"
 	"net/http"
+	"strings"
+	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	retryMaxAttempts = 3
+	retryBaseDelay   = 100 * time.Millisecond
+	retryMaxDelay    = 1 * time.Second
 )
 
 // RuntimeTransport is the shared outbound HTTP transport used by both the
 // reverse proxy and the stdio shim when forwarding to the runtime. It owns
-// the base round-tripper and the per-request timeout so production gates
-// (mTLS, bearer auth, retries, OTel) get implemented in a single place and
-// behave identically for both adapters.
+// every production gate — auth, OTel instrumentation, and method-keyed retry —
+// so both adapters behave identically with a single implementation.
 type RuntimeTransport struct {
-	// Base is the underlying round-tripper. nil means http.DefaultTransport
-	// (production); tests can swap in a mock by setting this field.
+	// Base is the underlying round-tripper. nil means http.DefaultTransport.
+	// Tests swap in a mock by setting this field.
 	Base http.RoundTripper
 	// Timeout is the per-request timeout applied to the *http.Client wrapper
-	// returned by Client(). Zero means no timeout (matches the previous
-	// "unbounded by default" behavior).
+	// returned by Client(). Zero means no timeout.
 	Timeout time.Duration
+	// AuthHeader is a static Authorization header value injected into every
+	// outbound request (e.g. "Bearer <token>"). Empty means no header is set.
+	AuthHeader string
+	// Tracer is an optional OTel tracer. When non-nil, RoundTrip opens one
+	// client span per RPC labelled with the JSON-RPC method name.
+	Tracer trace.Tracer
+	// Meter is an optional OTel meter. When non-nil, RoundTrip records a
+	// latency histogram and a denial counter keyed by method name.
+	Meter metric.Meter
+
+	otelOnce    sync.Once
+	latencyHist metric.Float64Histogram
+	denialCount metric.Int64Counter
 }
 
-// RoundTrip implements http.RoundTripper so the transport can plug directly
-// into httputil.ReverseProxy.Transport.
+// RoundTrip implements http.RoundTripper. Execution order per call:
+//  1. Start OTel span (if Tracer is set).
+//  2. Inject Authorization header (if AuthHeader is set).
+//  3. Execute the request, retrying idempotent methods on gateway errors.
+//  4. Record OTel latency histogram and denial counter (if Meter is set).
+//  5. Set span outcome and end it.
 func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	base := t.base()
-	return base.RoundTrip(req)
+	method := rpcMethodFromContext(req.Context())
+
+	// 1. Start OTel span before any I/O.
+	var span trace.Span
+	if t != nil && t.Tracer != nil {
+		spanName := method
+		if spanName == "" {
+			spanName = "rpc"
+		}
+		_, span = t.Tracer.Start(req.Context(), "adapter.rpc/"+spanName,
+			trace.WithSpanKind(trace.SpanKindClient),
+			trace.WithAttributes(attribute.String("rpc.method", spanName)))
+		defer span.End()
+	}
+
+	// 2. Inject auth header without mutating the caller's copy.
+	if t != nil && t.AuthHeader != "" {
+		cloned := req.Clone(req.Context())
+		cloned.Header.Set("Authorization", t.AuthHeader)
+		req = cloned
+	}
+
+	retryable := isRetryableMethod(method)
+	maxAttempts := 1
+	if retryable {
+		maxAttempts = retryMaxAttempts
+	}
+
+	// 3. Retry loop.
+	baseReq := req
+	start := time.Now()
+	var resp *http.Response
+	var lastErr error
+
+	for i := 0; i < maxAttempts; i++ {
+		if i > 0 {
+			select {
+			case <-req.Context().Done():
+				lastErr = req.Context().Err()
+				goto done
+			case <-time.After(retryBackoff(i)):
+			}
+			// Rehydrate the request body from the factory so the retry
+			// sends a fresh reader over the same in-memory bytes.
+			if baseReq.GetBody == nil {
+				break
+			}
+			body, err := baseReq.GetBody()
+			if err != nil {
+				break
+			}
+			req = baseReq.Clone(req.Context())
+			req.Body = body
+		}
+
+		resp, lastErr = t.base().RoundTrip(req)
+		if lastErr != nil {
+			if isRetryableError(lastErr) {
+				continue
+			}
+			break
+		}
+		if !shouldRetryStatus(resp.StatusCode) {
+			break
+		}
+		// Drain body before retry to allow connection reuse.
+		if i < maxAttempts-1 {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			resp = nil
+		}
+	}
+
+done:
+	// 4. Record OTel metrics.
+	if t != nil && t.Meter != nil {
+		t.initOTelInstruments()
+		elapsed := float64(time.Since(start).Milliseconds())
+		attrs := metric.WithAttributes(attribute.String("rpc.method", method))
+		t.latencyHist.Record(req.Context(), elapsed, attrs)
+		if lastErr == nil && resp != nil && resp.StatusCode >= http.StatusBadRequest {
+			t.denialCount.Add(req.Context(), 1, attrs)
+		}
+	}
+
+	// 5. Finalise span.
+	if span != nil {
+		if lastErr != nil {
+			span.RecordError(lastErr)
+			span.SetStatus(otelcodes.Error, lastErr.Error())
+		} else if resp != nil && resp.StatusCode >= http.StatusBadRequest {
+			span.SetStatus(otelcodes.Error, http.StatusText(resp.StatusCode))
+			span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
+		} else {
+			span.SetStatus(otelcodes.Ok, "")
+		}
+	}
+
+	return resp, lastErr
 }
 
 // Client returns an *http.Client whose Transport is this RuntimeTransport.
-// Both the stdio shim and the reverse proxy route outbound requests through
-// this wrapper so auth, OTel, and retry logic lives in one place.
+// Both adapters route requests through this wrapper so every gate (auth, OTel,
+// retry) applies uniformly.
 func (t *RuntimeTransport) Client() *http.Client {
 	var timeout time.Duration
 	if t != nil {
@@ -38,8 +166,8 @@ func (t *RuntimeTransport) Client() *http.Client {
 	return &http.Client{Transport: t, Timeout: timeout}
 }
 
-// CloseIdleConnections drains idle connections on the base round-tripper if
-// it supports the optional interface, matching net/http's contract.
+// CloseIdleConnections drains idle connections on the base round-tripper if it
+// supports the optional interface, matching net/http's contract.
 func (t *RuntimeTransport) CloseIdleConnections() {
 	if closer, ok := t.base().(interface{ CloseIdleConnections() }); ok {
 		closer.CloseIdleConnections()
@@ -51,4 +179,55 @@ func (t *RuntimeTransport) base() http.RoundTripper {
 		return http.DefaultTransport
 	}
 	return t.Base
+}
+
+func (t *RuntimeTransport) initOTelInstruments() {
+	t.otelOnce.Do(func() {
+		t.latencyHist, _ = t.Meter.Float64Histogram(
+			"mcp_adapter_rpc_duration_ms",
+			metric.WithDescription("Adapter→runtime RPC round-trip duration in milliseconds"),
+		)
+		t.denialCount, _ = t.Meter.Int64Counter(
+			"mcp_adapter_rpc_denials_total",
+			metric.WithDescription("Total 4xx denial responses seen by the adapter"),
+		)
+	})
+}
+
+// retryableMethods lists the read-only MCP methods safe to replay on a
+// transient gateway failure. tools/call and other mutating methods are never
+// retried to avoid double-execution.
+var retryableMethods = map[string]struct{}{
+	"tools/list":     {},
+	"resources/list": {},
+	"prompts/list":   {},
+	"ping":           {},
+}
+
+func isRetryableMethod(method string) bool {
+	_, ok := retryableMethods[method]
+	return ok
+}
+
+func shouldRetryStatus(status int) bool {
+	return status == http.StatusBadGateway || status == http.StatusGatewayTimeout
+}
+
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return !netErr.Timeout()
+	}
+	return strings.Contains(err.Error(), "connection reset by peer")
+}
+
+func retryBackoff(attempt int) time.Duration {
+	d := retryBaseDelay << uint(attempt-1)
+	if d > retryMaxDelay {
+		return retryMaxDelay
+	}
+	return d
 }

--- a/internal/agentadapter/transport.go
+++ b/internal/agentadapter/transport.go
@@ -116,7 +116,10 @@ func (t *RuntimeTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 			}
 			break
 		}
-		if !shouldRetryStatus(resp.StatusCode) {
+		// Defensive nil check: the RoundTripper contract guarantees a
+		// non-nil resp when err is nil, but a misbehaving Base might
+		// violate it and panic the adapter.
+		if resp == nil || !shouldRetryStatus(resp.StatusCode) {
 			break
 		}
 		// Drain body before retry to allow connection reuse.
@@ -134,7 +137,10 @@ done:
 		elapsed := float64(time.Since(start).Milliseconds())
 		attrs := metric.WithAttributes(attribute.String("rpc.method", method))
 		t.latencyHist.Record(req.Context(), elapsed, attrs)
-		if lastErr == nil && resp != nil && resp.StatusCode >= http.StatusBadRequest {
+		// Only count 4xx as denials: 5xx is an upstream failure and would
+		// inflate the denial metric, misclassifying availability incidents
+		// as authorization/policy denials.
+		if lastErr == nil && resp != nil && resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError {
 			t.denialCount.Add(req.Context(), 1, attrs)
 		}
 	}
@@ -225,9 +231,15 @@ func isRetryableError(err error) bool {
 }
 
 func retryBackoff(attempt int) time.Duration {
-	d := retryBaseDelay << uint(attempt-1)
-	if d > retryMaxDelay {
-		return retryMaxDelay
+	if attempt <= 1 {
+		return retryBaseDelay
+	}
+	d := retryBaseDelay
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= retryMaxDelay {
+			return retryMaxDelay
+		}
 	}
 	return d
 }

--- a/internal/agentadapter/transport_test.go
+++ b/internal/agentadapter/transport_test.go
@@ -1,7 +1,10 @@
 package agentadapter
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -65,5 +68,111 @@ func TestRuntimeTransportNilReceiverClientDoesNotPanic(t *testing.T) {
 	}
 	if client.Timeout != 0 {
 		t.Fatalf("client.Timeout = %s, want 0 for nil receiver", client.Timeout)
+	}
+}
+
+func TestRuntimeTransportInjectsAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	transport := &RuntimeTransport{
+		AuthHeader: "Bearer test-token",
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			gotAuth = req.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}, Request: req}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "http://example/mcp", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("Authorization header = %q, want Bearer test-token", gotAuth)
+	}
+}
+
+func TestRuntimeTransportAuthHeaderDoesNotMutateOriginalRequest(t *testing.T) {
+	t.Parallel()
+
+	transport := &RuntimeTransport{
+		AuthHeader: "Bearer secret",
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}, Request: req}, nil
+		}),
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, "http://example/mcp", nil)
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	if got := req.Header.Get("Authorization"); got != "" {
+		t.Fatalf("original request Authorization = %q, want empty (must not mutate caller)", got)
+	}
+}
+
+func TestRuntimeTransportRetriesRetryableMethodOnBadGateway(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	transport := &RuntimeTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < retryMaxAttempts {
+				return &http.Response{
+					StatusCode: http.StatusBadGateway,
+					Body:       io.NopCloser(strings.NewReader("")),
+					Header:     http.Header{},
+					Request:    req,
+				}, nil
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: http.Header{}, Request: req}, nil
+		}),
+	}
+
+	ctx := withRPCMethod(context.Background(), "tools/list")
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example/mcp", strings.NewReader(`{}`))
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d after retry", resp.StatusCode, http.StatusOK)
+	}
+	if attempts != retryMaxAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts, retryMaxAttempts)
+	}
+}
+
+func TestRuntimeTransportDoesNotRetryNonRetryableMethod(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	transport := &RuntimeTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     http.Header{},
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	ctx := withRPCMethod(context.Background(), "tools/call")
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example/mcp", strings.NewReader(`{}`))
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v", err)
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d (no retry for tools/call)", resp.StatusCode, http.StatusBadGateway)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry for tools/call)", attempts)
 	}
 }

--- a/internal/agentadapter/transport_test.go
+++ b/internal/agentadapter/transport_test.go
@@ -176,3 +176,48 @@ func TestRuntimeTransportDoesNotRetryNonRetryableMethod(t *testing.T) {
 		t.Fatalf("attempts = %d, want 1 (no retry for tools/call)", attempts)
 	}
 }
+
+func TestRuntimeTransportNilRespDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// Misbehaving base: returns (nil, nil), violating the RoundTripper
+	// contract. The transport must not panic.
+	transport := &RuntimeTransport{
+		Base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, nil
+		}),
+	}
+
+	ctx := withRPCMethod(context.Background(), "tools/list")
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "http://example/mcp", strings.NewReader(`{}`))
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() error = %v, want nil", err)
+	}
+	if resp != nil {
+		t.Fatalf("resp = %#v, want nil for nil-returning base", resp)
+	}
+}
+
+func TestRetryBackoffCapsWithoutShiftConversion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{attempt: 0, want: retryBaseDelay},
+		{attempt: 1, want: retryBaseDelay},
+		{attempt: 2, want: 2 * retryBaseDelay},
+		{attempt: 20, want: retryMaxDelay},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.want.String(), func(t *testing.T) {
+			t.Parallel()
+			if got := retryBackoff(tt.attempt); got != tt.want {
+				t.Fatalf("retryBackoff(%d) = %s, want %s", tt.attempt, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/adapter/flags.go
+++ b/internal/cli/adapter/flags.go
@@ -226,11 +226,8 @@ func parseEnvBoolSimple(name string) bool {
 	}
 }
 
-// newHTTPTransportWithTLS returns a *http.Transport that uses the supplied TLS
-// config. It clones http.DefaultTransport's settings so timeouts and keep-alive
-// behaviour are preserved.
+// newHTTPTransportWithTLS delegates to the shared agentadapter helper so the
+// env and flag paths produce identical transports.
 func newHTTPTransportWithTLS(cfg *tls.Config) *http.Transport {
-	base := http.DefaultTransport.(*http.Transport).Clone()
-	base.TLSClientConfig = cfg
-	return base
+	return agentadapter.NewHTTPTransportWithTLS(cfg)
 }

--- a/internal/cli/adapter/flags.go
+++ b/internal/cli/adapter/flags.go
@@ -1,7 +1,9 @@
 package adapter
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -26,6 +28,11 @@ type identityFlags struct {
 	requestTimeout  string
 	logLevel        string
 	disableXFF      bool
+	// upstream auth / TLS
+	authHeader    string
+	tlsClientCert string
+	tlsClientKey  string
+	tlsCABundle   string
 	// stdio-only
 	anonymous        bool
 	anonymousMethods string
@@ -52,6 +59,14 @@ func bindIdentityFlags(cmd *cobra.Command, f *identityFlags) {
 		"Do not set X-Forwarded-* headers when forwarding to the runtime")
 	cmd.Flags().StringVar(&f.requestTimeout, "request-timeout", os.Getenv(agentadapter.EnvRequestTimeout),
 		"HTTP request timeout for adapter→runtime calls, e.g. 30s (default: $"+agentadapter.EnvRequestTimeout+")")
+	cmd.Flags().StringVar(&f.authHeader, "auth-header", os.Getenv(agentadapter.EnvAuthHeader),
+		"Static Authorization header value for runtime requests, e.g. \"Bearer <token>\" (default: $"+agentadapter.EnvAuthHeader+")")
+	cmd.Flags().StringVar(&f.tlsClientCert, "tls-client-cert", os.Getenv(agentadapter.EnvTLSClientCert),
+		"Path to PEM client certificate for mTLS to the runtime (default: $"+agentadapter.EnvTLSClientCert+")")
+	cmd.Flags().StringVar(&f.tlsClientKey, "tls-client-key", os.Getenv(agentadapter.EnvTLSClientKey),
+		"Path to PEM client key for mTLS to the runtime (default: $"+agentadapter.EnvTLSClientKey+")")
+	cmd.Flags().StringVar(&f.tlsCABundle, "tls-ca-bundle", os.Getenv(agentadapter.EnvTLSCABundle),
+		"Path to PEM CA bundle to verify the runtime's TLS certificate (default: $"+agentadapter.EnvTLSCABundle+")")
 }
 
 // resolved holds the validated cross-cutting pieces of an adapter config —
@@ -93,6 +108,25 @@ func (f identityFlags) resolve() (resolved, error) {
 			return resolved{}, fmt.Errorf("--request-timeout (or $%s) must be greater than zero", agentadapter.EnvRequestTimeout)
 		}
 		out.transport = &agentadapter.RuntimeTransport{Timeout: timeout}
+	}
+	if raw := strings.TrimSpace(f.authHeader); raw != "" {
+		if out.transport == nil {
+			out.transport = &agentadapter.RuntimeTransport{}
+		}
+		out.transport.AuthHeader = raw
+	}
+	tlsCert := strings.TrimSpace(f.tlsClientCert)
+	tlsKey := strings.TrimSpace(f.tlsClientKey)
+	tlsCA := strings.TrimSpace(f.tlsCABundle)
+	if tlsCert != "" || tlsKey != "" || tlsCA != "" {
+		tlsCfg, err := agentadapter.BuildTLSConfig(tlsCert, tlsKey, tlsCA)
+		if err != nil {
+			return resolved{}, fmt.Errorf("TLS config: %w", err)
+		}
+		if out.transport == nil {
+			out.transport = &agentadapter.RuntimeTransport{}
+		}
+		out.transport.Base = newHTTPTransportWithTLS(tlsCfg)
 	}
 
 	if raw := strings.TrimSpace(f.runtimeURL); raw != "" {
@@ -190,4 +224,13 @@ func parseEnvBoolSimple(name string) bool {
 	default:
 		return false
 	}
+}
+
+// newHTTPTransportWithTLS returns a *http.Transport that uses the supplied TLS
+// config. It clones http.DefaultTransport's settings so timeouts and keep-alive
+// behaviour are preserved.
+func newHTTPTransportWithTLS(cfg *tls.Config) *http.Transport {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	base.TLSClientConfig = cfg
+	return base
 }

--- a/test/golden/cli/testdata/mcp-runtime_adapter_proxy_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_adapter_proxy_help.golden
@@ -10,6 +10,7 @@ Usage:
 
 Flags:
       --agent-id string           Issued agent identity (default: $MCP_RUNTIME_AGENT_ID)
+      --auth-header string        Static Authorization header value for runtime requests, e.g. "Bearer <token>" (default: $MCP_RUNTIME_AUTH_HEADER)
   -h, --help                      help for proxy
       --host-header string        Override the Host header sent to the runtime (default: $MCP_RUNTIME_HOST_HEADER)
       --human-id string           Issued human identity (default: $MCP_RUNTIME_HUMAN_ID)
@@ -21,6 +22,9 @@ Flags:
       --runtime-url string        Platform-issued absolute MCP runtime URL (default: $MCP_RUNTIME_URL)
       --session-id string         Issued agent session identity (default: $MCP_RUNTIME_SESSION_ID)
       --team-id string            Issued team identity for team-scoped grants (default: $MCP_RUNTIME_TEAM_ID)
+      --tls-ca-bundle string      Path to PEM CA bundle to verify the runtime's TLS certificate (default: $MCP_RUNTIME_TLS_CA_BUNDLE)
+      --tls-client-cert string    Path to PEM client certificate for mTLS to the runtime (default: $MCP_RUNTIME_TLS_CLIENT_CERT)
+      --tls-client-key string     Path to PEM client key for mTLS to the runtime (default: $MCP_RUNTIME_TLS_CLIENT_KEY)
 
 Global Flags:
       --debug   Enable debug mode with structured error logging

--- a/test/golden/cli/testdata/mcp-runtime_adapter_stdio_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_adapter_stdio_help.golden
@@ -13,6 +13,7 @@ Flags:
       --agent-id string            Issued agent identity (default: $MCP_RUNTIME_AGENT_ID)
       --anonymous                  Forward to the runtime without a session or issued identity (public/read-only routes); only methods in --anonymous-methods are forwarded (default: $MCP_RUNTIME_ANONYMOUS)
       --anonymous-methods string   Comma-separated list of MCP methods allowed in anonymous mode (default: $MCP_RUNTIME_ANONYMOUS_METHODS or initialize,notifications/initialized,ping,tools/list,resources/list,prompts/list)
+      --auth-header string         Static Authorization header value for runtime requests, e.g. "Bearer <token>" (default: $MCP_RUNTIME_AUTH_HEADER)
   -h, --help                       help for stdio
       --host-header string         Override the Host header sent to the runtime (default: $MCP_RUNTIME_HOST_HEADER)
       --human-id string            Issued human identity (default: $MCP_RUNTIME_HUMAN_ID)
@@ -23,6 +24,9 @@ Flags:
       --runtime-url string         Platform-issued absolute MCP runtime URL (default: $MCP_RUNTIME_URL)
       --session-id string          Issued agent session identity (default: $MCP_RUNTIME_SESSION_ID)
       --team-id string             Issued team identity for team-scoped grants (default: $MCP_RUNTIME_TEAM_ID)
+      --tls-ca-bundle string       Path to PEM CA bundle to verify the runtime's TLS certificate (default: $MCP_RUNTIME_TLS_CA_BUNDLE)
+      --tls-client-cert string     Path to PEM client certificate for mTLS to the runtime (default: $MCP_RUNTIME_TLS_CLIENT_CERT)
+      --tls-client-key string      Path to PEM client key for mTLS to the runtime (default: $MCP_RUNTIME_TLS_CLIENT_KEY)
 
 Global Flags:
       --debug   Enable debug mode with structured error logging


### PR DESCRIPTION
## Summary

Phase 4 of the agent-adapter improvements from #165. Adds five production gates on the shared `RuntimeTransport` so both the HTTP proxy and stdio shim benefit from a single implementation.

- **Shutdown cancellation**: `requestTracker` tracks every in-flight request via `context.CancelCauseFunc`. `RunHTTPProxy` now does `cancelAll → server.Shutdown → server.Close` fallback; `RunStdioShim` does `cancelAll → forwards.Wait()`. In-flight `client.Do` calls return immediately on ctx cancel.
- **Upstream auth / TLS**: `RuntimeTransport.AuthHeader` (static Authorization injected via `req.Clone`) and `BuildTLSConfig` (mTLS client cert/key + optional CA bundle). Env: `MCP_RUNTIME_AUTH_HEADER`, `MCP_RUNTIME_TLS_CLIENT_{CERT,KEY}`, `MCP_RUNTIME_TLS_CA_BUNDLE`. CLI flags mirror these on both subcommands.
- **OTel instrumentation**: optional `Tracer` and `Meter` fields on `RuntimeTransport`. One client span per RPC with `rpc.method` attribute; `mcp_adapter_rpc_duration_ms` histogram and `mcp_adapter_rpc_denials_total` counter. Instruments lazily initialised with `sync.Once`.
- **Method-keyed retry**: `tools/list`, `resources/list`, `prompts/list`, `ping` retried on 502/504/connection-reset; `tools/call` never retried. Method propagated through `context` via `withRPCMethod` so the transport stays decoupled from either adapter's call stack. Backoff: 100ms → 200ms → 1s cap.
- **Session-expiry signaling**: `isSessionExpiredBody` detects `session_expired` / `session_not_found` in denial bodies. Stdio emits `jsonRPCSessionExpiredError` with `error.data.runtime_status = "session_expired"`. Proxy's `ModifyResponse` calls `injectRuntimeStatus` on session-expired JSON-RPC bodies passing through.

Five remaining items from the issue (#1 IdentityProvider, #5 streaming JSON, #7 tools/list cache, plus Phase 5/6/7 work) are out of scope here — they need broader changes (platform-issued adapter sessions, doc rewrite, integration test scaffolding) per the Phase 5–7 plan.

## Test plan

- [x] `go test ./internal/agentadapter/... -race -count=1` — passes (new shutdown_test, transport auth/retry tests, proxy and stdio session-expiry tests)
- [x] `go test ./test/golden/... -count=1` — passes (both adapter help goldens updated for the four new flags)
- [x] `go build ./... && go vet ./...` — clean
- [x] Pre-commit (gofmt, staticcheck, go vet, full unit tests, generated-file-drift) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)