### PR TITLE
feat(agentadapter): Phase 5 — streaming/observability/cache

### DIFF
--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -1892,6 +1892,8 @@ const (
 	EnvTLSClientCert    = "MCP_RUNTIME_TLS_CLIENT_CERT"
 	EnvTLSClientKey     = "MCP_RUNTIME_TLS_CLIENT_KEY"
 	EnvTLSCABundle      = "MCP_RUNTIME_TLS_CA_BUNDLE"
+	EnvMaxInboundBytes  = "MCP_RUNTIME_MAX_INBOUND_BYTES"
+	EnvToolsCacheTTL    = "MCP_RUNTIME_TOOLS_CACHE_TTL"
 
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
@@ -1902,6 +1904,13 @@ const (
 	AgentSessionHeader = "X-MCP-Agent-Session"
 	MCPProtocolHeader  = "Mcp-Protocol-Version"
 	MCPSessionHeader   = "Mcp-Session-Id"
+)
+const (
+
+	// DefaultMaxInboundBytes caps the size of inbound JSON-RPC bodies that
+	// the proxy buffers for metadata capture. Requests over the cap get a
+	// 413 with a JSON-RPC parse-error body so the agent SDK can recover.
+	DefaultMaxInboundBytes int64 = 16 << 20
 )
 ```
 
@@ -2014,6 +2023,14 @@ type ProxyConfig struct {
 	LogLevel          string
 	LogWriter         io.Writer
 	DisableXForwarded bool
+	// MaxInboundBytes caps the size of JSON-RPC request bodies the proxy
+	// buffers when capturing metadata. Zero (or negative) means use
+	// DefaultMaxInboundBytes (16 MiB). Over-cap requests respond with 413.
+	MaxInboundBytes int64
+	// MetricsHandler, when set, is served at /metrics. Typical use: a
+	// Prometheus exporter wired to the OTel MeterProvider that backs
+	// RuntimeTransport.Meter. Nil → /metrics returns 404.
+	MetricsHandler http.Handler
 }
     ProxyConfig configures the local HTTP reverse-proxy adapter that exposes
     Streamable HTTP MCP to an agent SDK.
@@ -2110,6 +2127,11 @@ type ShimConfig struct {
 	// AnonymousMethods is the allowlist used when Anonymous is true. When empty
 	// the DefaultAnonymousMethods list applies.
 	AnonymousMethods []string
+	// ToolsCacheTTL enables a process-local tools/list response cache when
+	// set to a positive duration. Zero (or negative) disables the cache.
+	// Entries are keyed by identity + runtime URL and invalidated on a
+	// tools/list_changed notification or when the TTL expires.
+	ToolsCacheTTL time.Duration
 }
     ShimConfig configures the stdio adapter that bridges newline-delimited
     JSON-RPC MCP traffic to the runtime over HTTP.

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -31,6 +32,8 @@ const (
 	EnvTLSClientCert    = "MCP_RUNTIME_TLS_CLIENT_CERT"
 	EnvTLSClientKey     = "MCP_RUNTIME_TLS_CLIENT_KEY"
 	EnvTLSCABundle      = "MCP_RUNTIME_TLS_CA_BUNDLE"
+	EnvMaxInboundBytes  = "MCP_RUNTIME_MAX_INBOUND_BYTES"
+	EnvToolsCacheTTL    = "MCP_RUNTIME_TOOLS_CACHE_TTL"
 
 	DefaultListenAddr      = "127.0.0.1:8099"
 	DefaultProtocolVersion = "2025-06-18"
@@ -57,6 +60,14 @@ type ProxyConfig struct {
 	LogLevel          string
 	LogWriter         io.Writer
 	DisableXForwarded bool
+	// MaxInboundBytes caps the size of JSON-RPC request bodies the proxy
+	// buffers when capturing metadata. Zero (or negative) means use
+	// DefaultMaxInboundBytes (16 MiB). Over-cap requests respond with 413.
+	MaxInboundBytes int64
+	// MetricsHandler, when set, is served at /metrics. Typical use: a
+	// Prometheus exporter wired to the OTel MeterProvider that backs
+	// RuntimeTransport.Meter. Nil → /metrics returns 404.
+	MetricsHandler http.Handler
 }
 
 // ShimConfig configures the stdio adapter that bridges newline-delimited
@@ -77,6 +88,11 @@ type ShimConfig struct {
 	// AnonymousMethods is the allowlist used when Anonymous is true. When empty
 	// the DefaultAnonymousMethods list applies.
 	AnonymousMethods []string
+	// ToolsCacheTTL enables a process-local tools/list response cache when
+	// set to a positive duration. Zero (or negative) disables the cache.
+	// Entries are keyed by identity + runtime URL and invalidated on a
+	// tools/list_changed notification or when the TTL expires.
+	ToolsCacheTTL time.Duration
 }
 
 // DefaultAnonymousMethods is the set of MCP methods the stdio shim allows in
@@ -123,6 +139,13 @@ func loadProxyConfig(lookup envLookup) (ProxyConfig, error) {
 		}
 		cfg.DisableXForwarded = !setXForwarded
 	}
+	if raw := strings.TrimSpace(lookup(EnvMaxInboundBytes)); raw != "" {
+		n, err := parsePositiveBytes(raw)
+		if err != nil {
+			return ProxyConfig{}, fmt.Errorf("%s is invalid: %w", EnvMaxInboundBytes, err)
+		}
+		cfg.MaxInboundBytes = n
+	}
 	if err := cfg.Validate(); err != nil {
 		return ProxyConfig{}, err
 	}
@@ -152,10 +175,30 @@ func loadShimConfig(lookup envLookup) (ShimConfig, error) {
 	if raw := strings.TrimSpace(lookup(EnvAnonymousMethods)); raw != "" {
 		cfg.AnonymousMethods = SplitTrimmed(raw, ",")
 	}
+	if raw := strings.TrimSpace(lookup(EnvToolsCacheTTL)); raw != "" {
+		ttl, err := time.ParseDuration(raw)
+		if err != nil {
+			return ShimConfig{}, fmt.Errorf("%s is invalid: %w", EnvToolsCacheTTL, err)
+		}
+		cfg.ToolsCacheTTL = ttl
+	}
 	if err := cfg.Validate(); err != nil {
 		return ShimConfig{}, err
 	}
 	return cfg, nil
+}
+
+// parsePositiveBytes parses an int64 byte size from a string. Negative values
+// or unparseable input return an error.
+func parsePositiveBytes(s string) (int64, error) {
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("expected positive integer bytes, got %q", s)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("must be greater than zero")
+	}
+	return n, nil
 }
 
 // Validate enforces the runtime identity invariants for the HTTP proxy.

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -140,7 +140,7 @@ func loadProxyConfig(lookup envLookup) (ProxyConfig, error) {
 		cfg.DisableXForwarded = !setXForwarded
 	}
 	if raw := strings.TrimSpace(lookup(EnvMaxInboundBytes)); raw != "" {
-		n, err := parsePositiveBytes(raw)
+		n, err := parseNonNegativeBytes(raw)
 		if err != nil {
 			return ProxyConfig{}, fmt.Errorf("%s is invalid: %w", EnvMaxInboundBytes, err)
 		}
@@ -188,15 +188,16 @@ func loadShimConfig(lookup envLookup) (ShimConfig, error) {
 	return cfg, nil
 }
 
-// parsePositiveBytes parses an int64 byte size from a string. Negative values
-// or unparseable input return an error.
-func parsePositiveBytes(s string) (int64, error) {
+// parseNonNegativeBytes parses an int64 byte size from a string. Zero is
+// allowed and signals "use the default" to callers; negative values or
+// unparseable input return an error.
+func parseNonNegativeBytes(s string) (int64, error) {
 	n, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("expected positive integer bytes, got %q", s)
+		return 0, fmt.Errorf("expected non-negative integer bytes, got %q", s)
 	}
-	if n <= 0 {
-		return 0, fmt.Errorf("must be greater than zero")
+	if n < 0 {
+		return 0, fmt.Errorf("must be zero or positive")
 	}
 	return n, nil
 }

--- a/internal/agentadapter/config_test.go
+++ b/internal/agentadapter/config_test.go
@@ -287,3 +287,31 @@ func TestBuildTLSConfigRejectsDirectoryCABundle(t *testing.T) {
 func pemForCertificate(cert *x509.Certificate) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 }
+
+func TestParseNonNegativeBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in      string
+		want    int64
+		wantErr bool
+	}{
+		{in: "0", want: 0},
+		{in: "1024", want: 1024},
+		{in: "-1", wantErr: true},
+		{in: "abc", wantErr: true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseNonNegativeBytes(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseNonNegativeBytes(%q) error = %v, wantErr = %v", tt.in, err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Fatalf("parseNonNegativeBytes(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -16,6 +16,10 @@ import (
 const (
 	proxyReadHeaderTimeout = 5 * time.Second
 	proxyShutdownTimeout   = 10 * time.Second
+	// DefaultMaxInboundBytes caps the size of inbound JSON-RPC bodies that
+	// the proxy buffers for metadata capture. Requests over the cap get a
+	// 413 with a JSON-RPC parse-error body so the agent SDK can recover.
+	DefaultMaxInboundBytes int64 = 16 << 20
 )
 
 type rpcRequestMetadataContextKey struct{}
@@ -83,18 +87,41 @@ func newProxyHandlerAndTracker(cfg ProxyConfig) (http.Handler, *requestTracker, 
 		},
 	}
 
+	maxInbound := cfg.MaxInboundBytes
+	if maxInbound <= 0 {
+		maxInbound = DefaultMaxInboundBytes
+	}
+	metricsHandler := cfg.MetricsHandler
+
 	tracker := newRequestTracker()
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/healthz" {
+		switch r.URL.Path {
+		case "/healthz", "/livez":
 			w.WriteHeader(http.StatusNoContent)
+			return
+		case "/readyz":
+			w.WriteHeader(http.StatusNoContent)
+			return
+		case "/metrics":
+			if metricsHandler == nil {
+				http.Error(w, "metrics handler not configured", http.StatusNotFound)
+				return
+			}
+			metricsHandler.ServeHTTP(w, r)
 			return
 		}
 		// Track the request so shutdown can cancel it explicitly.
 		reqCtx, id := tracker.track(r.Context())
 		defer tracker.done(id)
 
-		meta, err := captureRPCRequestMetadata(r)
+		meta, err := captureRPCRequestMetadata(r, maxInbound)
 		if err != nil {
+			if errors.Is(err, errInboundBodyTooLarge) {
+				w.Header().Set("content-type", "application/json")
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				_, _ = w.Write(jsonRPCParseError("request body exceeds adapter limit"))
+				return
+			}
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
@@ -170,15 +197,24 @@ func mergeRawQuery(first, second string) string {
 	}
 }
 
-func captureRPCRequestMetadata(r *http.Request) (rpcRequestMetadata, error) {
+// errInboundBodyTooLarge signals that the inbound JSON-RPC body exceeded the
+// configured cap. Callers translate it to HTTP 413.
+var errInboundBodyTooLarge = errors.New("inbound body exceeds configured limit")
+
+func captureRPCRequestMetadata(r *http.Request, maxBytes int64) (rpcRequestMetadata, error) {
 	if r.Body == nil {
 		return rpcRequestMetadata{}, nil
 	}
-	body, err := io.ReadAll(r.Body)
+	// Read up to maxBytes+1 so we can distinguish "exactly at cap" from
+	// "over cap" without buffering an arbitrary amount.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBytes+1))
 	if err != nil {
 		return rpcRequestMetadata{}, err
 	}
 	_ = r.Body.Close()
+	if int64(len(body)) > maxBytes {
+		return rpcRequestMetadata{}, errInboundBodyTooLarge
+	}
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	r.ContentLength = int64(len(body))
 	r.GetBody = func() (io.ReadCloser, error) {

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -206,8 +207,13 @@ func captureRPCRequestMetadata(r *http.Request, maxBytes int64) (rpcRequestMetad
 		return rpcRequestMetadata{}, nil
 	}
 	// Read up to maxBytes+1 so we can distinguish "exactly at cap" from
-	// "over cap" without buffering an arbitrary amount.
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBytes+1))
+	// "over cap" without buffering an arbitrary amount. Guard against
+	// integer overflow when the caller configures math.MaxInt64.
+	limit := maxBytes
+	if limit < math.MaxInt64 {
+		limit++
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, limit))
 	if err != nil {
 		return rpcRequestMetadata{}, err
 	}

--- a/internal/agentadapter/proxy_test.go
+++ b/internal/agentadapter/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -404,6 +405,37 @@ func TestHTTPProxyInjectsRuntimeStatusOnSessionExpiredDenial(t *testing.T) {
 	}
 	if got, _ := response.Error.Data["runtime_status"].(string); got != "session_expired" {
 		t.Fatalf("runtime_status = %q, want session_expired", got)
+	}
+}
+
+func TestHTTPProxyMaxInboundBytesMaxInt64DoesNotOverflow(t *testing.T) {
+	t.Parallel()
+
+	var upstreamCalled bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, _ := url.Parse(upstream.URL + "/mcp")
+	cfg := testConfig(target)
+	// Setting maxBytes to MaxInt64 must not overflow when the handler computes
+	// maxBytes+1 internally; reads should succeed and the upstream should see
+	// the full body.
+	cfg.MaxInboundBytes = math.MaxInt64
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (cap=MaxInt64 must not cause early EOF)", w.Code)
+	}
+	if !upstreamCalled {
+		t.Fatal("upstream was not called; cap=MaxInt64 likely overflowed to a negative LimitReader")
 	}
 }
 

--- a/internal/agentadapter/proxy_test.go
+++ b/internal/agentadapter/proxy_test.go
@@ -407,6 +407,99 @@ func TestHTTPProxyInjectsRuntimeStatusOnSessionExpiredDenial(t *testing.T) {
 	}
 }
 
+func TestHTTPProxyReturns413WhenInboundExceedsCap(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("upstream must not be called when inbound body is rejected")
+	}))
+	t.Cleanup(upstream.Close)
+
+	target, _ := url.Parse(upstream.URL + "/mcp")
+	cfg := testConfig(target)
+	cfg.MaxInboundBytes = 64
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+
+	// Body larger than the 64-byte cap.
+	big := strings.Repeat("a", 200)
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1:8099/mcp", strings.NewReader(big))
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+	if !bytes.Contains(recorder.Body.Bytes(), []byte(`"code":-32700`)) {
+		t.Fatalf("body = %s, want JSON-RPC parse error", recorder.Body.String())
+	}
+}
+
+func TestHTTPProxyHealthEndpoints(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	target, _ := url.Parse(upstream.URL + "/mcp")
+	handler, err := NewHTTPProxyHandler(testConfig(target))
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+	for _, path := range []string{"/healthz", "/livez", "/readyz"} {
+		req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8099"+path, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("%s status = %d, want 204", path, w.Code)
+		}
+	}
+}
+
+func TestHTTPProxyMetricsEndpointDelegatesToConfiguredHandler(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	target, _ := url.Parse(upstream.URL + "/mcp")
+	cfg := testConfig(target)
+	cfg.MetricsHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("# HELP mcp_adapter_test"))
+	})
+	handler, err := NewHTTPProxyHandler(cfg)
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8099/metrics", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "mcp_adapter_test") {
+		t.Fatalf("body = %q, want delegated handler output", w.Body.String())
+	}
+}
+
+func TestHTTPProxyMetricsEndpointReturns404WhenUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(upstream.Close)
+	target, _ := url.Parse(upstream.URL + "/mcp")
+	handler, err := NewHTTPProxyHandler(testConfig(target))
+	if err != nil {
+		t.Fatalf("NewHTTPProxyHandler() error = %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8099/metrics", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (no metrics handler configured)", w.Code)
+	}
+}
+
 func testConfig(runtimeURL *url.URL) ProxyConfig {
 	return ProxyConfig{
 		RuntimeURL: runtimeURL,

--- a/internal/agentadapter/rpc_metadata.go
+++ b/internal/agentadapter/rpc_metadata.go
@@ -204,20 +204,21 @@ func isToolsListChangedNotification(body []byte) bool {
 
 // rebindResponseID replaces the "id" field of a JSON-RPC response body with the
 // supplied raw ID. Used to serve a cached tools/list response to a caller whose
-// request ID differs from the one captured at cache-store time. Returns body
-// unchanged when parsing fails.
+// request ID differs from the one captured at cache-store time. Returns nil
+// when rebinding fails (callers fall back to an authoritative upstream call;
+// returning the body with its old id would be a JSON-RPC protocol violation).
 func rebindResponseID(body []byte, id json.RawMessage) []byte {
 	if len(id) == 0 {
 		return body
 	}
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return body
+		return nil
 	}
 	raw["id"] = id
 	out, err := json.Marshal(raw)
 	if err != nil {
-		return body
+		return nil
 	}
 	return out
 }

--- a/internal/agentadapter/rpc_metadata.go
+++ b/internal/agentadapter/rpc_metadata.go
@@ -166,3 +166,58 @@ type rpcErrorForInject struct {
 	Message string         `json:"message"`
 	Data    map[string]any `json:"data,omitempty"`
 }
+
+// protocolVersionFromInitializeResult extracts result.protocolVersion from a
+// runtime initialize response body. Returns "" when the field is absent or the
+// body is not valid JSON-RPC.
+func protocolVersionFromInitializeResult(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var response struct {
+		Result struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(response.Result.ProtocolVersion)
+}
+
+// isToolsListChangedNotification reports whether a runtime response body is a
+// JSON-RPC notification announcing that the tools list changed. Agents that
+// see this should invalidate any cached tools/list response.
+func isToolsListChangedNotification(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	var msg struct {
+		JSONRPC string `json:"jsonrpc"`
+		Method  string `json:"method"`
+	}
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return false
+	}
+	return msg.JSONRPC == "2.0" && msg.Method == "notifications/tools/list_changed"
+}
+
+// rebindResponseID replaces the "id" field of a JSON-RPC response body with the
+// supplied raw ID. Used to serve a cached tools/list response to a caller whose
+// request ID differs from the one captured at cache-store time. Returns body
+// unchanged when parsing fails.
+func rebindResponseID(body []byte, id json.RawMessage) []byte {
+	if len(id) == 0 {
+		return body
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return body
+	}
+	raw["id"] = id
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -249,7 +249,11 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	if cacheableTools {
 		cacheKey = toolsCacheKey(s.cfg.Identity, s.cfg.RuntimeURL.String())
 		if cached, ok := s.toolsCache.get(cacheKey); ok {
-			return emit(rebindResponseID(cached, envelope.ID))
+			if rebound := rebindResponseID(cached, envelope.ID); rebound != nil {
+				return emit(rebound)
+			}
+			// Rebinding failed: fall through to refetch authoritatively
+			// rather than emit a response with a stale id.
 		}
 	}
 
@@ -293,7 +297,19 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	}
 
 	if resp.StatusCode < http.StatusBadRequest && strings.Contains(strings.ToLower(resp.Header.Get("content-type")), "text/event-stream") {
-		return streamStreamableHTTPEventMessages(resp.Body, emit)
+		// MCP runtimes typically deliver server-to-client notifications over
+		// SSE, so cache invalidation must inspect each SSE message. Wrapping
+		// emit keeps the buffered-body fallback unchanged.
+		sseEmit := emit
+		if s.toolsCache != nil {
+			sseEmit = func(message []byte) error {
+				if isToolsListChangedNotification(message) {
+					s.toolsCache.invalidate()
+				}
+				return emit(message)
+			}
+		}
+		return streamStreamableHTTPEventMessages(resp.Body, sseEmit)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes+1))
@@ -342,7 +358,7 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 			}
 		}
 	}
-	if cacheableTools && !looksLikeJSONRPCError(body) {
+	if cacheableTools && looksLikeJSONRPC(body) && !looksLikeJSONRPCError(body) {
 		s.toolsCache.put(cacheKey, body)
 	}
 	// tools/list_changed notifications from the runtime invalidate the cache

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -50,6 +50,7 @@ type stdioShim struct {
 	sessionSt       sessionState
 	sessionID       string
 	protocolVersion string
+	toolsCache      *toolsListCache
 }
 
 type stdioScanResult struct {
@@ -111,6 +112,7 @@ func RunStdioShim(ctx context.Context, cfg ShimConfig, opts StdioOptions) error 
 		client:          cfg.Transport.Client(),
 		sessionSt:       initState,
 		protocolVersion: cfg.ProtocolVersion,
+		toolsCache:      newToolsListCache(cfg.ToolsCacheTTL),
 	}
 
 	scanResults := scanStdioLines(ctx, opts.Stdin)
@@ -239,6 +241,18 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 		}
 	}
 
+	// tools/list cache: only when enabled, the call expects a response,
+	// and the caller is not in anonymous mode (anonymous responses cannot
+	// be safely shared between callers).
+	cacheableTools := meta.Method == "tools/list" && hasResponseID && !s.cfg.Anonymous && s.toolsCache != nil
+	var cacheKey string
+	if cacheableTools {
+		cacheKey = toolsCacheKey(s.cfg.Identity, s.cfg.RuntimeURL.String())
+		if cached, ok := s.toolsCache.get(cacheKey); ok {
+			return emit(rebindResponseID(cached, envelope.ID))
+		}
+	}
+
 	protocolVersion, sessionID := s.prepareRequestState(envelope)
 
 	// Tag context with method so RuntimeTransport can key retry and OTel on it.
@@ -321,7 +335,20 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 			s.setSessionState(sessionStateFailed)
 		} else {
 			s.setSessionState(sessionStateReady)
+			// Capture the runtime's negotiated protocol version so subsequent
+			// outbound calls advertise the version the runtime agreed to.
+			if pv := protocolVersionFromInitializeResult(body); pv != "" {
+				s.setProtocolVersion(pv)
+			}
 		}
+	}
+	if cacheableTools && !looksLikeJSONRPCError(body) {
+		s.toolsCache.put(cacheKey, body)
+	}
+	// tools/list_changed notifications from the runtime invalidate the cache
+	// so the next tools/list call refetches the authoritative response.
+	if isToolsListChangedNotification(body) {
+		s.toolsCache.invalidate()
 	}
 	if !hasResponseID {
 		return nil
@@ -347,6 +374,12 @@ func (s *stdioShim) setRuntimeSessionID(sessionID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sessionID = sessionID
+}
+
+func (s *stdioShim) setProtocolVersion(version string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.protocolVersion = version
 }
 
 func (s *stdioShim) getSessionState() sessionState {

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -749,6 +750,161 @@ func TestRunStdioShimSurfacesSessionExpiredRuntimeStatus(t *testing.T) {
 	}
 	if got, _ := response.Error.Data["runtime_status"].(string); got != "session_expired" {
 		t.Fatalf("runtime_status = %q, want session_expired", got)
+	}
+}
+
+func TestStdioShimCachesToolsListWhenTTLSet(t *testing.T) {
+	t.Parallel()
+
+	var listCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(r.Body)
+		method := parseRPCRequestMetadata(body.Bytes()).Method
+		w.Header().Set("content-type", "application/json")
+		w.Header().Set(MCPSessionHeader, "rt-session")
+		switch method {
+		case "initialize":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
+		case "tools/list":
+			atomic.AddInt32(&listCalls, 1)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"upper"}]}}`))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, _ := url.Parse(upstream.URL + "/mcp")
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdinReader.Close()
+	defer stdoutReader.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunStdioShim(context.Background(), ShimConfig{
+			RuntimeURL: runtimeURL,
+			Identity: Identity{
+				HumanID:   "human-1",
+				AgentID:   "agent-1",
+				SessionID: "session-1",
+			},
+			Transport:     &RuntimeTransport{Base: upstream.Client().Transport},
+			ToolsCacheTTL: 30 * time.Second,
+		}, StdioOptions{Stdin: stdinReader, Stdout: stdoutWriter})
+		_ = stdoutWriter.Close()
+	}()
+
+	reader := bufio.NewReader(stdoutReader)
+
+	// Initialize and wait for its response before issuing the first tools/list,
+	// so the second tools/list cannot start before the first one stores in the cache.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n"))
+	if _ = readLineWithin(t, reader, 2*time.Second); false {
+	}
+	// First tools/list — should hit upstream.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"))
+	first := readLineWithin(t, reader, 2*time.Second)
+	if !strings.Contains(first, `"id":2`) {
+		t.Fatalf("first response id mismatch: %q", first)
+	}
+	// Second tools/list — must hit cache.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":3,"method":"tools/list"}` + "\n"))
+	second := readLineWithin(t, reader, 2*time.Second)
+	if !strings.Contains(second, `"id":3`) {
+		t.Fatalf("second response did not rebind id: %q", second)
+	}
+	_ = stdinWriter.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 1 {
+		t.Fatalf("upstream tools/list calls = %d, want 1 (second should be cached)", got)
+	}
+}
+
+func TestStdioShimSkipsToolsCacheInAnonymousMode(t *testing.T) {
+	t.Parallel()
+
+	var listCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(r.Body)
+		method := parseRPCRequestMetadata(body.Bytes()).Method
+		w.Header().Set("content-type", "application/json")
+		switch method {
+		case "initialize":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
+		case "tools/list":
+			listCalls++
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, _ := url.Parse(upstream.URL + "/mcp")
+	var output bytes.Buffer
+	err := RunStdioShim(context.Background(), ShimConfig{
+		RuntimeURL:    runtimeURL,
+		Anonymous:     true,
+		Transport:     &RuntimeTransport{Base: upstream.Client().Transport},
+		ToolsCacheTTL: 30 * time.Second,
+	}, StdioOptions{
+		Stdin: strings.NewReader(
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n" +
+				`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n" +
+				`{"jsonrpc":"2.0","id":3,"method":"tools/list"}` + "\n",
+		),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if listCalls != 2 {
+		t.Fatalf("upstream tools/list calls = %d, want 2 (anonymous mode bypasses cache)", listCalls)
+	}
+}
+
+func TestStdioShimCapturesProtocolVersionFromInitializeResponse(t *testing.T) {
+	t.Parallel()
+
+	var seenProtocols []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenProtocols = append(seenProtocols, r.Header.Get(MCPProtocolHeader))
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(r.Body)
+		method := parseRPCRequestMetadata(body.Bytes()).Method
+		w.Header().Set("content-type", "application/json")
+		switch method {
+		case "initialize":
+			// Runtime negotiates a different protocol version than the client requested.
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2099-01-01"}}`))
+		default:
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{}}`))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, _ := url.Parse(upstream.URL + "/mcp")
+	var output bytes.Buffer
+	err := RunStdioShim(context.Background(), ShimConfig{
+		RuntimeURL: runtimeURL,
+		Identity:   Identity{HumanID: "h", AgentID: "a", SessionID: "s"},
+		Transport:  &RuntimeTransport{Base: upstream.Client().Transport},
+	}, StdioOptions{
+		Stdin: strings.NewReader(
+			`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}` + "\n" +
+				`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"upper"}}` + "\n",
+		),
+		Stdout: &output,
+	})
+	if err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if len(seenProtocols) < 2 {
+		t.Fatalf("expected at least 2 upstream requests, got %d", len(seenProtocols))
+	}
+	if seenProtocols[1] != "2099-01-01" {
+		t.Fatalf("second request protocol header = %q, want 2099-01-01 (runtime-negotiated)", seenProtocols[1])
 	}
 }
 

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -864,6 +864,81 @@ func TestStdioShimSkipsToolsCacheInAnonymousMode(t *testing.T) {
 	}
 }
 
+func TestStdioShimInvalidatesToolsCacheOnSSEListChanged(t *testing.T) {
+	t.Parallel()
+
+	var listCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(r.Body)
+		method := parseRPCRequestMetadata(body.Bytes()).Method
+		w.Header().Set(MCPSessionHeader, "rt-session")
+		switch method {
+		case "initialize":
+			w.Header().Set("content-type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
+		case "tools/list":
+			atomic.AddInt32(&listCalls, 1)
+			w.Header().Set("content-type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"upper"}]}}`))
+		case "tools/call":
+			// Stream a single notification: tools/list_changed. The shim must
+			// observe the SSE message and drop its cached tools/list entry.
+			w.Header().Set("content-type", "text/event-stream")
+			flusher, _ := w.(http.Flusher)
+			_, _ = w.Write([]byte("data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/tools/list_changed\"}\n\n"))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, _ := url.Parse(upstream.URL + "/mcp")
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdinReader.Close()
+	defer stdoutReader.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunStdioShim(context.Background(), ShimConfig{
+			RuntimeURL:    runtimeURL,
+			Identity:      Identity{HumanID: "h", AgentID: "a", SessionID: "s"},
+			Transport:     &RuntimeTransport{Base: upstream.Client().Transport},
+			ToolsCacheTTL: 30 * time.Second,
+		}, StdioOptions{Stdin: stdinReader, Stdout: stdoutWriter})
+		_ = stdoutWriter.Close()
+	}()
+
+	reader := bufio.NewReader(stdoutReader)
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n"))
+	_ = readLineWithin(t, reader, 2*time.Second)
+
+	// First tools/list — stores the cache entry.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"))
+	_ = readLineWithin(t, reader, 2*time.Second)
+
+	// tools/call returns an SSE list_changed notification. The shim emits it
+	// to stdout and invalidates the cache.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"x"}}` + "\n"))
+	notif := readLineWithin(t, reader, 2*time.Second)
+	if !strings.Contains(notif, `"notifications/tools/list_changed"`) {
+		t.Fatalf("did not receive SSE notification on stdout: %q", notif)
+	}
+
+	// Second tools/list — must re-hit upstream because the cache was dropped.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":4,"method":"tools/list"}` + "\n"))
+	_ = readLineWithin(t, reader, 2*time.Second)
+	_ = stdinWriter.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 2 {
+		t.Fatalf("upstream tools/list calls = %d, want 2 (cache must be invalidated by SSE notification)", got)
+	}
+}
+
 func TestStdioShimCapturesProtocolVersionFromInitializeResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agentadapter/toolscache.go
+++ b/internal/agentadapter/toolscache.go
@@ -1,0 +1,117 @@
+package agentadapter
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// toolsListCache stores recent tools/list response bodies keyed by the caller's
+// governance identity and the runtime URL. It is intended to absorb the chatty
+// tools/list calls some agent SDKs make every conversation turn without
+// hitting the runtime each time.
+//
+// Cache invariants:
+//   - Anonymous mode bypasses the cache entirely: the runtime can serve
+//     different policy versions to anonymous callers and we have no way to
+//     key on them.
+//   - Each entry is short-lived (caller-supplied TTL, typically 30 s). The
+//     gateway is the source of truth for grants; the cache is an optimisation.
+//   - On a tools/list_changed notification from the runtime, all entries
+//     are invalidated.
+type toolsListCache struct {
+	ttl time.Duration
+
+	mu      sync.Mutex
+	entries map[string]toolsCacheEntry
+}
+
+type toolsCacheEntry struct {
+	body    []byte
+	expires time.Time
+}
+
+func newToolsListCache(ttl time.Duration) *toolsListCache {
+	if ttl <= 0 {
+		return nil
+	}
+	return &toolsListCache{
+		ttl:     ttl,
+		entries: make(map[string]toolsCacheEntry),
+	}
+}
+
+func (c *toolsListCache) get(key string) ([]byte, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expires) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	// Return a copy so the caller can mutate freely.
+	out := make([]byte, len(entry.body))
+	copy(out, entry.body)
+	return out, true
+}
+
+func (c *toolsListCache) put(key string, body []byte) {
+	if c == nil || len(body) == 0 {
+		return
+	}
+	stored := make([]byte, len(body))
+	copy(stored, body)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = toolsCacheEntry{
+		body:    stored,
+		expires: time.Now().Add(c.ttl),
+	}
+}
+
+// invalidate drops every entry — used when the runtime emits
+// notifications/tools/list_changed.
+func (c *toolsListCache) invalidate() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k := range c.entries {
+		delete(c.entries, k)
+	}
+}
+
+func (c *toolsListCache) size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// toolsCacheKey deterministically combines the identity and runtime URL into a
+// cache key. The trailing "|" separators avoid collisions when one field is
+// empty (e.g. anonymous mode would have empty identity fields — but that path
+// short-circuits before reaching this function).
+func toolsCacheKey(id Identity, runtimeURL string) string {
+	var b strings.Builder
+	b.Grow(len(id.HumanID) + len(id.AgentID) + len(id.TeamID) + len(id.SessionID) + len(runtimeURL) + 8)
+	b.WriteString(id.HumanID)
+	b.WriteByte('|')
+	b.WriteString(id.AgentID)
+	b.WriteByte('|')
+	b.WriteString(id.TeamID)
+	b.WriteByte('|')
+	b.WriteString(id.SessionID)
+	b.WriteByte('|')
+	b.WriteString(runtimeURL)
+	return b.String()
+}

--- a/internal/agentadapter/toolscache_test.go
+++ b/internal/agentadapter/toolscache_test.go
@@ -1,0 +1,89 @@
+package agentadapter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestToolsListCacheHitsBeforeTTL(t *testing.T) {
+	t.Parallel()
+
+	c := newToolsListCache(50 * time.Millisecond)
+	if c == nil {
+		t.Fatal("newToolsListCache returned nil for positive ttl")
+	}
+
+	c.put("k1", []byte(`{"result":{"tools":[]}}`))
+	got, ok := c.get("k1")
+	if !ok {
+		t.Fatal("expected cache hit, got miss")
+	}
+	if string(got) != `{"result":{"tools":[]}}` {
+		t.Fatalf("body = %s, want stored value", got)
+	}
+}
+
+func TestToolsListCacheExpiresAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	c := newToolsListCache(10 * time.Millisecond)
+	c.put("k1", []byte(`{}`))
+	time.Sleep(20 * time.Millisecond)
+	if _, ok := c.get("k1"); ok {
+		t.Fatal("expected expiry, got hit")
+	}
+	if c.size() != 0 {
+		t.Fatalf("size = %d, want 0 after expiry", c.size())
+	}
+}
+
+func TestToolsListCacheInvalidateClearsAll(t *testing.T) {
+	t.Parallel()
+
+	c := newToolsListCache(time.Hour)
+	c.put("a", []byte(`{}`))
+	c.put("b", []byte(`{}`))
+	c.invalidate()
+	if c.size() != 0 {
+		t.Fatalf("size = %d, want 0 after invalidate", c.size())
+	}
+}
+
+func TestToolsListCacheDisabledWhenTTLZero(t *testing.T) {
+	t.Parallel()
+
+	if c := newToolsListCache(0); c != nil {
+		t.Fatal("expected nil cache for zero ttl")
+	}
+	if c := newToolsListCache(-1); c != nil {
+		t.Fatal("expected nil cache for negative ttl")
+	}
+}
+
+func TestToolsCacheKeyVariesOnIdentity(t *testing.T) {
+	t.Parallel()
+
+	id1 := Identity{HumanID: "h1", AgentID: "a", SessionID: "s"}
+	id2 := Identity{HumanID: "h2", AgentID: "a", SessionID: "s"}
+	if toolsCacheKey(id1, "http://r") == toolsCacheKey(id2, "http://r") {
+		t.Fatal("keys must differ when HumanID differs")
+	}
+	if toolsCacheKey(id1, "http://r1") == toolsCacheKey(id1, "http://r2") {
+		t.Fatal("keys must differ when runtimeURL differs")
+	}
+}
+
+func TestToolsListCacheNilSafe(t *testing.T) {
+	t.Parallel()
+
+	var c *toolsListCache
+	// nil receiver should not panic for any method.
+	c.put("k", []byte(`{}`))
+	if _, ok := c.get("k"); ok {
+		t.Fatal("nil cache must always miss")
+	}
+	c.invalidate()
+	if c.size() != 0 {
+		t.Fatalf("nil cache size = %d, want 0", c.size())
+	}
+}

--- a/internal/agentadapter/toolscache_test.go
+++ b/internal/agentadapter/toolscache_test.go
@@ -87,3 +87,12 @@ func TestToolsListCacheNilSafe(t *testing.T) {
 		t.Fatalf("nil cache size = %d, want 0", c.size())
 	}
 }
+
+func TestRebindResponseIDReturnsNilOnInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	out := rebindResponseID([]byte("not json"), []byte(`"new-id"`))
+	if out != nil {
+		t.Fatalf("rebindResponseID() = %q, want nil for invalid JSON (caller must fall back to upstream)", out)
+	}
+}

--- a/internal/cli/adapter/flags.go
+++ b/internal/cli/adapter/flags.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,9 +34,12 @@ type identityFlags struct {
 	tlsClientCert string
 	tlsClientKey  string
 	tlsCABundle   string
+	// proxy-only
+	maxInboundBytes int64
 	// stdio-only
 	anonymous        bool
 	anonymousMethods string
+	toolsCacheTTL    string
 }
 
 func bindIdentityFlags(cmd *cobra.Command, f *identityFlags) {
@@ -165,6 +169,7 @@ func (f identityFlags) toProxyConfig(listenAddr string) (agentadapter.ProxyConfi
 		ProtocolVersion:   r.protocolVersion,
 		LogLevel:          r.logLevel,
 		DisableXForwarded: f.disableXFF,
+		MaxInboundBytes:   f.maxInboundBytes,
 	}, nil
 }
 
@@ -187,6 +192,16 @@ func (f identityFlags) toShimConfig() (agentadapter.ShimConfig, error) {
 	if f.anonymous && strings.TrimSpace(f.anonymousMethods) != "" {
 		cfg.AnonymousMethods = agentadapter.SplitTrimmed(f.anonymousMethods, ",")
 	}
+	if raw := strings.TrimSpace(f.toolsCacheTTL); raw != "" {
+		ttl, err := time.ParseDuration(raw)
+		if err != nil {
+			return agentadapter.ShimConfig{}, fmt.Errorf("--tools-cache-ttl (or $%s) is invalid: %w", agentadapter.EnvToolsCacheTTL, err)
+		}
+		if ttl < 0 {
+			return agentadapter.ShimConfig{}, fmt.Errorf("--tools-cache-ttl (or $%s) must be zero or positive", agentadapter.EnvToolsCacheTTL)
+		}
+		cfg.ToolsCacheTTL = ttl
+	}
 	return cfg, nil
 }
 
@@ -200,6 +215,30 @@ func bindStdioFlags(cmd *cobra.Command, f *identityFlags) {
 		os.Getenv(agentadapter.EnvAnonymousMethods),
 		"Comma-separated list of MCP methods allowed in anonymous mode "+
 			"(default: $"+agentadapter.EnvAnonymousMethods+" or initialize,notifications/initialized,ping,tools/list,resources/list,prompts/list)")
+	cmd.Flags().StringVar(&f.toolsCacheTTL, "tools-cache-ttl",
+		os.Getenv(agentadapter.EnvToolsCacheTTL),
+		"Cache tools/list responses for this duration, e.g. 30s. Empty disables the cache. "+
+			"(default: $"+agentadapter.EnvToolsCacheTTL+")")
+}
+
+// bindProxyFlags adds proxy-specific flags on top of the shared identity flags.
+func bindProxyFlags(cmd *cobra.Command, f *identityFlags) {
+	cmd.Flags().Int64Var(&f.maxInboundBytes, "max-inbound-bytes",
+		parseEnvInt64(agentadapter.EnvMaxInboundBytes, 0),
+		"Maximum inbound JSON-RPC body bytes the proxy buffers before responding with 413 "+
+			"(default: $"+agentadapter.EnvMaxInboundBytes+" or 16777216)")
+}
+
+func parseEnvInt64(name string, def int64) int64 {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
 }
 
 func parseEnvBool(name string, def bool) bool {

--- a/internal/cli/adapter/proxy.go
+++ b/internal/cli/adapter/proxy.go
@@ -43,6 +43,7 @@ variables. Flags win when both are set.`,
 	}
 
 	bindIdentityFlags(cmd, &flags)
+	bindProxyFlags(cmd, &flags)
 	cmd.Flags().StringVar(&listenAddr, "listen", os.Getenv(agentadapter.EnvListenAddr),
 		"Local listen address (default: $"+agentadapter.EnvListenAddr+" or "+agentadapter.DefaultListenAddr+")")
 	return cmd

--- a/test/golden/cli/testdata/mcp-runtime_adapter_proxy_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_adapter_proxy_help.golden
@@ -16,6 +16,7 @@ Flags:
       --human-id string           Issued human identity (default: $MCP_RUNTIME_HUMAN_ID)
       --listen string             Local listen address (default: $MCP_RUNTIME_LISTEN_ADDR or 127.0.0.1:8099)
       --log-level string          Adapter log level: info logs runtime denials (default: $MCP_RUNTIME_LOG_LEVEL)
+      --max-inbound-bytes int     Maximum inbound JSON-RPC body bytes the proxy buffers before responding with 413 (default: $MCP_RUNTIME_MAX_INBOUND_BYTES or 16777216)
       --no-xforwarded             Do not set X-Forwarded-* headers when forwarding to the runtime
       --protocol-version string   MCP protocol version header to advertise (default: $MCP_RUNTIME_PROTOCOL_VERSION or 2025-06-18)
       --request-timeout string    HTTP request timeout for adapter→runtime calls, e.g. 30s (default: $MCP_RUNTIME_REQUEST_TIMEOUT)

--- a/test/golden/cli/testdata/mcp-runtime_adapter_stdio_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_adapter_stdio_help.golden
@@ -27,6 +27,7 @@ Flags:
       --tls-ca-bundle string       Path to PEM CA bundle to verify the runtime's TLS certificate (default: $MCP_RUNTIME_TLS_CA_BUNDLE)
       --tls-client-cert string     Path to PEM client certificate for mTLS to the runtime (default: $MCP_RUNTIME_TLS_CLIENT_CERT)
       --tls-client-key string      Path to PEM client key for mTLS to the runtime (default: $MCP_RUNTIME_TLS_CLIENT_KEY)
+      --tools-cache-ttl string     Cache tools/list responses for this duration, e.g. 30s. Empty disables the cache. (default: $MCP_RUNTIME_TOOLS_CACHE_TTL)
 
 Global Flags:
       --debug   Enable debug mode with structured error logging


### PR DESCRIPTION
## Summary

Phase 5 of #165. Hardens the adapter against unbounded reads, adds health/metrics endpoints, and introduces a process-local tools/list cache. Also captures the protocol version the runtime negotiates in its initialize response.

- **Inbound body cap (proxy)** — \`captureRPCRequestMetadata\` reads up to \`ProxyConfig.MaxInboundBytes\` (default 16 MiB) and returns HTTP 413 + a JSON-RPC parse-error body on over-cap. Closes the unbounded \`io.ReadAll\` (codex point #6). Env: \`MCP_RUNTIME_MAX_INBOUND_BYTES\`. Flag: \`--max-inbound-bytes\`.
- **Health endpoints** — \`/healthz\`, \`/livez\`, \`/readyz\` return 204. \`/metrics\` delegates to \`ProxyConfig.MetricsHandler\` (typically a Prometheus exporter wired to the OTel MeterProvider that backs \`RuntimeTransport.Meter\`). Returns 404 when unconfigured, so the adapter package stays free of metrics-backend deps.
- **tools/list cache (stdio)** — \`ShimConfig.ToolsCacheTTL\` (zero disables). Key: \`(humanID, agentID, teamID, sessionID, runtimeURL)\`. Anonymous mode bypasses entirely. Invalidated on \`notifications/tools/list_changed\` or TTL expiry. \`rebindResponseID\` rewrites the cached response's \`id\` so the agent sees its own request id. Env: \`MCP_RUNTIME_TOOLS_CACHE_TTL\`. Flag: \`--tools-cache-ttl\`.
- **Negotiated protocol version capture (stdio)** — after a successful 2xx initialize response, \`protocolVersionFromInitializeResult\` parses \`result.protocolVersion\` and the shim's stored version is updated, so subsequent outbound calls advertise the negotiated version rather than the client's request.

## Trade-offs

- The proxy uses a hard cap + 413 rather than streaming JSON header peek. A streaming peek would lower memory at scale but complicates body replay through \`httputil.ReverseProxy\`; the cap is simpler and matches the stdio \`maxStdioMessageBytes\` cap (16 MiB).
- The cache key omits \`policyVersion\` because the runtime does not yet emit it. TTL (typical: 30 s) bounds staleness on grant changes. Adding policy version is a future change.
- \`/metrics\` is pluggable rather than baked in so we don't force a Prometheus client dependency on every adapter consumer.

## Test plan

- [x] \`go test ./internal/agentadapter/... -race -count=1\` — passes (new \`toolscache_test.go\`, stdio cache/protocol-version tests, proxy 413/livez/readyz/metrics tests)
- [x] \`go test ./test/golden/... -count=1\` — passes (both adapter help goldens updated for the two new flags)
- [x] \`go build ./... && go vet ./...\` — clean
- [x] Pre-commit (gofmt, staticcheck, vet, full unit tests, generated-file-drift) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)