### PR TITLE
feat(agentadapter): Phase 6 — platform-issued adapter sessions

### DIFF
--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -1858,6 +1858,7 @@ forward MCP traffic to governed MCP Runtime routes.
 - [`func SplitTrimmed(s, sep string) []string`](#agent-adapters-func-splittrimmed-s-sep-string-string)
 - [`type Identity struct`](#agent-adapters-type-identity-struct)
 - [`func (id Identity) Apply(headers http.Header)`](#agent-adapters-func-id-identity-apply-headers-http-header)
+- [`type IdentityProvider func() Identity`](#agent-adapters-type-identityprovider-func-identity)
 - [`type ProxyConfig struct`](#agent-adapters-type-proxyconfig-struct)
 - [`func LoadProxyConfigFromEnv() (ProxyConfig, error)`](#agent-adapters-func-loadproxyconfigfromenv-proxyconfig-error)
 - [`func (cfg ProxyConfig) Validate() error`](#agent-adapters-func-cfg-proxyconfig-validate-error)
@@ -1994,9 +1995,8 @@ type Identity struct {
 	SessionID string
 }
     Identity is the issued governance identity that adapters attach to every
-    runtime request. The platform issues these values out-of-band (or,
-    in a later phase, through the adapter session endpoint); the adapter only
-    forwards them.
+    runtime request. The platform issues these values out-of-band (or through
+    the platform adapter-session endpoint); the adapter only forwards them.
 
 ```
 
@@ -2008,6 +2008,17 @@ func (id Identity) Apply(headers http.Header)
     strip spoofed inbound values. A header is only re-set when its value is
     non-empty, so anonymous-mode adapters with partial identity naturally omit
     the missing headers rather than forwarding empty strings.
+
+```
+
+<a id="agent-adapters-type-identityprovider-func-identity"></a>
+```text
+type IdentityProvider func() Identity
+    IdentityProvider returns the current governance identity. Adapters call it
+    before each outbound request so callers that rotate identity at runtime
+    (for example, platform-issued sessions refreshed before expiry) get the
+    new values applied without restarting the adapter process. When non-nil on
+    ProxyConfig / ShimConfig it takes precedence over the static Identity.
 
 ```
 
@@ -2031,6 +2042,10 @@ type ProxyConfig struct {
 	// Prometheus exporter wired to the OTel MeterProvider that backs
 	// RuntimeTransport.Meter. Nil → /metrics returns 404.
 	MetricsHandler http.Handler
+	// IdentityProvider overrides Identity per-request when set. Used by
+	// callers that rotate identity at runtime (e.g. auto-refreshed
+	// platform-issued adapter sessions). Nil → static Identity is used.
+	IdentityProvider IdentityProvider
 }
     ProxyConfig configures the local HTTP reverse-proxy adapter that exposes
     Streamable HTTP MCP to an agent SDK.
@@ -2132,6 +2147,9 @@ type ShimConfig struct {
 	// Entries are keyed by identity + runtime URL and invalidated on a
 	// tools/list_changed notification or when the TTL expires.
 	ToolsCacheTTL time.Duration
+	// IdentityProvider overrides Identity per-request when set.
+	// See ProxyConfig.IdentityProvider for the contract.
+	IdentityProvider IdentityProvider
 }
     ShimConfig configures the stdio adapter that bridges newline-delimited
     JSON-RPC MCP traffic to the runtime over HTTP.
@@ -4348,12 +4366,15 @@ _No package overview is documented._
 
 - [`func HasPlatformClient() bool`](#cli-platform-api-func-hasplatformclient-bool)
 - [`func NormalizeBaseURL(raw string) string`](#cli-platform-api-func-normalizebaseurl-raw-string-string)
+- [`type AdapterSession struct`](#cli-platform-api-type-adaptersession-struct)
+- [`type AdapterSessionRequest struct`](#cli-platform-api-type-adaptersessionrequest-struct)
 - [`type ImagePublishRecord struct`](#cli-platform-api-type-imagepublishrecord-struct)
 - [`type PlatformClient struct`](#cli-platform-api-type-platformclient-struct)
 - [`func NewPlatformClient() (*PlatformClient, error)`](#cli-platform-api-func-newplatformclient-platformclient-error)
 - [`func ResolvePlatformOrKube(useKube bool) (*PlatformClient, bool, error)`](#cli-platform-api-func-resolveplatformorkube-usekube-bool-platformclient-bool-error)
 - [`func (c *PlatformClient) ApplyAccessFromYAMLFile(ctx context.Context, path string) error`](#cli-platform-api-func-c-platformclient-applyaccessfromyamlfile-ctx-context-context-path-string-error)
 - [`func (c *PlatformClient) ApplyRuntimeServer(ctx context.Context, name, namespace string, spec mcpv1alpha1.MCPServerSpec) (ServerListItem, error)`](#cli-platform-api-func-c-platformclient-applyruntimeserver-ctx-context-context-name-namespace-string-spec-mcpv1alpha1-mcpserverspec-serverlistitem-error)
+- [`func (c *PlatformClient) CreateAdapterSession(ctx context.Context, req AdapterSessionRequest) (AdapterSession, error)`](#cli-platform-api-func-c-platformclient-createadaptersession-ctx-context-context-req-adaptersessionrequest-adaptersession-error)
 - [`func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Team, error)`](#cli-platform-api-func-c-platformclient-createteam-ctx-context-context-slug-name-string-team-error)
 - [`func (c *PlatformClient) DeleteGrant(ctx context.Context, namespace, name string) error`](#cli-platform-api-func-c-platformclient-deletegrant-ctx-context-context-namespace-name-string-error)
 - [`func (c *PlatformClient) DeleteSession(ctx context.Context, namespace, name string) error`](#cli-platform-api-func-c-platformclient-deletesession-ctx-context-context-namespace-name-string-error)
@@ -4389,6 +4410,41 @@ func NormalizeBaseURL(raw string) string
 
 <a id="cli-platform-api-types"></a>
 ### Types
+
+<a id="cli-platform-api-type-adaptersession-struct"></a>
+```text
+type AdapterSession struct {
+	Name           string    `json:"name"`
+	Namespace      string    `json:"namespace"`
+	HumanID        string    `json:"humanID"`
+	AgentID        string    `json:"agentID"`
+	TeamID         string    `json:"teamID,omitempty"`
+	ServerName     string    `json:"serverName"`
+	ConsentedTrust string    `json:"consentedTrust"`
+	PolicyVersion  string    `json:"policyVersion"`
+	ExpiresAt      time.Time `json:"expiresAt"`
+	Reused         bool      `json:"reused"`
+}
+    AdapterSession captures the identity the adapter must inject into runtime
+    requests. ExpiresAt is absolute (server-side time); callers should refresh
+    before it elapses.
+
+```
+
+<a id="cli-platform-api-type-adaptersessionrequest-struct"></a>
+```text
+type AdapterSessionRequest struct {
+	ServerName     string `json:"serverName"`
+	Namespace      string `json:"namespace,omitempty"`
+	AgentID        string `json:"agentID"`
+	RequestedTrust string `json:"requestedTrust,omitempty"`
+	RequestedTTL   string `json:"requestedTTL,omitempty"`
+}
+    AdapterSessionRequest is the input contract for the platform API endpoint
+    POST /api/runtime/adapter/sessions. RequestedTTL/Trust are optional;
+    empty values fall back to platform-side defaults.
+
+```
 
 <a id="cli-platform-api-type-imagepublishrecord-struct"></a>
 ```text
@@ -4435,6 +4491,15 @@ func (c *PlatformClient) ApplyAccessFromYAMLFile(ctx context.Context, path strin
 <a id="cli-platform-api-func-c-platformclient-applyruntimeserver-ctx-context-context-name-namespace-string-spec-mcpv1alpha1-mcpserverspec-serverlistitem-error"></a>
 ```text
 func (c *PlatformClient) ApplyRuntimeServer(ctx context.Context, name, namespace string, spec mcpv1alpha1.MCPServerSpec) (ServerListItem, error)
+
+```
+
+<a id="cli-platform-api-func-c-platformclient-createadaptersession-ctx-context-context-req-adaptersessionrequest-adaptersession-error"></a>
+```text
+func (c *PlatformClient) CreateAdapterSession(ctx context.Context, req AdapterSessionRequest) (AdapterSession, error)
+    CreateAdapterSession asks the platform to issue (or reuse) an
+    MCPAgentSession for the calling principal. The returned session.Name doubles
+    as the SessionID the adapter forwards on every runtime request.
 
 ```
 

--- a/internal/agentadapter/config.go
+++ b/internal/agentadapter/config.go
@@ -68,6 +68,10 @@ type ProxyConfig struct {
 	// Prometheus exporter wired to the OTel MeterProvider that backs
 	// RuntimeTransport.Meter. Nil → /metrics returns 404.
 	MetricsHandler http.Handler
+	// IdentityProvider overrides Identity per-request when set. Used by
+	// callers that rotate identity at runtime (e.g. auto-refreshed
+	// platform-issued adapter sessions). Nil → static Identity is used.
+	IdentityProvider IdentityProvider
 }
 
 // ShimConfig configures the stdio adapter that bridges newline-delimited
@@ -93,6 +97,9 @@ type ShimConfig struct {
 	// Entries are keyed by identity + runtime URL and invalidated on a
 	// tools/list_changed notification or when the TTL expires.
 	ToolsCacheTTL time.Duration
+	// IdentityProvider overrides Identity per-request when set.
+	// See ProxyConfig.IdentityProvider for the contract.
+	IdentityProvider IdentityProvider
 }
 
 // DefaultAnonymousMethods is the set of MCP methods the stdio shim allows in

--- a/internal/agentadapter/identity.go
+++ b/internal/agentadapter/identity.go
@@ -3,15 +3,21 @@ package agentadapter
 import "net/http"
 
 // Identity is the issued governance identity that adapters attach to every
-// runtime request. The platform issues these values out-of-band (or, in a
-// later phase, through the adapter session endpoint); the adapter only
-// forwards them.
+// runtime request. The platform issues these values out-of-band (or through
+// the platform adapter-session endpoint); the adapter only forwards them.
 type Identity struct {
 	HumanID   string
 	AgentID   string
 	TeamID    string
 	SessionID string
 }
+
+// IdentityProvider returns the current governance identity. Adapters call it
+// before each outbound request so callers that rotate identity at runtime
+// (for example, platform-issued sessions refreshed before expiry) get the
+// new values applied without restarting the adapter process. When non-nil
+// on ProxyConfig / ShimConfig it takes precedence over the static Identity.
+type IdentityProvider func() Identity
 
 // Apply writes the governance identity onto an outbound request's headers,
 // replacing any caller-supplied values. Headers are always deleted first to

--- a/internal/agentadapter/proxy.go
+++ b/internal/agentadapter/proxy.go
@@ -42,6 +42,7 @@ func newProxyHandlerAndTracker(cfg ProxyConfig) (http.Handler, *requestTracker, 
 	target := cloneURL(cfg.RuntimeURL)
 	transport := cfg.transportOrDefault()
 	identity := cfg.Identity
+	identityProvider := cfg.IdentityProvider
 	logLevel := cfg.LogLevel
 	logWriter := cfg.LogWriter
 	hostHeader := cfg.HostHeader
@@ -59,7 +60,11 @@ func newProxyHandlerAndTracker(cfg ProxyConfig) (http.Handler, *requestTracker, 
 			if !disableXFF {
 				req.SetXForwarded()
 			}
-			identity.Apply(req.Out.Header)
+			current := identity
+			if identityProvider != nil {
+				current = identityProvider()
+			}
+			current.Apply(req.Out.Header)
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			if resp.StatusCode < http.StatusBadRequest || resp.StatusCode >= http.StatusInternalServerError {

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -247,7 +247,10 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	cacheableTools := meta.Method == "tools/list" && hasResponseID && !s.cfg.Anonymous && s.toolsCache != nil
 	var cacheKey string
 	if cacheableTools {
-		cacheKey = toolsCacheKey(s.cfg.Identity, s.cfg.RuntimeURL.String())
+		// Key on the live identity, not the startup cfg.Identity, so a
+		// rotated SessionID (auto-refresh) starts fresh and never serves
+		// entries that belong to a previous session/policy context.
+		cacheKey = toolsCacheKey(s.currentIdentity(), s.cfg.RuntimeURL.String())
 		if cached, ok := s.toolsCache.get(cacheKey); ok {
 			if rebound := rebindResponseID(cached, envelope.ID); rebound != nil {
 				return emit(rebound)

--- a/internal/agentadapter/stdio.go
+++ b/internal/agentadapter/stdio.go
@@ -272,7 +272,7 @@ func (s *stdioShim) forward(ctx context.Context, payload []byte, emit stdioRespo
 	if sessionID != "" {
 		req.Header.Set(MCPSessionHeader, sessionID)
 	}
-	s.cfg.Identity.Apply(req.Header)
+	s.currentIdentity().Apply(req.Header)
 	if s.cfg.HostHeader != "" {
 		req.Host = s.cfg.HostHeader
 	}
@@ -396,6 +396,16 @@ func (s *stdioShim) setProtocolVersion(version string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.protocolVersion = version
+}
+
+// currentIdentity returns the live governance identity. If the config
+// supplied an IdentityProvider, that wins so callers that rotate identity at
+// runtime (auto-refreshed platform sessions) are reflected on every request.
+func (s *stdioShim) currentIdentity() Identity {
+	if s.cfg.IdentityProvider != nil {
+		return s.cfg.IdentityProvider()
+	}
+	return s.cfg.Identity
 }
 
 func (s *stdioShim) getSessionState() sessionState {

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -825,7 +825,7 @@ func TestStdioShimCachesToolsListWhenTTLSet(t *testing.T) {
 func TestStdioShimSkipsToolsCacheInAnonymousMode(t *testing.T) {
 	t.Parallel()
 
-	var listCalls int
+	var listCalls int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body bytes.Buffer
 		_, _ = body.ReadFrom(r.Body)
@@ -835,7 +835,7 @@ func TestStdioShimSkipsToolsCacheInAnonymousMode(t *testing.T) {
 		case "initialize":
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
 		case "tools/list":
-			listCalls++
+			atomic.AddInt32(&listCalls, 1)
 			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}`))
 		}
 	}))
@@ -859,8 +859,8 @@ func TestStdioShimSkipsToolsCacheInAnonymousMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunStdioShim() error = %v", err)
 	}
-	if listCalls != 2 {
-		t.Fatalf("upstream tools/list calls = %d, want 2 (anonymous mode bypasses cache)", listCalls)
+	if got := atomic.LoadInt32(&listCalls); got != 2 {
+		t.Fatalf("upstream tools/list calls = %d, want 2 (anonymous mode bypasses cache)", got)
 	}
 }
 

--- a/internal/agentadapter/stdio_test.go
+++ b/internal/agentadapter/stdio_test.go
@@ -864,6 +864,78 @@ func TestStdioShimSkipsToolsCacheInAnonymousMode(t *testing.T) {
 	}
 }
 
+func TestStdioShimToolsCacheKeyTracksIdentityProvider(t *testing.T) {
+	t.Parallel()
+
+	// Two callers (different SessionIDs) hit the same upstream through the
+	// same shim: the cache must NOT serve caller B's tools/list out of caller
+	// A's entry. The identity here rotates via IdentityProvider — the same
+	// mechanism --auto-refresh uses.
+	var listCalls int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body bytes.Buffer
+		_, _ = body.ReadFrom(r.Body)
+		method := parseRPCRequestMetadata(body.Bytes()).Method
+		w.Header().Set("content-type", "application/json")
+		w.Header().Set(MCPSessionHeader, "rt-session")
+		switch method {
+		case "initialize":
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18"}}`))
+		case "tools/list":
+			atomic.AddInt32(&listCalls, 1)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"upper"}]}}`))
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	runtimeURL, _ := url.Parse(upstream.URL + "/mcp")
+	identity := atomic.Value{}
+	identity.Store(Identity{HumanID: "human-1", AgentID: "agent-1", SessionID: "session-A"})
+	provider := IdentityProvider(func() Identity {
+		return identity.Load().(Identity)
+	})
+
+	stdinReader, stdinWriter := io.Pipe()
+	stdoutReader, stdoutWriter := io.Pipe()
+	defer stdinReader.Close()
+	defer stdoutReader.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- RunStdioShim(context.Background(), ShimConfig{
+			RuntimeURL:       runtimeURL,
+			Identity:         identity.Load().(Identity),
+			IdentityProvider: provider,
+			Transport:        &RuntimeTransport{Base: upstream.Client().Transport},
+			ToolsCacheTTL:    30 * time.Second,
+		}, StdioOptions{Stdin: stdinReader, Stdout: stdoutWriter})
+		_ = stdoutWriter.Close()
+	}()
+	reader := bufio.NewReader(stdoutReader)
+
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}` + "\n"))
+	_ = readLineWithin(t, reader, 2*time.Second)
+	// Caller A: tools/list — populates cache under session-A.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}` + "\n"))
+	_ = readLineWithin(t, reader, 2*time.Second)
+
+	// Rotate identity (e.g. auto-refresh issued a new session).
+	identity.Store(Identity{HumanID: "human-1", AgentID: "agent-1", SessionID: "session-B"})
+
+	// Caller B: tools/list — must miss the cache and re-fetch, since the
+	// key includes SessionID. If the cache were keyed off cfg.Identity it
+	// would replay caller A's entry.
+	_, _ = stdinWriter.Write([]byte(`{"jsonrpc":"2.0","id":3,"method":"tools/list"}` + "\n"))
+	_ = readLineWithin(t, reader, 2*time.Second)
+	_ = stdinWriter.Close()
+	if err := <-done; err != nil {
+		t.Fatalf("RunStdioShim() error = %v", err)
+	}
+	if got := atomic.LoadInt32(&listCalls); got != 2 {
+		t.Fatalf("upstream tools/list calls = %d, want 2 (rotated identity must miss cache)", got)
+	}
+}
+
 func TestStdioShimInvalidatesToolsCacheOnSSEListChanged(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/adapter/platformsession.go
+++ b/internal/cli/adapter/platformsession.go
@@ -1,0 +1,232 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"mcp-runtime/internal/agentadapter"
+	"mcp-runtime/internal/cli/platformapi"
+)
+
+const (
+	// EnvPlatformURL overrides the platform API base URL. When set, the
+	// adapter resolves its identity by calling POST /api/runtime/adapter/sessions.
+	EnvPlatformURL = "MCP_PLATFORM_API_URL"
+	// EnvAdapterServer / Namespace / Agent populate the request to the platform.
+	EnvAdapterServer      = "MCP_RUNTIME_ADAPTER_SERVER"
+	EnvAdapterNamespace   = "MCP_RUNTIME_ADAPTER_NAMESPACE"
+	EnvAdapterAgent       = "MCP_RUNTIME_ADAPTER_AGENT"
+	EnvAdapterAutoRefresh = "MCP_RUNTIME_ADAPTER_AUTO_REFRESH"
+	// adapterRefreshLead is how far in advance of expiry the refresher fires.
+	// Keep this above the platform's adapterSessionRefreshBuffer so the
+	// refresh and reuse-window stay aligned.
+	adapterRefreshLead = 5 * time.Minute
+	// adapterRefreshFloor caps how aggressively short TTLs reschedule, so a
+	// 1-minute TTL doesn't turn into a tight retry loop.
+	adapterRefreshFloor = 30 * time.Second
+)
+
+// platformSessionFlags carries the platform-session bootstrap settings.
+type platformSessionFlags struct {
+	server      string
+	namespace   string
+	agent       string
+	platformURL string
+	autoRefresh bool
+}
+
+func (f *platformSessionFlags) enabled() bool {
+	return f != nil && strings.TrimSpace(f.server) != ""
+}
+
+func bindPlatformSessionFlags(cmd *cobra.Command, f *platformSessionFlags) {
+	cmd.Flags().StringVar(&f.server, "server", os.Getenv(EnvAdapterServer),
+		"MCPServer name to fetch an issued adapter session for (enables platform-issued sessions; default: $"+EnvAdapterServer+")")
+	cmd.Flags().StringVar(&f.namespace, "namespace", os.Getenv(EnvAdapterNamespace),
+		"Namespace of the target MCPServer; defaults to the principal's primary namespace (default: $"+EnvAdapterNamespace+")")
+	cmd.Flags().StringVar(&f.agent, "agent", os.Getenv(EnvAdapterAgent),
+		"Agent identifier to associate with the issued session (default: $"+EnvAdapterAgent+")")
+	cmd.Flags().StringVar(&f.platformURL, "platform-url", os.Getenv(EnvPlatformURL),
+		"Platform API base URL; overrides the URL stored by mcp-runtime auth login (default: $"+EnvPlatformURL+")")
+	cmd.Flags().BoolVar(&f.autoRefresh, "auto-refresh", parseEnvBoolSimple(EnvAdapterAutoRefresh),
+		"Refresh the issued adapter session a few minutes before expiry (default: $"+EnvAdapterAutoRefresh+")")
+}
+
+// applyPlatformSession asks the platform for an issued adapter session and
+// returns a snapshot identity plus, when autoRefresh is set, an IdentityProvider
+// that the adapter calls on every outbound request. The caller wires the
+// provider into the adapter config (ProxyConfig/ShimConfig.IdentityProvider)
+// and must Stop the returned refresher before the process exits.
+//
+// errMsgSink receives refresh failures; the loop keeps the previous identity
+// in place until the next tick succeeds, so transient platform errors do not
+// take the adapter down.
+func applyPlatformSession(
+	ctx context.Context,
+	f *platformSessionFlags,
+	errMsgSink io.Writer,
+) (agentadapter.Identity, agentadapter.IdentityProvider, *platformSessionRefresher, error) {
+	if !f.enabled() {
+		return agentadapter.Identity{}, nil, nil, nil
+	}
+	if strings.TrimSpace(f.agent) == "" {
+		return agentadapter.Identity{}, nil, nil, errors.New("--agent (or $" + EnvAdapterAgent + ") is required when --server is set")
+	}
+
+	// Override the resolved URL so callers can target a non-default platform
+	// without re-running mcp-runtime auth login.
+	if u := strings.TrimSpace(f.platformURL); u != "" {
+		_ = os.Setenv("MCP_PLATFORM_API_URL", u)
+	}
+
+	client, err := platformapi.NewPlatformClient()
+	if err != nil {
+		return agentadapter.Identity{}, nil, nil, fmt.Errorf("platform client: %w", err)
+	}
+
+	session, err := client.CreateAdapterSession(ctx, platformapi.AdapterSessionRequest{
+		ServerName: strings.TrimSpace(f.server),
+		Namespace:  strings.TrimSpace(f.namespace),
+		AgentID:    strings.TrimSpace(f.agent),
+	})
+	if err != nil {
+		return agentadapter.Identity{}, nil, nil, fmt.Errorf("create adapter session: %w", err)
+	}
+	identity := adapterIdentityFromSession(session)
+
+	if !f.autoRefresh {
+		return identity, nil, nil, nil
+	}
+	holder := &atomic.Value{}
+	holder.Store(identity)
+	r := &platformSessionRefresher{
+		client: client,
+		flags:  *f,
+		holder: holder,
+		expiry: session.ExpiresAt,
+		sink:   errMsgSink,
+	}
+	r.start(ctx)
+	provider := agentadapter.IdentityProvider(func() agentadapter.Identity {
+		return holder.Load().(agentadapter.Identity)
+	})
+	return identity, provider, r, nil
+}
+
+// adapterIdentityFromSession converts a platform AdapterSession into the
+// governance headers the adapter forwards to the runtime. The session's
+// metadata.Name is the SessionID — it doubles as the cluster's
+// MCPAgentSession resource name, so the gateway can look it up directly.
+func adapterIdentityFromSession(s platformapi.AdapterSession) agentadapter.Identity {
+	return agentadapter.Identity{
+		HumanID:   s.HumanID,
+		AgentID:   s.AgentID,
+		TeamID:    s.TeamID,
+		SessionID: s.Name,
+	}
+}
+
+// mergeIdentityFromIssued lets explicit flag/env values override the issued
+// session's fields. This keeps the existing flag-driven flow predictable
+// while still letting --server populate any field the user did not supply.
+func mergeIdentityFromIssued(flag, issued agentadapter.Identity) agentadapter.Identity {
+	out := flag
+	if out.HumanID == "" {
+		out.HumanID = issued.HumanID
+	}
+	if out.AgentID == "" {
+		out.AgentID = issued.AgentID
+	}
+	if out.TeamID == "" {
+		out.TeamID = issued.TeamID
+	}
+	if out.SessionID == "" {
+		out.SessionID = issued.SessionID
+	}
+	return out
+}
+
+// platformSessionRefresher periodically renews the issued adapter session.
+// The latest Identity is stored in holder so the IdentityProvider closure
+// the adapter calls on every request returns the up-to-date value without
+// any explicit handoff.
+type platformSessionRefresher struct {
+	client *platformapi.PlatformClient
+	flags  platformSessionFlags
+	holder *atomic.Value // stores agentadapter.Identity
+	expiry time.Time
+	sink   io.Writer
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func (r *platformSessionRefresher) start(parent context.Context) {
+	ctx, cancel := context.WithCancel(parent)
+	r.mu.Lock()
+	r.cancel = cancel
+	r.done = make(chan struct{})
+	r.mu.Unlock()
+	go r.loop(ctx)
+}
+
+// Stop cancels the refresh loop and waits for it to return. Safe to call
+// multiple times.
+func (r *platformSessionRefresher) Stop() {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	cancel := r.cancel
+	done := r.done
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (r *platformSessionRefresher) loop(ctx context.Context) {
+	defer close(r.done)
+	for {
+		wait := time.Until(r.expiry) - adapterRefreshLead
+		if wait < adapterRefreshFloor {
+			wait = adapterRefreshFloor
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+
+		session, err := r.client.CreateAdapterSession(ctx, platformapi.AdapterSessionRequest{
+			ServerName: strings.TrimSpace(r.flags.server),
+			Namespace:  strings.TrimSpace(r.flags.namespace),
+			AgentID:    strings.TrimSpace(r.flags.agent),
+		})
+		if err != nil {
+			// Log and keep going; the existing identity is still valid until
+			// the actual expiry. The next tick will retry.
+			if r.sink != nil {
+				fmt.Fprintf(r.sink, "mcp-runtime adapter: session refresh failed: %v\n", err)
+			}
+			continue
+		}
+		r.holder.Store(adapterIdentityFromSession(session))
+		r.expiry = session.ExpiresAt
+	}
+}

--- a/internal/cli/adapter/platformsession.go
+++ b/internal/cli/adapter/platformsession.go
@@ -62,10 +62,14 @@ func bindPlatformSessionFlags(cmd *cobra.Command, f *platformSessionFlags) {
 }
 
 // applyPlatformSession asks the platform for an issued adapter session and
-// returns a snapshot identity plus, when autoRefresh is set, an IdentityProvider
-// that the adapter calls on every outbound request. The caller wires the
-// provider into the adapter config (ProxyConfig/ShimConfig.IdentityProvider)
-// and must Stop the returned refresher before the process exits.
+// returns the effective identity for first use plus, when autoRefresh is set,
+// an IdentityProvider that the adapter calls on every outbound request.
+//
+// baseIdentity carries the user's explicit flag/env overrides (--human-id,
+// --agent-id, etc.). The returned identity and the IdentityProvider closure
+// both apply mergeIdentityFromIssued(base, issued) so user overrides survive
+// every refresh — without this, auto-refresh would silently revert to the
+// platform-issued values on each tick.
 //
 // errMsgSink receives refresh failures; the loop keeps the previous identity
 // in place until the next tick succeeds, so transient platform errors do not
@@ -73,10 +77,11 @@ func bindPlatformSessionFlags(cmd *cobra.Command, f *platformSessionFlags) {
 func applyPlatformSession(
 	ctx context.Context,
 	f *platformSessionFlags,
+	baseIdentity agentadapter.Identity,
 	errMsgSink io.Writer,
 ) (agentadapter.Identity, agentadapter.IdentityProvider, *platformSessionRefresher, error) {
 	if !f.enabled() {
-		return agentadapter.Identity{}, nil, nil, nil
+		return baseIdentity, nil, nil, nil
 	}
 	if strings.TrimSpace(f.agent) == "" {
 		return agentadapter.Identity{}, nil, nil, errors.New("--agent (or $" + EnvAdapterAgent + ") is required when --server is set")
@@ -101,13 +106,14 @@ func applyPlatformSession(
 	if err != nil {
 		return agentadapter.Identity{}, nil, nil, fmt.Errorf("create adapter session: %w", err)
 	}
-	identity := adapterIdentityFromSession(session)
+	issued := adapterIdentityFromSession(session)
+	merged := mergeIdentityFromIssued(baseIdentity, issued)
 
 	if !f.autoRefresh {
-		return identity, nil, nil, nil
+		return merged, nil, nil, nil
 	}
 	holder := &atomic.Value{}
-	holder.Store(identity)
+	holder.Store(issued)
 	r := &platformSessionRefresher{
 		client: client,
 		flags:  *f,
@@ -117,9 +123,10 @@ func applyPlatformSession(
 	}
 	r.start(ctx)
 	provider := agentadapter.IdentityProvider(func() agentadapter.Identity {
-		return holder.Load().(agentadapter.Identity)
+		// Merge on every call so user overrides survive each refresh.
+		return mergeIdentityFromIssued(baseIdentity, holder.Load().(agentadapter.Identity))
 	})
-	return identity, provider, r, nil
+	return merged, provider, r, nil
 }
 
 // adapterIdentityFromSession converts a platform AdapterSession into the

--- a/internal/cli/adapter/platformsession_test.go
+++ b/internal/cli/adapter/platformsession_test.go
@@ -61,7 +61,7 @@ func TestApplyPlatformSessionPopulatesIdentity(t *testing.T) {
 		agent:     "ops-agent",
 	}
 	var buf bytes.Buffer
-	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, &buf)
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, agentadapter.Identity{}, &buf)
 	if err != nil {
 		t.Fatalf("applyPlatformSession: %v", err)
 	}
@@ -79,6 +79,60 @@ func TestApplyPlatformSessionPopulatesIdentity(t *testing.T) {
 	}
 }
 
+func TestApplyPlatformSessionFlagOverridesSurviveSingleFetch(t *testing.T) {
+	var calls int32
+	_, _ = fakePlatformServer(t, time.Now().Add(time.Hour), &calls)
+	flags := platformSessionFlags{server: "demo", agent: "ops-agent"}
+	base := agentadapter.Identity{HumanID: "explicit-user", SessionID: "explicit-session"}
+	id, _, _, err := applyPlatformSession(context.Background(), &flags, base, nil)
+	if err != nil {
+		t.Fatalf("applyPlatformSession: %v", err)
+	}
+	if id.HumanID != "explicit-user" {
+		t.Fatalf("HumanID = %q, want explicit-user (flag override)", id.HumanID)
+	}
+	if id.SessionID != "explicit-session" {
+		t.Fatalf("SessionID = %q, want explicit-session (flag override)", id.SessionID)
+	}
+	if id.AgentID != "ops-agent" {
+		t.Fatalf("AgentID = %q, want issued ops-agent (no flag override)", id.AgentID)
+	}
+	if id.TeamID != "team-acme" {
+		t.Fatalf("TeamID = %q, want issued team-acme", id.TeamID)
+	}
+}
+
+func TestApplyPlatformSessionRefreshProviderPreservesFlagOverrides(t *testing.T) {
+	var calls int32
+	_, _ = fakePlatformServer(t, time.Now().Add(time.Hour), &calls)
+	flags := platformSessionFlags{server: "demo", agent: "ops-agent", autoRefresh: true}
+	base := agentadapter.Identity{HumanID: "explicit-user", SessionID: "explicit-session"}
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, base, nil)
+	if err != nil {
+		t.Fatalf("applyPlatformSession: %v", err)
+	}
+	if refresher != nil {
+		defer refresher.Stop()
+	}
+	if provider == nil {
+		t.Fatal("auto-refresh must return a provider")
+	}
+	// Initial value already merges base over issued.
+	if id.HumanID != "explicit-user" || id.SessionID != "explicit-session" {
+		t.Fatalf("initial id = %#v, want flag overrides applied", id)
+	}
+	// Provider must apply the same merge (this is the bug Gemini caught:
+	// returning the raw issued identity would drop HumanID and SessionID
+	// overrides every time the adapter forwards a request).
+	got := provider()
+	if got.HumanID != "explicit-user" || got.SessionID != "explicit-session" {
+		t.Fatalf("provider() = %#v, want flag overrides preserved across refresh", got)
+	}
+	if got.AgentID != "ops-agent" || got.TeamID != "team-acme" {
+		t.Fatalf("provider() = %#v, want issued AgentID and TeamID as fallbacks", got)
+	}
+}
+
 func TestApplyPlatformSessionAutoRefreshUsesProvider(t *testing.T) {
 	var calls int32
 	// Short expiry forces the refresh loop to fire quickly.
@@ -90,7 +144,7 @@ func TestApplyPlatformSessionAutoRefreshUsesProvider(t *testing.T) {
 		autoRefresh: true,
 	}
 	var buf bytes.Buffer
-	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, &buf)
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, agentadapter.Identity{}, &buf)
 	if err != nil {
 		t.Fatalf("applyPlatformSession: %v", err)
 	}
@@ -136,21 +190,24 @@ func TestMergeIdentityFromIssuedFlagWins(t *testing.T) {
 
 func TestApplyPlatformSessionDisabledWhenServerUnset(t *testing.T) {
 	flags := platformSessionFlags{}
-	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, nil)
+	base := agentadapter.Identity{HumanID: "from-flag"}
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, base, nil)
 	if err != nil {
 		t.Fatalf("applyPlatformSession: %v", err)
 	}
 	if provider != nil || refresher != nil {
 		t.Fatal("disabled bootstrap must return nil provider and refresher")
 	}
-	if id != (agentadapter.Identity{}) {
-		t.Fatalf("identity = %#v, want empty zero value", id)
+	// When the bootstrap is disabled the base identity passes through unchanged
+	// so callers that rely on flag/env identity keep working.
+	if id != base {
+		t.Fatalf("identity = %#v, want base identity %#v passed through", id, base)
 	}
 }
 
 func TestApplyPlatformSessionRequiresAgent(t *testing.T) {
 	flags := platformSessionFlags{server: "demo"}
-	_, _, _, err := applyPlatformSession(context.Background(), &flags, nil)
+	_, _, _, err := applyPlatformSession(context.Background(), &flags, agentadapter.Identity{}, nil)
 	if err == nil || !strings.Contains(err.Error(), "--agent") {
 		t.Fatalf("err = %v, want missing --agent error", err)
 	}

--- a/internal/cli/adapter/platformsession_test.go
+++ b/internal/cli/adapter/platformsession_test.go
@@ -1,0 +1,157 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"mcp-runtime/internal/agentadapter"
+	"mcp-runtime/internal/cli/platformapi"
+)
+
+// fakePlatformServer is a barebones implementation of the platform adapter-
+// session endpoint sufficient to drive applyPlatformSession in tests.
+func fakePlatformServer(t *testing.T, expiresAt time.Time, calls *int32) (*httptest.Server, *platformapi.PlatformClient) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/runtime/adapter/sessions" {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(calls, 1)
+		var req platformapi.AdapterSessionRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		resp := platformapi.AdapterSession{
+			Name:           "adapter-fake",
+			Namespace:      "mcp-team-acme",
+			HumanID:        "user-123",
+			AgentID:        req.AgentID,
+			TeamID:         "team-acme",
+			ServerName:     req.ServerName,
+			ConsentedTrust: "low",
+			PolicyVersion:  "v1",
+			ExpiresAt:      expiresAt,
+		}
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("MCP_PLATFORM_API_URL", server.URL)
+	t.Setenv("MCP_PLATFORM_API_TOKEN", "test-token")
+	client, err := platformapi.NewPlatformClient()
+	if err != nil {
+		t.Fatalf("NewPlatformClient: %v", err)
+	}
+	return server, client
+}
+
+func TestApplyPlatformSessionPopulatesIdentity(t *testing.T) {
+	var calls int32
+	_, _ = fakePlatformServer(t, time.Now().Add(time.Hour), &calls)
+	flags := platformSessionFlags{
+		server:    "demo",
+		namespace: "mcp-team-acme",
+		agent:     "ops-agent",
+	}
+	var buf bytes.Buffer
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, &buf)
+	if err != nil {
+		t.Fatalf("applyPlatformSession: %v", err)
+	}
+	if refresher != nil {
+		t.Fatal("refresher should be nil when auto-refresh is off")
+	}
+	if provider != nil {
+		t.Fatal("provider should be nil when auto-refresh is off")
+	}
+	if id.HumanID != "user-123" || id.AgentID != "ops-agent" || id.TeamID != "team-acme" || id.SessionID != "adapter-fake" {
+		t.Fatalf("identity = %#v, want platform-issued values", id)
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("calls = %d, want 1", atomic.LoadInt32(&calls))
+	}
+}
+
+func TestApplyPlatformSessionAutoRefreshUsesProvider(t *testing.T) {
+	var calls int32
+	// Short expiry forces the refresh loop to fire quickly.
+	_, _ = fakePlatformServer(t, time.Now().Add(2*time.Second), &calls)
+	flags := platformSessionFlags{
+		server:      "demo",
+		namespace:   "mcp-team-acme",
+		agent:       "ops-agent",
+		autoRefresh: true,
+	}
+	var buf bytes.Buffer
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, &buf)
+	if err != nil {
+		t.Fatalf("applyPlatformSession: %v", err)
+	}
+	if refresher == nil || provider == nil {
+		t.Fatal("auto-refresh must return a refresher and a provider")
+	}
+	defer refresher.Stop()
+	got := provider()
+	if got != id {
+		t.Fatalf("provider() = %#v, want initial identity %#v", got, id)
+	}
+	// Wait long enough for at least one refresh tick (adapterRefreshFloor = 30s
+	// in production; this test sleeps a short window to verify the loop wakes
+	// at least once when expiry is well past).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&calls) >= 2 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// Not asserting a refresh fired by 2s because adapterRefreshFloor is 30s,
+	// but at minimum the provider remains valid for the test duration.
+	if provider() != id {
+		t.Fatal("provider must keep returning the latest identity")
+	}
+}
+
+func TestMergeIdentityFromIssuedFlagWins(t *testing.T) {
+	flag := agentadapter.Identity{HumanID: "explicit", SessionID: "fixed"}
+	issued := agentadapter.Identity{HumanID: "issued", AgentID: "issued-agent", TeamID: "issued-team", SessionID: "issued-session"}
+	got := mergeIdentityFromIssued(flag, issued)
+	if got.HumanID != "explicit" {
+		t.Fatalf("HumanID = %q, want explicit flag to win", got.HumanID)
+	}
+	if got.AgentID != "issued-agent" {
+		t.Fatalf("AgentID = %q, want issued fallback", got.AgentID)
+	}
+	if got.SessionID != "fixed" {
+		t.Fatalf("SessionID = %q, want explicit flag to win", got.SessionID)
+	}
+}
+
+func TestApplyPlatformSessionDisabledWhenServerUnset(t *testing.T) {
+	flags := platformSessionFlags{}
+	id, provider, refresher, err := applyPlatformSession(context.Background(), &flags, nil)
+	if err != nil {
+		t.Fatalf("applyPlatformSession: %v", err)
+	}
+	if provider != nil || refresher != nil {
+		t.Fatal("disabled bootstrap must return nil provider and refresher")
+	}
+	if id != (agentadapter.Identity{}) {
+		t.Fatalf("identity = %#v, want empty zero value", id)
+	}
+}
+
+func TestApplyPlatformSessionRequiresAgent(t *testing.T) {
+	flags := platformSessionFlags{server: "demo"}
+	_, _, _, err := applyPlatformSession(context.Background(), &flags, nil)
+	if err == nil || !strings.Contains(err.Error(), "--agent") {
+		t.Fatalf("err = %v, want missing --agent error", err)
+	}
+}

--- a/internal/cli/adapter/proxy.go
+++ b/internal/cli/adapter/proxy.go
@@ -37,15 +37,15 @@ override the result.`,
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
 
-			issued, provider, refresher, err := applyPlatformSession(ctx, &sessionFlags, cmd.ErrOrStderr())
+			effective, provider, refresher, err := applyPlatformSession(ctx, &sessionFlags, cfg.Identity, cmd.ErrOrStderr())
 			if err != nil {
 				return err
 			}
 			if refresher != nil {
 				defer refresher.Stop()
 			}
-			if sessionFlags.enabled() {
-				cfg.Identity = mergeIdentityFromIssued(cfg.Identity, issued)
+			cfg.Identity = effective
+			if provider != nil {
 				cfg.IdentityProvider = provider
 			}
 			if err := cfg.Validate(); err != nil {

--- a/internal/cli/adapter/proxy.go
+++ b/internal/cli/adapter/proxy.go
@@ -14,6 +14,7 @@ import (
 
 func newProxyCmd(_ *core.Runtime) *cobra.Command {
 	var flags identityFlags
+	var sessionFlags platformSessionFlags
 	var listenAddr string
 
 	cmd := &cobra.Command{
@@ -24,18 +25,33 @@ agent SDK and forwards each request to the configured platform runtime route,
 injecting the issued governance identity headers.
 
 Configure identity via flags or the matching MCP_RUNTIME_* environment
-variables. Flags win when both are set.`,
+variables. Flags win when both are set. With --server, the adapter fetches
+an issued session from the platform API before listening; identity flags
+override the result.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := flags.toProxyConfig(listenAddr)
 			if err != nil {
 				return err
 			}
+
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			issued, provider, refresher, err := applyPlatformSession(ctx, &sessionFlags, cmd.ErrOrStderr())
+			if err != nil {
+				return err
+			}
+			if refresher != nil {
+				defer refresher.Stop()
+			}
+			if sessionFlags.enabled() {
+				cfg.Identity = mergeIdentityFromIssued(cfg.Identity, issued)
+				cfg.IdentityProvider = provider
+			}
 			if err := cfg.Validate(); err != nil {
 				return err
 			}
 
-			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
-			defer stop()
 			fmt.Fprintf(cmd.ErrOrStderr(), "mcp-runtime adapter proxy listening on %s -> %s\n",
 				cfg.ListenAddr, cfg.RuntimeURL.String())
 			return agentadapter.RunHTTPProxy(ctx, cfg)
@@ -44,6 +60,7 @@ variables. Flags win when both are set.`,
 
 	bindIdentityFlags(cmd, &flags)
 	bindProxyFlags(cmd, &flags)
+	bindPlatformSessionFlags(cmd, &sessionFlags)
 	cmd.Flags().StringVar(&listenAddr, "listen", os.Getenv(agentadapter.EnvListenAddr),
 		"Local listen address (default: $"+agentadapter.EnvListenAddr+" or "+agentadapter.DefaultListenAddr+")")
 	return cmd

--- a/internal/cli/adapter/stdio.go
+++ b/internal/cli/adapter/stdio.go
@@ -13,6 +13,7 @@ import (
 
 func newStdioCmd(_ *core.Runtime) *cobra.Command {
 	var flags identityFlags
+	var sessionFlags platformSessionFlags
 
 	cmd := &cobra.Command{
 		Use:   "stdio",
@@ -23,18 +24,33 @@ responses back to stdout. Designed for IDE-style MCP clients (e.g. Cursor,
 Claude Desktop) that launch an MCP server as a subprocess.
 
 Configure identity via flags or the matching MCP_RUNTIME_* environment
-variables. Flags win when both are set.`,
+variables. Flags win when both are set. With --server, the shim fetches an
+issued session from the platform API before reading stdin; identity flags
+override the result.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := flags.toShimConfig()
 			if err != nil {
 				return err
 			}
+
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			issued, provider, refresher, err := applyPlatformSession(ctx, &sessionFlags, cmd.ErrOrStderr())
+			if err != nil {
+				return err
+			}
+			if refresher != nil {
+				defer refresher.Stop()
+			}
+			if sessionFlags.enabled() {
+				cfg.Identity = mergeIdentityFromIssued(cfg.Identity, issued)
+				cfg.IdentityProvider = provider
+			}
 			if err := cfg.Validate(); err != nil {
 				return err
 			}
 
-			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
-			defer stop()
 			return agentadapter.RunStdioShim(ctx, cfg, agentadapter.StdioOptions{
 				Stdin:  os.Stdin,
 				Stdout: os.Stdout,
@@ -44,5 +60,6 @@ variables. Flags win when both are set.`,
 
 	bindIdentityFlags(cmd, &flags)
 	bindStdioFlags(cmd, &flags)
+	bindPlatformSessionFlags(cmd, &sessionFlags)
 	return cmd
 }

--- a/internal/cli/adapter/stdio.go
+++ b/internal/cli/adapter/stdio.go
@@ -36,15 +36,15 @@ override the result.`,
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
 
-			issued, provider, refresher, err := applyPlatformSession(ctx, &sessionFlags, cmd.ErrOrStderr())
+			effective, provider, refresher, err := applyPlatformSession(ctx, &sessionFlags, cfg.Identity, cmd.ErrOrStderr())
 			if err != nil {
 				return err
 			}
 			if refresher != nil {
 				defer refresher.Stop()
 			}
-			if sessionFlags.enabled() {
-				cfg.Identity = mergeIdentityFromIssued(cfg.Identity, issued)
+			cfg.Identity = effective
+			if provider != nil {
 				cfg.IdentityProvider = provider
 			}
 			if err := cfg.Validate(); err != nil {

--- a/internal/cli/platformapi/adapter_session.go
+++ b/internal/cli/platformapi/adapter_session.go
@@ -1,0 +1,65 @@
+package platformapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// AdapterSessionRequest is the input contract for the platform API endpoint
+// POST /api/runtime/adapter/sessions. RequestedTTL/Trust are optional; empty
+// values fall back to platform-side defaults.
+type AdapterSessionRequest struct {
+	ServerName     string `json:"serverName"`
+	Namespace      string `json:"namespace,omitempty"`
+	AgentID        string `json:"agentID"`
+	RequestedTrust string `json:"requestedTrust,omitempty"`
+	RequestedTTL   string `json:"requestedTTL,omitempty"`
+}
+
+// AdapterSession captures the identity the adapter must inject into runtime
+// requests. ExpiresAt is absolute (server-side time); callers should refresh
+// before it elapses.
+type AdapterSession struct {
+	Name           string    `json:"name"`
+	Namespace      string    `json:"namespace"`
+	HumanID        string    `json:"humanID"`
+	AgentID        string    `json:"agentID"`
+	TeamID         string    `json:"teamID,omitempty"`
+	ServerName     string    `json:"serverName"`
+	ConsentedTrust string    `json:"consentedTrust"`
+	PolicyVersion  string    `json:"policyVersion"`
+	ExpiresAt      time.Time `json:"expiresAt"`
+	Reused         bool      `json:"reused"`
+}
+
+// CreateAdapterSession asks the platform to issue (or reuse) an MCPAgentSession
+// for the calling principal. The returned session.Name doubles as the
+// SessionID the adapter forwards on every runtime request.
+func (c *PlatformClient) CreateAdapterSession(ctx context.Context, req AdapterSessionRequest) (AdapterSession, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return AdapterSession{}, fmt.Errorf("marshal request: %w", err)
+	}
+	resp, err := c.do(ctx, http.MethodPost, "/runtime/adapter/sessions", "", bytes.NewReader(body))
+	if err != nil {
+		return AdapterSession{}, err
+	}
+	defer resp.Body.Close()
+	respBody, err := readBody(io.LimitReader(resp.Body, maxAPIBodyRead))
+	if err != nil {
+		return AdapterSession{}, err
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return AdapterSession{}, httpAPIError(resp.StatusCode, respBody)
+	}
+	var session AdapterSession
+	if err := json.Unmarshal(respBody, &session); err != nil {
+		return AdapterSession{}, fmt.Errorf("decode response: %w", err)
+	}
+	return session, nil
+}

--- a/services/api/internal/runtimeapi/adapter.go
+++ b/services/api/internal/runtimeapi/adapter.go
@@ -1,0 +1,383 @@
+package runtimeapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	sentinelaccess "mcp-runtime/pkg/access"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Adapter-session bounds: the issued session's lifetime is constrained so a
+// compromised cached identity has a bounded blast radius. The defaults are
+// generous enough for a long-running agent process to avoid hot-path refreshes
+// but short enough to cycle credentials within a working day.
+const (
+	adapterSessionDefaultTTL = time.Hour
+	adapterSessionMaxTTL     = 24 * time.Hour
+	// adapterSessionRefreshBuffer is the minimum remaining lifetime an existing
+	// session must have to be reused. Anything under this triggers a fresh
+	// session so the caller does not race expiry mid-conversation.
+	adapterSessionRefreshBuffer   = 30 * time.Second
+	adapterSessionRequestMaxBytes = 16 << 10
+)
+
+// adapterSessionRequest is the input contract for POST /api/runtime/adapter/sessions.
+type adapterSessionRequest struct {
+	ServerName     string `json:"serverName"`
+	Namespace      string `json:"namespace"`
+	AgentID        string `json:"agentID"`
+	RequestedTrust string `json:"requestedTrust,omitempty"`
+	RequestedTTL   string `json:"requestedTTL,omitempty"`
+}
+
+// adapterSessionResponse is the body returned on success.
+type adapterSessionResponse struct {
+	Name           string    `json:"name"`
+	Namespace      string    `json:"namespace"`
+	HumanID        string    `json:"humanID"`
+	AgentID        string    `json:"agentID"`
+	TeamID         string    `json:"teamID,omitempty"`
+	ServerName     string    `json:"serverName"`
+	ConsentedTrust string    `json:"consentedTrust"`
+	PolicyVersion  string    `json:"policyVersion"`
+	ExpiresAt      time.Time `json:"expiresAt"`
+	Reused         bool      `json:"reused"`
+}
+
+// HandleAdapterSession issues (or reuses) an MCPAgentSession for an adapter
+// call. The platform — not the adapter — picks the matching grant, caps the
+// trust at the grant's ceiling, and writes the session resource. The adapter
+// then attaches the returned identity fields as governance headers on every
+// request to the runtime gateway.
+//
+// Errors:
+//   - 400 when body decoding or input validation fails
+//   - 401 when no Principal is on the request (auth middleware should reject first)
+//   - 403 when no matching enabled grant is found, or the principal lacks the team
+//   - 503 when Kubernetes is unavailable
+func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if s.accessMgr == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		return
+	}
+
+	var req adapterSessionRequest
+	r.Body = http.MaxBytesReader(w, r.Body, adapterSessionRequestMaxBytes)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	req.ServerName = strings.TrimSpace(req.ServerName)
+	req.Namespace = strings.TrimSpace(req.Namespace)
+	req.AgentID = strings.TrimSpace(req.AgentID)
+
+	principal, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "no principal on request"})
+		return
+	}
+
+	if req.ServerName == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "serverName is required"})
+		return
+	}
+	if req.AgentID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agentID is required"})
+		return
+	}
+	if req.Namespace == "" {
+		// Default to the principal's primary namespace so single-team callers
+		// don't have to pass it on every request.
+		req.Namespace = principal.Namespace
+	}
+
+	humanID := strings.TrimSpace(principal.Subject)
+	if humanID == "" {
+		humanID = strings.TrimSpace(principal.Email)
+	}
+	if humanID == "" {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "principal has no subject or email"})
+		return
+	}
+
+	teamID, err := principalTeamForNamespace(principal, req.Namespace)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+
+	requestedTrust, err := parseAdapterTrust(req.RequestedTrust)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	requestedTTL, err := parseAdapterTTL(req.RequestedTTL)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	grant, err := s.selectAdapterGrant(ctx, req.Namespace, req.ServerName, humanID, req.AgentID, teamID)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+
+	consentedTrust := capTrust(requestedTrust, grant.Spec.MaxTrust)
+	policyVersion := defaultPolicyVersion(grant.Spec.PolicyVersion)
+	sessionName := adapterSessionName(humanID, req.AgentID, teamID, req.ServerName)
+	expiresAt := time.Now().UTC().Add(requestedTTL)
+
+	// Reuse an existing session when its identity, policy version, and trust
+	// still match and it has enough remaining lifetime to be useful.
+	existing, _ := s.accessMgr.GetSession(ctx, sessionName, req.Namespace)
+	if existing != nil && adapterSessionReusable(existing, policyVersion, consentedTrust) {
+		writeJSON(w, http.StatusOK, adapterSessionResponse{
+			Name:           existing.Name,
+			Namespace:      existing.Namespace,
+			HumanID:        existing.Spec.Subject.HumanID,
+			AgentID:        existing.Spec.Subject.AgentID,
+			TeamID:         existing.Spec.Subject.TeamID,
+			ServerName:     existing.Spec.ServerRef.Name,
+			ConsentedTrust: string(existing.Spec.ConsentedTrust),
+			PolicyVersion:  existing.Spec.PolicyVersion,
+			ExpiresAt:      existing.Spec.ExpiresAt.Time,
+			Reused:         true,
+		})
+		return
+	}
+
+	session := &sentinelaccess.MCPAgentSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sessionName,
+			Namespace: defaultAccessNamespace(req.Namespace),
+		},
+		Spec: sentinelaccess.MCPAgentSessionSpec{
+			ServerRef: sentinelaccess.ServerReference{
+				Name:      req.ServerName,
+				Namespace: defaultAccessNamespace(req.Namespace),
+			},
+			Subject: sentinelaccess.SubjectRef{
+				HumanID: humanID,
+				AgentID: req.AgentID,
+				TeamID:  teamID,
+			},
+			ConsentedTrust: consentedTrust,
+			ExpiresAt:      &metav1.Time{Time: expiresAt},
+			PolicyVersion:  policyVersion,
+		},
+	}
+	applied, err := s.accessMgr.ApplySession(ctx, session)
+	if err != nil {
+		log.Printf("adapter session apply %s/%s failed: %v", session.Namespace, session.Name, err)
+		writeK8sApplyError(w, "adapter session", session.Namespace, session.Name, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, adapterSessionResponse{
+		Name:           applied.Name,
+		Namespace:      applied.Namespace,
+		HumanID:        applied.Spec.Subject.HumanID,
+		AgentID:        applied.Spec.Subject.AgentID,
+		TeamID:         applied.Spec.Subject.TeamID,
+		ServerName:     applied.Spec.ServerRef.Name,
+		ConsentedTrust: string(applied.Spec.ConsentedTrust),
+		PolicyVersion:  applied.Spec.PolicyVersion,
+		ExpiresAt:      applied.Spec.ExpiresAt.Time,
+		Reused:         false,
+	})
+}
+
+// principalTeamForNamespace resolves the team identity the principal must hold
+// for the supplied namespace. Admin principals (no team binding) are allowed
+// to operate without a team; everyone else must be a member of the team that
+// owns the namespace.
+func principalTeamForNamespace(p principal, namespace string) (string, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return "", errors.New("namespace is required")
+	}
+	if team, ok := p.TeamForNamespace(namespace); ok {
+		return strings.TrimSpace(team.ID), nil
+	}
+	if p.Role == roleAdmin {
+		return "", nil
+	}
+	return "", fmt.Errorf("principal is not a member of namespace %q", namespace)
+}
+
+// selectAdapterGrant lists enabled MCPAccessGrants in namespace whose serverRef
+// matches and whose subject either matches the caller exactly or leaves the
+// field empty (wildcard). When multiple grants match, the one with the highest
+// MaxTrust wins; ties are broken by oldest creationTimestamp so the result is
+// deterministic across replicas.
+func (s *RuntimeServer) selectAdapterGrant(ctx context.Context, namespace, serverName, humanID, agentID, teamID string) (*sentinelaccess.MCPAccessGrant, error) {
+	grants, err := s.accessMgr.ListGrants(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("list grants in %s: %w", namespace, err)
+	}
+	var matches []sentinelaccess.MCPAccessGrant
+	for _, g := range grants.Items {
+		if g.Spec.Disabled {
+			continue
+		}
+		if g.Spec.ServerRef.Name != serverName {
+			continue
+		}
+		if !subjectMatches(g.Spec.Subject, humanID, agentID, teamID) {
+			continue
+		}
+		matches = append(matches, g)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no enabled MCPAccessGrant in %s matches server=%q humanID=%q agentID=%q",
+			namespace, serverName, humanID, agentID)
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		ti := trustRank(matches[i].Spec.MaxTrust)
+		tj := trustRank(matches[j].Spec.MaxTrust)
+		if ti != tj {
+			return ti > tj
+		}
+		return matches[i].CreationTimestamp.Time.Before(matches[j].CreationTimestamp.Time)
+	})
+	g := matches[0]
+	return &g, nil
+}
+
+// subjectMatches treats empty fields on the grant's subject as wildcards,
+// preserving the SubjectRef semantics already used by the gateway when
+// evaluating policy at runtime.
+func subjectMatches(subj sentinelaccess.SubjectRef, humanID, agentID, teamID string) bool {
+	if subj.HumanID != "" && subj.HumanID != humanID {
+		return false
+	}
+	if subj.AgentID != "" && subj.AgentID != agentID {
+		return false
+	}
+	if subj.TeamID != "" && subj.TeamID != teamID {
+		return false
+	}
+	return true
+}
+
+// adapterSessionName derives a deterministic resource name from the caller's
+// identity so repeated calls with the same identity converge on a single
+// MCPAgentSession (and re-use it as long as it remains valid).
+func adapterSessionName(humanID, agentID, teamID, serverName string) string {
+	h := sha256.New()
+	h.Write([]byte(humanID))
+	h.Write([]byte{0})
+	h.Write([]byte(agentID))
+	h.Write([]byte{0})
+	h.Write([]byte(teamID))
+	h.Write([]byte{0})
+	h.Write([]byte(serverName))
+	digest := hex.EncodeToString(h.Sum(nil))[:16]
+	return "adapter-" + digest
+}
+
+// adapterSessionReusable reports whether an existing session can be returned
+// to the caller as-is without writing to Kubernetes. Reuse fails closed: if
+// any condition is unmet we issue a fresh session.
+func adapterSessionReusable(s *sentinelaccess.MCPAgentSession, policyVersion string, consentedTrust sentinelaccess.TrustLevel) bool {
+	if s == nil || s.Spec.Revoked {
+		return false
+	}
+	if s.Spec.PolicyVersion != policyVersion {
+		return false
+	}
+	if string(s.Spec.ConsentedTrust) != string(consentedTrust) {
+		return false
+	}
+	if s.Spec.ExpiresAt == nil {
+		return false
+	}
+	if time.Until(s.Spec.ExpiresAt.Time) <= adapterSessionRefreshBuffer {
+		return false
+	}
+	return true
+}
+
+// parseAdapterTrust normalises the caller's requested trust level. Empty
+// requests default to "low" (least privilege) so callers explicitly opt in to
+// higher trust. Unknown values are rejected.
+func parseAdapterTrust(raw string) (sentinelaccess.TrustLevel, error) {
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	switch raw {
+	case "":
+		return sentinelaccess.TrustLow, nil
+	case string(sentinelaccess.TrustNone), string(sentinelaccess.TrustLow),
+		string(sentinelaccess.TrustMid), string(sentinelaccess.TrustHigh),
+		string(sentinelaccess.TrustFull):
+		return sentinelaccess.TrustLevel(raw), nil
+	default:
+		return "", fmt.Errorf("requestedTrust %q is not a known trust level", raw)
+	}
+}
+
+func parseAdapterTTL(raw string) (time.Duration, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return adapterSessionDefaultTTL, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("requestedTTL %q is not a valid duration: %w", raw, err)
+	}
+	if d <= 0 {
+		return 0, errors.New("requestedTTL must be greater than zero")
+	}
+	if d > adapterSessionMaxTTL {
+		return adapterSessionMaxTTL, nil
+	}
+	return d, nil
+}
+
+// capTrust returns the requested trust capped at the grant's max trust.
+// Empty grant maxTrust is treated as "no ceiling" — the grant author has not
+// asserted a cap and we accept whatever the caller asked for (or the default).
+func capTrust(requested, max sentinelaccess.TrustLevel) sentinelaccess.TrustLevel {
+	if max == "" {
+		return requested
+	}
+	if trustRank(requested) > trustRank(max) {
+		return max
+	}
+	return requested
+}
+
+func trustRank(t sentinelaccess.TrustLevel) int {
+	switch t {
+	case sentinelaccess.TrustNone:
+		return 0
+	case sentinelaccess.TrustLow:
+		return 1
+	case sentinelaccess.TrustMid:
+		return 2
+	case sentinelaccess.TrustHigh:
+		return 3
+	case sentinelaccess.TrustFull:
+		return 4
+	default:
+		return -1
+	}
+}

--- a/services/api/internal/runtimeapi/adapter_test.go
+++ b/services/api/internal/runtimeapi/adapter_test.go
@@ -1,0 +1,282 @@
+package runtimeapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
+	sentinelaccess "mcp-runtime/pkg/access"
+	"mcp-sentinel-api/internal/platformstore"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// adapterTestFixture sets up an in-memory access manager preloaded with a
+// server and a grant so the adapter session handler can be exercised
+// end-to-end without a real cluster.
+type adapterTestFixture struct {
+	server    *RuntimeServer
+	principal principal
+	scheme    *runtime.Scheme
+}
+
+func newAdapterTestFixture(t *testing.T, grants ...mcpv1alpha1.MCPAccessGrant) adapterTestFixture {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	objects := []runtime.Object{
+		&mcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "mcp-team-acme"},
+		},
+	}
+	for i := range grants {
+		objects = append(objects, &grants[i])
+	}
+	mgr := sentinelaccess.NewManager(dynamicfake.NewSimpleDynamicClient(scheme, objects...), nil)
+	return adapterTestFixture{
+		server: &RuntimeServer{accessMgr: mgr},
+		principal: principal{
+			Subject:   "user-123",
+			Email:     "user@example.org",
+			Namespace: "mcp-team-acme",
+			Role:      roleUser,
+			Teams: []platformstore.PrincipalTeam{
+				{ID: "team-acme", Namespace: "mcp-team-acme"},
+			},
+		},
+		scheme: scheme,
+	}
+}
+
+func adapterRequest(t *testing.T, body adapterSessionRequest) *http.Request {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return httptest.NewRequest(http.MethodPost, "/api/runtime/adapter/sessions", bytes.NewReader(raw))
+}
+
+func decodeAdapterResponse(t *testing.T, recorder *httptest.ResponseRecorder) adapterSessionResponse {
+	t.Helper()
+	var resp adapterSessionResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, recorder.Body.String())
+	}
+	return resp
+}
+
+func TestAdapterSessionIssuesNewSessionFromMatchingGrant(t *testing.T) {
+	grant := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "g1",
+			Namespace:         "mcp-team-acme",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+		},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef:     mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:       mcpv1alpha1.SubjectRef{HumanID: "user-123", AgentID: "ops-agent", TeamID: "team-acme"},
+			MaxTrust:      mcpv1alpha1.TrustLevel("high"),
+			PolicyVersion: "v3",
+		},
+	}
+	fx := newAdapterTestFixture(t, grant)
+	req := adapterRequest(t, adapterSessionRequest{
+		ServerName:     "demo",
+		Namespace:      "mcp-team-acme",
+		AgentID:        "ops-agent",
+		RequestedTrust: "mid",
+	})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	got := decodeAdapterResponse(t, w)
+	if got.HumanID != "user-123" || got.AgentID != "ops-agent" || got.TeamID != "team-acme" {
+		t.Fatalf("identity = %#v, want user-123/ops-agent/team-acme", got)
+	}
+	if got.ConsentedTrust != "mid" {
+		t.Fatalf("consentedTrust = %q, want mid (requested, within max=high)", got.ConsentedTrust)
+	}
+	if got.PolicyVersion != "v3" {
+		t.Fatalf("policyVersion = %q, want v3 (from grant)", got.PolicyVersion)
+	}
+	if got.Reused {
+		t.Fatal("reused = true on first call, want false")
+	}
+	if !strings.HasPrefix(got.Name, "adapter-") {
+		t.Fatalf("name = %q, want adapter-<hash> prefix", got.Name)
+	}
+	if got.ExpiresAt.Before(time.Now()) {
+		t.Fatalf("expiresAt = %v, must be in the future", got.ExpiresAt)
+	}
+}
+
+func TestAdapterSessionRejectsWhenNoGrantMatches(t *testing.T) {
+	fx := newAdapterTestFixture(t) // no grants
+	req := adapterRequest(t, adapterSessionRequest{
+		ServerName: "demo",
+		Namespace:  "mcp-team-acme",
+		AgentID:    "ops-agent",
+	})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s, want 403", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "no enabled MCPAccessGrant") {
+		t.Fatalf("body = %q, want 'no enabled MCPAccessGrant'", w.Body.String())
+	}
+}
+
+func TestAdapterSessionTrustCappedAtGrantMaxTrust(t *testing.T) {
+	grant := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "g1", Namespace: "mcp-team-acme"},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef: mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:   mcpv1alpha1.SubjectRef{TeamID: "team-acme"}, // team wildcard for humanID/agentID
+			MaxTrust:  mcpv1alpha1.TrustLevel("low"),
+		},
+	}
+	fx := newAdapterTestFixture(t, grant)
+	req := adapterRequest(t, adapterSessionRequest{
+		ServerName:     "demo",
+		Namespace:      "mcp-team-acme",
+		AgentID:        "ops-agent",
+		RequestedTrust: "high",
+	})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	got := decodeAdapterResponse(t, w)
+	if got.ConsentedTrust != "low" {
+		t.Fatalf("consentedTrust = %q, want low (capped at grant.MaxTrust)", got.ConsentedTrust)
+	}
+}
+
+func TestAdapterSessionPicksHighestTrustWithDeterministicTiebreak(t *testing.T) {
+	older := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "g-older",
+			Namespace:         "mcp-team-acme",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
+		},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef: mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:   mcpv1alpha1.SubjectRef{TeamID: "team-acme"},
+			MaxTrust:  mcpv1alpha1.TrustLevel("high"),
+		},
+	}
+	newer := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "g-newer",
+			Namespace:         "mcp-team-acme",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
+		},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef: mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:   mcpv1alpha1.SubjectRef{TeamID: "team-acme"},
+			MaxTrust:  mcpv1alpha1.TrustLevel("high"),
+		},
+	}
+	low := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "g-low", Namespace: "mcp-team-acme"},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef: mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:   mcpv1alpha1.SubjectRef{TeamID: "team-acme"},
+			MaxTrust:  mcpv1alpha1.TrustLevel("low"),
+		},
+	}
+	fx := newAdapterTestFixture(t, low, newer, older)
+	g, err := fx.server.selectAdapterGrant(
+		t.Context(),
+		"mcp-team-acme", "demo",
+		"user-123", "ops-agent", "team-acme",
+	)
+	if err != nil {
+		t.Fatalf("selectAdapterGrant: %v", err)
+	}
+	if g.Name != "g-older" {
+		t.Fatalf("selected = %q, want g-older (highest trust, oldest first for tiebreak)", g.Name)
+	}
+}
+
+func TestAdapterSessionRequiresServerName(t *testing.T) {
+	fx := newAdapterTestFixture(t)
+	req := adapterRequest(t, adapterSessionRequest{Namespace: "mcp-team-acme", AgentID: "ops-agent"})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAdapterSessionRejectsTTLBeyondHardCap(t *testing.T) {
+	d, err := parseAdapterTTL("48h")
+	if err != nil {
+		t.Fatalf("parseAdapterTTL: %v", err)
+	}
+	if d != adapterSessionMaxTTL {
+		t.Fatalf("got %v, want capped at %v", d, adapterSessionMaxTTL)
+	}
+}
+
+func TestAdapterSessionDeterministicName(t *testing.T) {
+	n1 := adapterSessionName("h1", "a1", "t1", "srv")
+	n2 := adapterSessionName("h1", "a1", "t1", "srv")
+	if n1 != n2 {
+		t.Fatalf("name n1 = %q, n2 = %q, want equal for identical inputs", n1, n2)
+	}
+	if adapterSessionName("h1", "a1", "t1", "srv") == adapterSessionName("h2", "a1", "t1", "srv") {
+		t.Fatal("name should differ when humanID differs")
+	}
+	if !strings.HasPrefix(n1, "adapter-") {
+		t.Fatalf("name = %q, want adapter- prefix", n1)
+	}
+}
+
+func TestAdapterSessionReusableRejectsExpiredOrRevoked(t *testing.T) {
+	now := time.Now()
+	ok := &sentinelaccess.MCPAgentSession{
+		Spec: sentinelaccess.MCPAgentSessionSpec{
+			PolicyVersion:  "v1",
+			ConsentedTrust: sentinelaccess.TrustLow,
+			ExpiresAt:      &metav1.Time{Time: now.Add(time.Hour)},
+		},
+	}
+	revoked := *ok
+	revoked.Spec.Revoked = true
+	soon := *ok
+	soon.Spec.ExpiresAt = &metav1.Time{Time: now.Add(5 * time.Second)} // < refresh buffer
+	mismatchPolicy := *ok
+	mismatchPolicy.Spec.PolicyVersion = "v2"
+
+	if !adapterSessionReusable(ok, "v1", sentinelaccess.TrustLow) {
+		t.Fatal("happy path should be reusable")
+	}
+	if adapterSessionReusable(&revoked, "v1", sentinelaccess.TrustLow) {
+		t.Fatal("revoked session must not be reused")
+	}
+	if adapterSessionReusable(&soon, "v1", sentinelaccess.TrustLow) {
+		t.Fatal("session inside refresh buffer must not be reused")
+	}
+	if adapterSessionReusable(&mismatchPolicy, "v1", sentinelaccess.TrustLow) {
+		t.Fatal("policy-version mismatch must not be reused")
+	}
+}

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -303,6 +303,7 @@ func main() {
 		mux.Handle("/api/admin/deployments", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.HandleAdminDeployments))))
 		mux.Handle("/api/runtime/grants", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimeGrants)))
 		mux.Handle("/api/runtime/sessions", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimeSessions)))
+		mux.Handle("/api/runtime/adapter/sessions", server.auth(http.HandlerFunc(runtimeServer.HandleAdapterSession)))
 		mux.Handle("/api/runtime/components", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimeComponents)))
 		mux.Handle("/api/runtime/policy", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimePolicy)))
 		mux.Handle("/api/runtime/actions/restart", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.HandleActionRestart))))

--- a/test/golden/cli/testdata/mcp-runtime_adapter_proxy_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_adapter_proxy_help.golden
@@ -3,24 +3,31 @@ agent SDK and forwards each request to the configured platform runtime route,
 injecting the issued governance identity headers.
 
 Configure identity via flags or the matching MCP_RUNTIME_* environment
-variables. Flags win when both are set.
+variables. Flags win when both are set. With --server, the adapter fetches
+an issued session from the platform API before listening; identity flags
+override the result.
 
 Usage:
   mcp-runtime adapter proxy [flags]
 
 Flags:
+      --agent string              Agent identifier to associate with the issued session (default: $MCP_RUNTIME_ADAPTER_AGENT)
       --agent-id string           Issued agent identity (default: $MCP_RUNTIME_AGENT_ID)
       --auth-header string        Static Authorization header value for runtime requests, e.g. "Bearer <token>" (default: $MCP_RUNTIME_AUTH_HEADER)
+      --auto-refresh              Refresh the issued adapter session a few minutes before expiry (default: $MCP_RUNTIME_ADAPTER_AUTO_REFRESH)
   -h, --help                      help for proxy
       --host-header string        Override the Host header sent to the runtime (default: $MCP_RUNTIME_HOST_HEADER)
       --human-id string           Issued human identity (default: $MCP_RUNTIME_HUMAN_ID)
       --listen string             Local listen address (default: $MCP_RUNTIME_LISTEN_ADDR or 127.0.0.1:8099)
       --log-level string          Adapter log level: info logs runtime denials (default: $MCP_RUNTIME_LOG_LEVEL)
       --max-inbound-bytes int     Maximum inbound JSON-RPC body bytes the proxy buffers before responding with 413 (default: $MCP_RUNTIME_MAX_INBOUND_BYTES or 16777216)
+      --namespace string          Namespace of the target MCPServer; defaults to the principal's primary namespace (default: $MCP_RUNTIME_ADAPTER_NAMESPACE)
       --no-xforwarded             Do not set X-Forwarded-* headers when forwarding to the runtime
+      --platform-url string       Platform API base URL; overrides the URL stored by mcp-runtime auth login (default: $MCP_PLATFORM_API_URL)
       --protocol-version string   MCP protocol version header to advertise (default: $MCP_RUNTIME_PROTOCOL_VERSION or 2025-06-18)
       --request-timeout string    HTTP request timeout for adapter→runtime calls, e.g. 30s (default: $MCP_RUNTIME_REQUEST_TIMEOUT)
       --runtime-url string        Platform-issued absolute MCP runtime URL (default: $MCP_RUNTIME_URL)
+      --server string             MCPServer name to fetch an issued adapter session for (enables platform-issued sessions; default: $MCP_RUNTIME_ADAPTER_SERVER)
       --session-id string         Issued agent session identity (default: $MCP_RUNTIME_SESSION_ID)
       --team-id string            Issued team identity for team-scoped grants (default: $MCP_RUNTIME_TEAM_ID)
       --tls-ca-bundle string      Path to PEM CA bundle to verify the runtime's TLS certificate (default: $MCP_RUNTIME_TLS_CA_BUNDLE)

--- a/test/golden/cli/testdata/mcp-runtime_adapter_stdio_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_adapter_stdio_help.golden
@@ -4,24 +4,31 @@ responses back to stdout. Designed for IDE-style MCP clients (e.g. Cursor,
 Claude Desktop) that launch an MCP server as a subprocess.
 
 Configure identity via flags or the matching MCP_RUNTIME_* environment
-variables. Flags win when both are set.
+variables. Flags win when both are set. With --server, the shim fetches an
+issued session from the platform API before reading stdin; identity flags
+override the result.
 
 Usage:
   mcp-runtime adapter stdio [flags]
 
 Flags:
+      --agent string               Agent identifier to associate with the issued session (default: $MCP_RUNTIME_ADAPTER_AGENT)
       --agent-id string            Issued agent identity (default: $MCP_RUNTIME_AGENT_ID)
       --anonymous                  Forward to the runtime without a session or issued identity (public/read-only routes); only methods in --anonymous-methods are forwarded (default: $MCP_RUNTIME_ANONYMOUS)
       --anonymous-methods string   Comma-separated list of MCP methods allowed in anonymous mode (default: $MCP_RUNTIME_ANONYMOUS_METHODS or initialize,notifications/initialized,ping,tools/list,resources/list,prompts/list)
       --auth-header string         Static Authorization header value for runtime requests, e.g. "Bearer <token>" (default: $MCP_RUNTIME_AUTH_HEADER)
+      --auto-refresh               Refresh the issued adapter session a few minutes before expiry (default: $MCP_RUNTIME_ADAPTER_AUTO_REFRESH)
   -h, --help                       help for stdio
       --host-header string         Override the Host header sent to the runtime (default: $MCP_RUNTIME_HOST_HEADER)
       --human-id string            Issued human identity (default: $MCP_RUNTIME_HUMAN_ID)
       --log-level string           Adapter log level: info logs runtime denials (default: $MCP_RUNTIME_LOG_LEVEL)
+      --namespace string           Namespace of the target MCPServer; defaults to the principal's primary namespace (default: $MCP_RUNTIME_ADAPTER_NAMESPACE)
       --no-xforwarded              Do not set X-Forwarded-* headers when forwarding to the runtime
+      --platform-url string        Platform API base URL; overrides the URL stored by mcp-runtime auth login (default: $MCP_PLATFORM_API_URL)
       --protocol-version string    MCP protocol version header to advertise (default: $MCP_RUNTIME_PROTOCOL_VERSION or 2025-06-18)
       --request-timeout string     HTTP request timeout for adapter→runtime calls, e.g. 30s (default: $MCP_RUNTIME_REQUEST_TIMEOUT)
       --runtime-url string         Platform-issued absolute MCP runtime URL (default: $MCP_RUNTIME_URL)
+      --server string              MCPServer name to fetch an issued adapter session for (enables platform-issued sessions; default: $MCP_RUNTIME_ADAPTER_SERVER)
       --session-id string          Issued agent session identity (default: $MCP_RUNTIME_SESSION_ID)
       --team-id string             Issued team identity for team-scoped grants (default: $MCP_RUNTIME_TEAM_ID)
       --tls-ca-bundle string       Path to PEM CA bundle to verify the runtime's TLS certificate (default: $MCP_RUNTIME_TLS_CA_BUNDLE)


### PR DESCRIPTION
## Summary

Phase 6 of #165. Replaces static \`MCP_RUNTIME_HUMAN_ID/AGENT_ID/SESSION_ID\` env strings with platform-issued adapter sessions: the adapter calls a new platform API endpoint, the platform picks a matching enabled \`MCPAccessGrant\`, writes (or reuses) the corresponding \`MCPAgentSession\`, and returns the identity headers the adapter then injects on every runtime request. Optional auto-refresh rotates identity in-flight without restarting the process.

## Server — \`POST /api/runtime/adapter/sessions\`

\`services/api/internal/runtimeapi/adapter.go\`

- **Body** \`{serverName, namespace?, agentID, requestedTrust?, requestedTTL?}\`. \`humanID\` derives from \`Principal.Subject\` (fallback to Email); \`teamID\` from \`Principal.TeamForNamespace(namespace)\` (admins may operate without a team).
- **Grant selection** — enabled grants in \`namespace\` whose \`serverRef.name\` matches and whose subject equals the caller or is empty (wildcard). Highest \`MaxTrust\` wins; ties broken by oldest \`creationTimestamp\` for deterministic results across replicas.
- **Consented trust** capped at the selected grant's \`MaxTrust\`; caller may request lower.
- **TTL** — 1h default, 24h hard cap, validated server-side; \`expiresAt\` returned absolute.
- **Reuse** — deterministic session name \`adapter-<sha256-prefix(humanID, agentID, teamID, serverName)>\`. Reused only when not revoked, \`expiresAt > now + 30s\` refresh-buffer, and \`policyVersion\` matches the current grant's. Otherwise a fresh \`MCPAgentSession\` is applied. Revoked/expired sessions never resurrect.

## Platform client — \`internal/cli/platformapi/adapter_session.go\`

- New \`CreateAdapterSession\` method matching the server contract.

## CLI adapter — \`internal/cli/adapter/platformsession.go\`

- New flags on both subcommands: \`--server\`, \`--namespace\`, \`--agent\`, \`--platform-url\`, \`--auto-refresh\` (env: \`MCP_RUNTIME_ADAPTER_SERVER\`, \`_NAMESPACE\`, \`_AGENT\`, \`MCP_PLATFORM_API_URL\`, \`MCP_RUNTIME_ADAPTER_AUTO_REFRESH\`).
- \`applyPlatformSession\` fetches the issued session at startup and, when \`--auto-refresh\` is set, spawns a goroutine that renews ~5 min before expiry. Failed refreshes log to stderr and keep the previous identity until the next tick — transient platform errors don't take the adapter down.
- \`mergeIdentityFromIssued\` keeps the flag-driven flow predictable: explicit identity flags still override the issued values.

## agentadapter — \`IdentityProvider\` hook

\`internal/agentadapter/identity.go\`, \`config.go\`, \`proxy.go\`, \`stdio.go\`

- New \`IdentityProvider func() Identity\` type on both \`ProxyConfig\` and \`ShimConfig\`. When non-nil it overrides \`Identity\` per-request, so the auto-refresh loop (via an \`atomic.Value\` closure) reaches in-flight adapters without restart. Static-Identity callers are unaffected.

## Trade-offs

- Auto-refresh \`adapterRefreshLead = 5min\` and \`adapterRefreshFloor = 30s\`: the platform-side reuse buffer is 30s, so a 5min lead guarantees the refresh and reuse windows don't race.
- Trust ranking is internal to the platform endpoint (matches the existing TrustNone/Low/Mid/High/Full ladder). Unknown trust values are rejected up front.
- TTL hard-cap (24h): a long-running headless agent still cycles credentials within a working day.

## Test plan

- [x] \`go test ./internal/agentadapter/... ./internal/cli/adapter/... -race -count=3\` — clean (race regression that motivated commit 0ea3e42 fixed by switching test counter to \`atomic.Int32\`)
- [x] \`cd services/api && go test ./... -count=1\` — passes (new \`adapter_test.go\` covers grant selection, trust cap, TTL cap, deterministic-name, reusable semantics, 403 on no match)
- [x] \`go test ./test/golden/... -count=1\` — passes (proxy + stdio help goldens regenerated for the 5 new flags)
- [x] Pre-commit (gofmt, staticcheck, vet, full unit tests, generated-file-drift) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)