### PR TITLE
Add user MCP analytics dashboard

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -260,14 +260,16 @@ X-MCP-Agent-Session: sess-8f1b9d
 
 ## Dashboard API
 
-Overview statistics and usage analytics for the admin dashboard.
+Overview statistics and usage analytics for the admin and user dashboards.
 
 ```text
 GET /api/dashboard/summary
 GET /api/analytics/usage?limit=10
+GET /api/user/analytics/usage?window_days=7&server=payments
 ```
 
-Requires admin authentication. For direct curl/API clients, send an
+The admin dashboard endpoints require admin authentication. For direct
+curl/API clients, send an
 `x-api-key` value that is present in both `API_KEYS` and `ADMIN_API_KEYS`.
 `setup` keeps `UI_API_KEY` in both lists for browser/API-key admin login.
 `INGEST_API_KEYS` is only for event ingestion and is not accepted here.
@@ -278,7 +280,17 @@ Requires admin authentication. For direct curl/API clients, send an
 
 `/api/analytics/usage` reads the ClickHouse event stream and returns admin
 usage rollups for the dashboard: totals, top MCP servers, top human/agent
-pairs, top tools, and decision counts. Query: `limit` (1-50, default 10).
+pairs, top tools, decision counts, recent activity, and request buckets.
+Query: `limit` (1-50, default 10), `window_days` (1-365, default 30),
+`namespace`, `team_id`, `server`, `decision`, and `tool_name`.
+
+`/api/user/analytics/usage` is available to normal platform users. It returns
+the same analytics shape, but the API enforces scope before querying
+ClickHouse: non-admin callers can see only events from their own user namespace
+and team namespaces, and the shared `mcp-servers` catalog is excluded from user
+analytics. Query: `window_days`, `limit`, `namespace`, `server`, `decision`,
+and `tool_name`. Passing `namespace` narrows the result only when the caller
+owns that namespace or belongs to that team.
 
 ## Runtime Governance API
 
@@ -405,6 +417,7 @@ GET  /api/admin/operations             # Admin-only user, image, deployment, and
 GET  /api/user/api-keys                # List caller-owned API keys
 POST /api/user/api-keys                # Create caller-owned API key
 POST /api/user/api-keys/{id}/revoke    # Revoke caller-owned API key
+GET  /api/user/analytics/usage         # User/team-scoped MCP server analytics
 GET  /api/user/registry-credentials    # List caller-owned registry credentials
 POST /api/user/registry-credentials    # Create a registry credential
 POST /api/user/registry-credentials/{id}/revoke

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -9,8 +9,8 @@
 | **mcp-proxy** | Transparent sidecar. Extracts identity, evaluates tool-level policy, emits allow/deny audit events, forwards traffic upstream. |
 | **ingest** | Receives `POST /events`, validates ingest-scoped API keys or optional JWTs, writes to Kafka. |
 | **processor** | Consumes Kafka, batches, writes into ClickHouse with indexed audit fields. |
-| **api** | Analytics endpoints, dashboard summaries, runtime governance APIs (grants/sessions), platform audit, MCP server catalog, component operations. |
-| **ui** | Control-plane dashboard: MCP server catalog and connect config, user API keys, analytics dashboard, governance, MCP operations, and platform management. |
+| **api** | Analytics endpoints, dashboard summaries, user/team-scoped analytics, runtime governance APIs (grants/sessions), platform audit, MCP server catalog, component operations. |
+| **ui** | Control-plane dashboard: user MCP server dashboard, MCP server catalog and connect config, user API keys, analytics dashboard, governance, MCP operations, and platform management. |
 | **gateway** | Kubernetes deployment fronting the sentinel API, ingest, and UI surfaces. |
 | **reference mcp-server** | Small example server in `examples/go-mcp-server` for end-to-end smoke tests. |
 
@@ -98,8 +98,8 @@ For local `setup --test-mode` clusters, setup seeds two email/password logins:
 | **UI** | `/` | `mcp-sentinel-ui:8082` | Browser app, browser login/session routes, and `/api` reverse proxy. |
 | **API** | `/api/*` through UI | `mcp-sentinel-api:8080` | Auth, analytics queries, runtime governance, deployments, admin/user APIs. The UI proxy forwards browser origin headers so local connect configs can point at `http://localhost:18080/<server-name>/mcp`. |
 | **Ingest** | `/ingest/events` | `mcp-sentinel-ingest:8081/events` | Event intake used by `mcp-proxy`; the public ingress strips `/ingest`. |
-| **Grafana** | `/grafana` | `grafana:3000` | Observability UI. |
-| **Prometheus** | `/prometheus` | `prometheus:9090` | Metrics query UI. |
+| **Grafana** | `/grafana` | `grafana:3000` | Admin observability UI. Keep private or behind auth-aware ingress; tenant-scoped access is intentionally not exposed by the user dashboard. |
+| **Prometheus** | `/prometheus` | `prometheus:9090` | Admin metrics query UI. Keep private or behind auth-aware ingress; tenant-scoped access is intentionally not exposed by the user dashboard. |
 | **MCP proxy sidecar** | per-server route, for example `/demo-one/mcp` | pod-local sidecar port | Enforces policy and forwards to the MCP server container. |
 
 ### Auth model
@@ -126,7 +126,8 @@ metrics on `METRICS_PORT` (default `9090`).
 | `POST` | `/api/auth/oidc` | Exchange a configured OIDC ID token for a platform bearer token. Returns `200` with `access_token`, `token_type`, `expires_in`, and `user`. |
 | `GET` | `/api/auth/me` | Return the authenticated principal. |
 | `GET` | `/api/dashboard/summary` | Dashboard cards: event totals, active grants/sessions, latest event metadata. Admin role required. |
-| `GET` | `/api/analytics/usage` | Dashboard usage analytics from ClickHouse: totals, top MCP servers, human/agent pairs, tools, and decision counts. Query: `limit` (1-50, default 10). Admin role required. |
+| `GET` | `/api/analytics/usage` | Dashboard usage analytics from ClickHouse: totals, top MCP servers, human/agent pairs, tools, decision counts, recent activity, and request buckets. Query: `limit` (1-50, default 10), `window_days` (1-365, default 30), `namespace`, `team_id`, `server`, `decision`, and `tool_name`. Admin role required. |
+| `GET` | `/api/user/analytics/usage` | User dashboard analytics from ClickHouse. Normal users are scoped to their own user namespace and team namespaces; the shared catalog is excluded. Query: `limit`, `window_days`, `namespace`, `server`, `decision`, and `tool_name`. |
 | `GET` | `/api/events` | Recent ClickHouse-backed audit events, newest first. Query: `limit` (1-1000, default 100). Admin role required. |
 | `GET` | `/api/events/filter` | Filtered audit events. Query: `source`, `event_type`, `server`, `namespace`, `team_id`, `cluster`, `human_id`, `agent_id`, `session_id`, `decision`, `tool_name`, `limit`. Admin role required. |
 | `GET` | `/api/stats` | Total event count. Admin role required. |
@@ -160,6 +161,7 @@ metrics on `METRICS_PORT` (default `9090`).
 | `GET` | `/api/admin/operations` | Admin operations snapshot for the UI: user activity, last login/activity, image activity, platform timeline, and deployment inventory. Same filters as `/api/admin/audit`. |
 | `GET`, `POST` | `/api/user/api-keys` | List or create caller-owned API keys. |
 | `POST` | `/api/user/api-keys/{id}/revoke` | Revoke one caller-owned API key. |
+| `GET` | `/api/user/analytics/usage` | Caller-scoped MCP server analytics used by the user dashboard. |
 | `GET`, `POST` | `/api/user/registry-credentials` | List or create caller-owned registry credentials. |
 | `POST` | `/api/user/registry-credentials/{id}/revoke` | Revoke one registry credential. |
 | `*` | `/api/registry/authz` | Forward-auth guard used by the bundled registry ingress. Admin role required. |

--- a/services/api/analytics_test.go
+++ b/services/api/analytics_test.go
@@ -50,6 +50,51 @@ func TestAnalyticsWhereClauseScopesByNamespaceAndTeam(t *testing.T) {
 	}
 }
 
+func TestAnalyticsScopeFiltersIncludesTeamIDs(t *testing.T) {
+	t.Parallel()
+
+	filters := analyticsQueryScope{
+		Namespaces: []string{"user-a", "user-a"},
+		TeamIDs:    []string{"team-acme-id", "team-acme-id"},
+		Server:     "payments",
+		Decision:   "deny",
+		ToolName:   "refund",
+	}.Filters()
+
+	if got := strings.Join(filters.Namespaces, ","); got != "user-a" {
+		t.Fatalf("namespaces = %q, want deduped user-a", got)
+	}
+	if got := strings.Join(filters.TeamIDs, ","); got != "team-acme-id" {
+		t.Fatalf("teamIDs = %q, want deduped team-acme-id", got)
+	}
+	if filters.Server != "payments" || filters.Decision != "deny" || filters.ToolName != "refund" {
+		t.Fatalf("filters = %#v, want scalar filters preserved", filters)
+	}
+}
+
+func TestHandleAnalyticsUsageRejectsNonGET(t *testing.T) {
+	t.Parallel()
+
+	server := &apiServer{dbName: "mcp"}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/analytics/usage", nil)
+
+	server.handleAnalyticsUsage(recorder, request)
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("allow"); got != http.MethodGet {
+		t.Fatalf("allow header = %q, want GET", got)
+	}
+	var payload map[string]string
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload["error"] != "method_not_allowed" {
+		t.Fatalf("payload = %#v, want method_not_allowed", payload)
+	}
+}
+
 func TestAnalyticsPrincipalOwnedScopeExcludesSharedCatalog(t *testing.T) {
 	t.Parallel()
 

--- a/services/api/analytics_test.go
+++ b/services/api/analytics_test.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAnalyticsServersQueryExtractsTeamIDFromPayload(t *testing.T) {
 	t.Parallel()
 
-	query := analyticsServersQuery("mcp")
+	query := analyticsServersQuery("mcp", "WHERE timestamp >= ? AND server != ''")
 	if !strings.Contains(query, "JSONExtractString(payload, 'team_id') AS team_id") {
 		t.Fatalf("query = %q, want team_id extracted from payload", query)
 	}
@@ -17,5 +21,95 @@ func TestAnalyticsServersQueryExtractsTeamIDFromPayload(t *testing.T) {
 	}
 	if !strings.Contains(query, "GROUP BY server, namespace, team_id") {
 		t.Fatalf("query = %q, want stable grouping by team_id alias", query)
+	}
+}
+
+func TestAnalyticsWhereClauseScopesByNamespaceAndTeam(t *testing.T) {
+	t.Parallel()
+
+	scope := analyticsQueryScope{
+		Since:      time.Unix(1700000000, 0).UTC(),
+		Namespaces: []string{"user-a", "mcp-team-acme"},
+		TeamIDs:    []string{"team-acme-id"},
+		Server:     "payments",
+		Decision:   "deny",
+		ToolName:   "refund",
+	}
+	where, args := analyticsWhereClause(scope, "server != ''")
+	if !strings.Contains(where, "timestamp >= ?") {
+		t.Fatalf("where = %q, want timestamp filter", where)
+	}
+	if !strings.Contains(where, "(namespace IN (?, ?) OR JSONExtractString(payload, 'team_id') IN (?))") {
+		t.Fatalf("where = %q, want namespace/team scoped OR filter", where)
+	}
+	if !strings.Contains(where, "server = ?") || !strings.Contains(where, "decision = ?") || !strings.Contains(where, "tool_name = ?") {
+		t.Fatalf("where = %q, want request filters", where)
+	}
+	if len(args) != 7 {
+		t.Fatalf("args = %#v, want 7 args", args)
+	}
+}
+
+func TestAnalyticsPrincipalOwnedScopeExcludesSharedCatalog(t *testing.T) {
+	t.Parallel()
+
+	scope := analyticsPrincipalOwnedScope(principal{
+		Role:      roleUser,
+		Namespace: "user-a",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Namespace: "mcp-team-acme",
+		}},
+		AllowedNamespaces: []string{"user-a", "mcp-team-acme", sharedCatalogNamespace},
+	})
+	if got := strings.Join(scope.Namespaces, ","); got != "user-a,mcp-team-acme" {
+		t.Fatalf("namespaces = %q, want user/team only", got)
+	}
+	if got := strings.Join(scope.TeamIDs, ","); got != "team-acme-id" {
+		t.Fatalf("teamIDs = %q, want team-acme-id", got)
+	}
+}
+
+func TestAnalyticsPrincipalScopeForNamespaceRejectsForeignAndShared(t *testing.T) {
+	t.Parallel()
+
+	p := principal{
+		Role:              roleUser,
+		Namespace:         "user-a",
+		AllowedNamespaces: []string{"user-a", sharedCatalogNamespace},
+	}
+	if _, ok := analyticsPrincipalScopeForNamespace(p, "user-a"); !ok {
+		t.Fatal("expected user namespace to be allowed")
+	}
+	if _, ok := analyticsPrincipalScopeForNamespace(p, sharedCatalogNamespace); ok {
+		t.Fatal("shared catalog should not be allowed for user analytics")
+	}
+	if _, ok := analyticsPrincipalScopeForNamespace(p, "mcp-team-other"); ok {
+		t.Fatal("foreign namespace should not be allowed")
+	}
+}
+
+func TestHandleUserAnalyticsUsageRejectsForeignNamespaceBeforeQuery(t *testing.T) {
+	t.Parallel()
+
+	server := &apiServer{dbName: "mcp"}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/user/analytics/usage?namespace=mcp-team-other", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:              roleUser,
+		Namespace:         "user-a",
+		AllowedNamespaces: []string{"user-a", sharedCatalogNamespace},
+	}))
+
+	server.handleUserAnalyticsUsage(recorder, request)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body = %s", recorder.Code, recorder.Body.String())
+	}
+	var payload map[string]string
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload["error"] != "forbidden namespace" {
+		t.Fatalf("payload = %#v, want forbidden namespace", payload)
 	}
 }

--- a/services/api/docs/platform-api.md
+++ b/services/api/docs/platform-api.md
@@ -45,6 +45,7 @@ noted otherwise. Authenticated routes accept `Authorization: Bearer <token>` or
 | `GET` | `/api/auth/me` | Return the authenticated principal. |
 | `GET`, `POST` | `/api/user/api-keys` | List or create caller-owned API keys. |
 | `POST` | `/api/user/api-keys/{id}/revoke` | Revoke one caller-owned API key. |
+| `GET` | `/api/user/analytics/usage` | Caller-scoped MCP server usage analytics for the user dashboard. |
 | `GET`, `POST` | `/api/user/registry-credentials` | List or create registry credentials. |
 | `POST` | `/api/user/registry-credentials/{id}/revoke` | Revoke one registry credential. |
 | `*` | `/api/registry/authz` | Traefik forward-auth endpoint for bundled registry ingress. Admin role required. |
@@ -56,9 +57,9 @@ noted otherwise. Authenticated routes accept `Authorization: Bearer <token>` or
 | `GET` | `/api/admin/operations` | Admin operations snapshot for user activity, image activity, deployments, and timeline events. |
 | `POST` | `/api/user/activity/image-publish` | Record a successful image publish event for the authenticated user. |
 
-The same API service also hosts analytics and runtime governance routes such as
-`/api/events`, `/api/runtime/grants`, and `/api/runtime/sessions`; keep those
-details in `../../../docs/api.md`.
+The same API service also hosts admin analytics and runtime governance routes
+such as `/api/events`, `/api/analytics/usage`, `/api/runtime/grants`, and
+`/api/runtime/sessions`; keep those details in `../../../docs/api.md`.
 
 ## Signup and Login
 

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -128,6 +128,7 @@ type analyticsUsageResponse struct {
 
 type analyticsUsageFilters struct {
 	Namespaces []string `json:"namespaces,omitempty"`
+	TeamIDs    []string `json:"team_ids,omitempty"`
 	Server     string   `json:"server,omitempty"`
 	Decision   string   `json:"decision,omitempty"`
 	ToolName   string   `json:"tool_name,omitempty"`
@@ -516,6 +517,11 @@ func (s *apiServer) handleEventTypes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *apiServer) handleAnalyticsUsage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return
+	}
 	limit := clampInt(queryInt(r, "limit", 10), 1, 50)
 	windowDays := clampInt(queryInt(r, "window_days", analyticsDefaultWindowDays), 1, analyticsMaxWindowDays)
 	scope := analyticsScopeFromRequest(r, windowDays, limit)
@@ -695,6 +701,7 @@ func emptyAnalyticsUsageResponse(scope analyticsQueryScope) analyticsUsageRespon
 func (scope analyticsQueryScope) Filters() analyticsUsageFilters {
 	return analyticsUsageFilters{
 		Namespaces: dedupeAnalyticsStrings(scope.Namespaces),
+		TeamIDs:    dedupeAnalyticsStrings(scope.TeamIDs),
 		Server:     scope.Server,
 		Decision:   scope.Decision,
 		ToolName:   scope.ToolName,

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -84,6 +84,26 @@ type analyticsDecisionUsage struct {
 	Events   uint64 `json:"events"`
 }
 
+type analyticsTimePoint struct {
+	Bucket  time.Time `json:"bucket"`
+	Events  uint64    `json:"events"`
+	Allowed uint64    `json:"allowed"`
+	Denied  uint64    `json:"denied"`
+}
+
+type analyticsRecentActivity struct {
+	Timestamp time.Time `json:"timestamp"`
+	Server    string    `json:"server,omitempty"`
+	Namespace string    `json:"namespace,omitempty"`
+	TeamID    string    `json:"team_id,omitempty"`
+	HumanID   string    `json:"human_id,omitempty"`
+	AgentID   string    `json:"agent_id,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
+	Decision  string    `json:"decision,omitempty"`
+	ToolName  string    `json:"tool_name,omitempty"`
+	EventType string    `json:"event_type,omitempty"`
+}
+
 type analyticsTotals struct {
 	Events         uint64 `json:"events"`
 	Allowed        uint64 `json:"allowed"`
@@ -95,12 +115,22 @@ type analyticsTotals struct {
 }
 
 type analyticsUsageResponse struct {
-	Totals     analyticsTotals          `json:"totals"`
-	Servers    []analyticsServerUsage   `json:"servers"`
-	Actors     []analyticsActorUsage    `json:"actors"`
-	Tools      []analyticsToolUsage     `json:"tools"`
-	Decisions  []analyticsDecisionUsage `json:"decisions"`
-	WindowDays int                      `json:"window_days"`
+	Totals     analyticsTotals           `json:"totals"`
+	Servers    []analyticsServerUsage    `json:"servers"`
+	Actors     []analyticsActorUsage     `json:"actors"`
+	Tools      []analyticsToolUsage      `json:"tools"`
+	Decisions  []analyticsDecisionUsage  `json:"decisions"`
+	Series     []analyticsTimePoint      `json:"series,omitempty"`
+	Recent     []analyticsRecentActivity `json:"recent,omitempty"`
+	WindowDays int                       `json:"window_days"`
+	Filters    analyticsUsageFilters     `json:"filters,omitempty"`
+}
+
+type analyticsUsageFilters struct {
+	Namespaces []string `json:"namespaces,omitempty"`
+	Server     string   `json:"server,omitempty"`
+	Decision   string   `json:"decision,omitempty"`
+	ToolName   string   `json:"tool_name,omitempty"`
 }
 
 type apiServer struct {
@@ -276,6 +306,7 @@ func main() {
 	mux.Handle("/api/analytics/usage", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleAnalyticsUsage))))
 	mux.Handle("/api/events/filter", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(server.handleEventsFilter))))
 	mux.Handle("/api/auth/me", server.auth(http.HandlerFunc(server.handleAuthMe)))
+	mux.Handle("/api/user/analytics/usage", server.auth(http.HandlerFunc(server.handleUserAnalyticsUsage)))
 	mux.Handle("/api/user/registry-credentials", server.auth(http.HandlerFunc(server.handleRegistryCredentials)))
 	mux.Handle("/api/user/registry-credentials/", server.auth(http.HandlerFunc(server.handleRegistryCredentialItem)))
 	mux.Handle("/api/user/activity/image-publish", server.auth(http.HandlerFunc(server.handleUserImagePublishActivity)))
@@ -487,9 +518,191 @@ func (s *apiServer) handleEventTypes(w http.ResponseWriter, r *http.Request) {
 func (s *apiServer) handleAnalyticsUsage(w http.ResponseWriter, r *http.Request) {
 	limit := clampInt(queryInt(r, "limit", 10), 1, 50)
 	windowDays := clampInt(queryInt(r, "window_days", analyticsDefaultWindowDays), 1, analyticsMaxWindowDays)
-	since := time.Now().AddDate(0, 0, -windowDays)
+	scope := analyticsScopeFromRequest(r, windowDays, limit)
+	applyAdminAnalyticsScopeFilters(r, &scope)
 
-	ctx, cancel := context.WithCancel(r.Context())
+	response, err := s.queryAnalyticsUsage(r.Context(), scope)
+	if err != nil {
+		log.Printf("analytics usage query failed window_days=%d limit=%d since=%s filters=%+v err=%v", scope.WindowDays, scope.Limit, scope.Since.Format(time.RFC3339), scope.Filters(), err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *apiServer) handleUserAnalyticsUsage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		return
+	}
+	p, ok := principalFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	limit := clampInt(queryInt(r, "limit", 10), 1, 50)
+	windowDays := clampInt(queryInt(r, "window_days", analyticsDefaultWindowDays), 1, analyticsMaxWindowDays)
+	scope := analyticsScopeFromRequest(r, windowDays, limit)
+
+	requestedNamespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	if p.Role == roleAdmin {
+		applyAdminAnalyticsScopeFilters(r, &scope)
+	} else {
+		var principalScope analyticsPrincipalScope
+		var allowed bool
+		if requestedNamespace != "" {
+			principalScope, allowed = analyticsPrincipalScopeForNamespace(p, requestedNamespace)
+			if !allowed {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+				return
+			}
+		} else {
+			principalScope = analyticsPrincipalOwnedScope(p)
+			allowed = len(principalScope.Namespaces) > 0 || len(principalScope.TeamIDs) > 0
+		}
+		if !allowed {
+			writeJSON(w, http.StatusOK, emptyAnalyticsUsageResponse(scope))
+			return
+		}
+		scope.Namespaces = principalScope.Namespaces
+		scope.TeamIDs = principalScope.TeamIDs
+	}
+
+	response, err := s.queryAnalyticsUsage(r.Context(), scope)
+	if err != nil {
+		log.Printf("user analytics usage query failed window_days=%d limit=%d since=%s filters=%+v err=%v", scope.WindowDays, scope.Limit, scope.Since.Format(time.RFC3339), scope.Filters(), err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+type analyticsQueryScope struct {
+	Since      time.Time
+	WindowDays int
+	Limit      int
+	Namespaces []string
+	TeamIDs    []string
+	Server     string
+	Decision   string
+	ToolName   string
+}
+
+type analyticsPrincipalScope struct {
+	Namespaces []string
+	TeamIDs    []string
+}
+
+func analyticsScopeFromRequest(r *http.Request, windowDays, limit int) analyticsQueryScope {
+	decision := strings.TrimSpace(r.URL.Query().Get("decision"))
+	if decision == "" {
+		decision = strings.TrimSpace(r.URL.Query().Get("status"))
+	}
+	if decision == "" {
+		decision = strings.TrimSpace(r.URL.Query().Get("outcome"))
+	}
+	toolName := strings.TrimSpace(r.URL.Query().Get("tool_name"))
+	if toolName == "" {
+		toolName = strings.TrimSpace(r.URL.Query().Get("tool"))
+	}
+	return analyticsQueryScope{
+		Since:      time.Now().AddDate(0, 0, -windowDays),
+		WindowDays: windowDays,
+		Limit:      limit,
+		Server:     strings.TrimSpace(r.URL.Query().Get("server")),
+		Decision:   decision,
+		ToolName:   toolName,
+	}
+}
+
+func applyAdminAnalyticsScopeFilters(r *http.Request, scope *analyticsQueryScope) {
+	namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
+	if namespace != "" {
+		scope.Namespaces = []string{namespace}
+	}
+	teamID := strings.TrimSpace(r.URL.Query().Get("team_id"))
+	if teamID != "" {
+		scope.TeamIDs = []string{teamID}
+	}
+}
+
+func analyticsPrincipalOwnedScope(p principal) analyticsPrincipalScope {
+	var scope analyticsPrincipalScope
+	addNamespace := func(namespace string) {
+		namespace = strings.TrimSpace(namespace)
+		if namespace == "" || namespace == sharedCatalogNamespace {
+			return
+		}
+		scope.Namespaces = append(scope.Namespaces, namespace)
+	}
+	addNamespace(p.Namespace)
+	for _, team := range p.Teams {
+		addNamespace(team.Namespace)
+		if teamID := strings.TrimSpace(team.ID); teamID != "" {
+			scope.TeamIDs = append(scope.TeamIDs, teamID)
+		}
+	}
+	for _, namespace := range p.AllowedNamespaces {
+		addNamespace(namespace)
+	}
+	scope.Namespaces = dedupeAnalyticsStrings(scope.Namespaces)
+	scope.TeamIDs = dedupeAnalyticsStrings(scope.TeamIDs)
+	return scope
+}
+
+func analyticsPrincipalScopeForNamespace(p principal, namespace string) (analyticsPrincipalScope, bool) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" || namespace == sharedCatalogNamespace {
+		return analyticsPrincipalScope{}, false
+	}
+	if strings.TrimSpace(p.Namespace) == namespace {
+		return analyticsPrincipalScope{Namespaces: []string{namespace}}, true
+	}
+	for _, team := range p.Teams {
+		if strings.TrimSpace(team.Namespace) == namespace {
+			scope := analyticsPrincipalScope{Namespaces: []string{namespace}}
+			if teamID := strings.TrimSpace(team.ID); teamID != "" {
+				scope.TeamIDs = []string{teamID}
+			}
+			return scope, true
+		}
+	}
+	for _, allowed := range p.AllowedNamespaces {
+		if strings.TrimSpace(allowed) == namespace {
+			return analyticsPrincipalScope{Namespaces: []string{namespace}}, true
+		}
+	}
+	return analyticsPrincipalScope{}, false
+}
+
+func emptyAnalyticsUsageResponse(scope analyticsQueryScope) analyticsUsageResponse {
+	return analyticsUsageResponse{
+		Servers:    []analyticsServerUsage{},
+		Actors:     []analyticsActorUsage{},
+		Tools:      []analyticsToolUsage{},
+		Decisions:  []analyticsDecisionUsage{},
+		Series:     []analyticsTimePoint{},
+		Recent:     []analyticsRecentActivity{},
+		WindowDays: scope.WindowDays,
+		Filters:    scope.Filters(),
+	}
+}
+
+func (scope analyticsQueryScope) Filters() analyticsUsageFilters {
+	return analyticsUsageFilters{
+		Namespaces: dedupeAnalyticsStrings(scope.Namespaces),
+		Server:     scope.Server,
+		Decision:   scope.Decision,
+		ToolName:   scope.ToolName,
+	}
+}
+
+func (s *apiServer) queryAnalyticsUsage(parent context.Context, scope analyticsQueryScope) (analyticsUsageResponse, error) {
+	ctx, cancel := context.WithCancel(parent)
 	defer cancel()
 
 	var (
@@ -498,6 +711,8 @@ func (s *apiServer) handleAnalyticsUsage(w http.ResponseWriter, r *http.Request)
 		actors    []analyticsActorUsage
 		tools     []analyticsToolUsage
 		decisions []analyticsDecisionUsage
+		series    []analyticsTimePoint
+		recent    []analyticsRecentActivity
 
 		wg          sync.WaitGroup
 		errOnce     sync.Once
@@ -516,59 +731,73 @@ func (s *apiServer) handleAnalyticsUsage(w http.ResponseWriter, r *http.Request)
 		})
 	}
 
-	wg.Add(5)
+	wg.Add(7)
 	go func() {
 		defer wg.Done()
 		var err error
-		totals, err = s.queryAnalyticsTotals(ctx, since)
+		totals, err = s.queryAnalyticsTotals(ctx, scope)
 		recordErr("totals", err)
 	}()
 	go func() {
 		defer wg.Done()
 		var err error
-		servers, err = s.queryAnalyticsServers(ctx, since, limit)
+		servers, err = s.queryAnalyticsServers(ctx, scope)
 		recordErr("servers", err)
 	}()
 	go func() {
 		defer wg.Done()
 		var err error
-		actors, err = s.queryAnalyticsActors(ctx, since, limit)
+		actors, err = s.queryAnalyticsActors(ctx, scope)
 		recordErr("actors", err)
 	}()
 	go func() {
 		defer wg.Done()
 		var err error
-		tools, err = s.queryAnalyticsTools(ctx, since, limit)
+		tools, err = s.queryAnalyticsTools(ctx, scope)
 		recordErr("tools", err)
 	}()
 	go func() {
 		defer wg.Done()
 		var err error
-		decisions, err = s.queryAnalyticsDecisions(ctx, since)
+		decisions, err = s.queryAnalyticsDecisions(ctx, scope)
 		recordErr("decisions", err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		series, err = s.queryAnalyticsSeries(ctx, scope)
+		recordErr("series", err)
+	}()
+	go func() {
+		defer wg.Done()
+		var err error
+		recent, err = s.queryAnalyticsRecent(ctx, scope)
+		recordErr("recent", err)
 	}()
 	wg.Wait()
 
 	if firstErr != nil {
-		log.Printf("analytics usage query failed query=%s window_days=%d limit=%d since=%s err=%v", firstErrKey, windowDays, limit, since.Format(time.RFC3339), firstErr)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
-		return
+		return analyticsUsageResponse{}, fmt.Errorf("%s: %w", firstErrKey, firstErr)
 	}
 
-	writeJSON(w, http.StatusOK, analyticsUsageResponse{
+	return analyticsUsageResponse{
 		Totals:     totals,
 		Servers:    servers,
 		Actors:     actors,
 		Tools:      tools,
 		Decisions:  decisions,
-		WindowDays: windowDays,
-	})
+		Series:     series,
+		Recent:     recent,
+		WindowDays: scope.WindowDays,
+		Filters:    scope.Filters(),
+	}, nil
 }
 
-func (s *apiServer) queryAnalyticsTotals(ctx context.Context, since time.Time) (analyticsTotals, error) {
-	query := "SELECT count(), countIf(decision = 'allow'), countIf(decision = 'deny'), uniqIf(server, server != ''), uniqIf(human_id, human_id != ''), uniqIf(agent_id, agent_id != ''), uniqIf(session_id, session_id != '') FROM " + s.dbName + ".events WHERE timestamp >= ?"
+func (s *apiServer) queryAnalyticsTotals(ctx context.Context, scope analyticsQueryScope) (analyticsTotals, error) {
+	where, args := analyticsWhereClause(scope)
+	query := "SELECT count(), countIf(decision = 'allow'), countIf(decision = 'deny'), uniqIf(server, server != ''), uniqIf(human_id, human_id != ''), uniqIf(agent_id, agent_id != ''), uniqIf(session_id, session_id != '') FROM " + s.dbName + ".events " + where
 	var totals analyticsTotals
-	err := s.db.QueryRow(ctx, query, since).Scan(
+	err := s.db.QueryRow(ctx, query, args...).Scan(
 		&totals.Events,
 		&totals.Allowed,
 		&totals.Denied,
@@ -580,15 +809,17 @@ func (s *apiServer) queryAnalyticsTotals(ctx context.Context, since time.Time) (
 	return totals, err
 }
 
-func (s *apiServer) queryAnalyticsServers(ctx context.Context, since time.Time, limit int) ([]analyticsServerUsage, error) {
-	query := analyticsServersQuery(s.dbName)
-	rows, err := s.db.Query(ctx, query, since, limit)
+func (s *apiServer) queryAnalyticsServers(ctx context.Context, scope analyticsQueryScope) ([]analyticsServerUsage, error) {
+	where, args := analyticsWhereClause(scope, "server != ''")
+	query := analyticsServersQuery(s.dbName, where)
+	args = append(args, scope.Limit)
+	rows, err := s.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	out := make([]analyticsServerUsage, 0, limit)
+	out := make([]analyticsServerUsage, 0, scope.Limit)
 	for rows.Next() {
 		var row analyticsServerUsage
 		if err := rows.Scan(&row.Server, &row.Namespace, &row.TeamID, &row.Events, &row.Allowed, &row.Denied, &row.UniqueHumans, &row.UniqueAgents, &row.LastSeen); err != nil {
@@ -599,19 +830,21 @@ func (s *apiServer) queryAnalyticsServers(ctx context.Context, since time.Time, 
 	return out, rows.Err()
 }
 
-func analyticsServersQuery(dbName string) string {
-	return "SELECT server, namespace, " + analyticsTeamIDExpression + " AS team_id, count() AS events, countIf(decision = 'allow') AS allowed, countIf(decision = 'deny') AS denied, uniqIf(human_id, human_id != '') AS unique_humans, uniqIf(agent_id, agent_id != '') AS unique_agents, max(timestamp) AS last_seen FROM " + dbName + ".events WHERE timestamp >= ? AND server != '' GROUP BY server, namespace, team_id ORDER BY events DESC LIMIT ?"
+func analyticsServersQuery(dbName, where string) string {
+	return "SELECT server, namespace, " + analyticsTeamIDExpression + " AS team_id, count() AS events, countIf(decision = 'allow') AS allowed, countIf(decision = 'deny') AS denied, uniqIf(human_id, human_id != '') AS unique_humans, uniqIf(agent_id, agent_id != '') AS unique_agents, max(timestamp) AS last_seen FROM " + dbName + ".events " + where + " GROUP BY server, namespace, team_id ORDER BY events DESC LIMIT ?"
 }
 
-func (s *apiServer) queryAnalyticsActors(ctx context.Context, since time.Time, limit int) ([]analyticsActorUsage, error) {
-	query := "SELECT human_id, agent_id, count() AS events, uniqIf(server, server != '') AS unique_servers, uniqIf(tool_name, tool_name != '') AS unique_tools, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE timestamp >= ? AND (human_id != '' OR agent_id != '') GROUP BY human_id, agent_id ORDER BY events DESC LIMIT ?"
-	rows, err := s.db.Query(ctx, query, since, limit)
+func (s *apiServer) queryAnalyticsActors(ctx context.Context, scope analyticsQueryScope) ([]analyticsActorUsage, error) {
+	where, args := analyticsWhereClause(scope, "(human_id != '' OR agent_id != '')")
+	query := "SELECT human_id, agent_id, count() AS events, uniqIf(server, server != '') AS unique_servers, uniqIf(tool_name, tool_name != '') AS unique_tools, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events " + where + " GROUP BY human_id, agent_id ORDER BY events DESC LIMIT ?"
+	args = append(args, scope.Limit)
+	rows, err := s.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	out := make([]analyticsActorUsage, 0, limit)
+	out := make([]analyticsActorUsage, 0, scope.Limit)
 	for rows.Next() {
 		var row analyticsActorUsage
 		if err := rows.Scan(&row.HumanID, &row.AgentID, &row.Events, &row.UniqueServers, &row.UniqueTools, &row.Denied, &row.LastSeen); err != nil {
@@ -622,15 +855,17 @@ func (s *apiServer) queryAnalyticsActors(ctx context.Context, since time.Time, l
 	return out, rows.Err()
 }
 
-func (s *apiServer) queryAnalyticsTools(ctx context.Context, since time.Time, limit int) ([]analyticsToolUsage, error) {
-	query := "SELECT server, tool_name, count() AS events, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events WHERE timestamp >= ? AND tool_name != '' GROUP BY server, tool_name ORDER BY events DESC LIMIT ?"
-	rows, err := s.db.Query(ctx, query, since, limit)
+func (s *apiServer) queryAnalyticsTools(ctx context.Context, scope analyticsQueryScope) ([]analyticsToolUsage, error) {
+	where, args := analyticsWhereClause(scope, "tool_name != ''")
+	query := "SELECT server, tool_name, count() AS events, countIf(decision = 'deny') AS denied, max(timestamp) AS last_seen FROM " + s.dbName + ".events " + where + " GROUP BY server, tool_name ORDER BY events DESC LIMIT ?"
+	args = append(args, scope.Limit)
+	rows, err := s.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	out := make([]analyticsToolUsage, 0, limit)
+	out := make([]analyticsToolUsage, 0, scope.Limit)
 	for rows.Next() {
 		var row analyticsToolUsage
 		if err := rows.Scan(&row.Server, &row.ToolName, &row.Events, &row.Denied, &row.LastSeen); err != nil {
@@ -641,9 +876,10 @@ func (s *apiServer) queryAnalyticsTools(ctx context.Context, since time.Time, li
 	return out, rows.Err()
 }
 
-func (s *apiServer) queryAnalyticsDecisions(ctx context.Context, since time.Time) ([]analyticsDecisionUsage, error) {
-	query := "SELECT if(decision = '', 'unknown', decision) AS decision_label, count() AS events FROM " + s.dbName + ".events WHERE timestamp >= ? GROUP BY decision_label ORDER BY events DESC"
-	rows, err := s.db.Query(ctx, query, since)
+func (s *apiServer) queryAnalyticsDecisions(ctx context.Context, scope analyticsQueryScope) ([]analyticsDecisionUsage, error) {
+	where, args := analyticsWhereClause(scope)
+	query := "SELECT if(decision = '', 'unknown', decision) AS decision_label, count() AS events FROM " + s.dbName + ".events " + where + " GROUP BY decision_label ORDER BY events DESC"
+	rows, err := s.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -658,6 +894,134 @@ func (s *apiServer) queryAnalyticsDecisions(ctx context.Context, since time.Time
 		out = append(out, row)
 	}
 	return out, rows.Err()
+}
+
+func (s *apiServer) queryAnalyticsSeries(ctx context.Context, scope analyticsQueryScope) ([]analyticsTimePoint, error) {
+	where, args := analyticsWhereClause(scope)
+	query := "SELECT " + analyticsBucketExpression(scope.WindowDays) + " AS bucket, count() AS events, countIf(decision = 'allow') AS allowed, countIf(decision = 'deny') AS denied FROM " + s.dbName + ".events " + where + " GROUP BY bucket ORDER BY bucket ASC"
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]analyticsTimePoint, 0)
+	for rows.Next() {
+		var row analyticsTimePoint
+		if err := rows.Scan(&row.Bucket, &row.Events, &row.Allowed, &row.Denied); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func (s *apiServer) queryAnalyticsRecent(ctx context.Context, scope analyticsQueryScope) ([]analyticsRecentActivity, error) {
+	where, args := analyticsWhereClause(scope)
+	query := "SELECT timestamp, server, namespace, " + analyticsTeamIDExpression + " AS team_id, human_id, agent_id, session_id, decision, tool_name, event_type FROM " + s.dbName + ".events " + where + " ORDER BY timestamp DESC LIMIT ?"
+	args = append(args, scope.Limit)
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]analyticsRecentActivity, 0, scope.Limit)
+	for rows.Next() {
+		var row analyticsRecentActivity
+		if err := rows.Scan(&row.Timestamp, &row.Server, &row.Namespace, &row.TeamID, &row.HumanID, &row.AgentID, &row.SessionID, &row.Decision, &row.ToolName, &row.EventType); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+func analyticsBucketExpression(windowDays int) string {
+	if windowDays <= 2 {
+		return "toStartOfHour(timestamp)"
+	}
+	return "toStartOfDay(timestamp)"
+}
+
+func analyticsWhereClause(scope analyticsQueryScope, extraConditions ...string) (string, []any) {
+	conditions := []string{"timestamp >= ?"}
+	args := []any{scope.Since}
+
+	scopeFilters, scopeArgs := analyticsScopeConditions(scope)
+	if len(scopeFilters) > 0 {
+		conditions = append(conditions, "("+strings.Join(scopeFilters, " OR ")+")")
+		args = append(args, scopeArgs...)
+	}
+	if scope.Server != "" {
+		conditions = append(conditions, "server = ?")
+		args = append(args, scope.Server)
+	}
+	if scope.Decision != "" {
+		conditions = append(conditions, "decision = ?")
+		args = append(args, scope.Decision)
+	}
+	if scope.ToolName != "" {
+		conditions = append(conditions, "tool_name = ?")
+		args = append(args, scope.ToolName)
+	}
+	for _, condition := range extraConditions {
+		if condition = strings.TrimSpace(condition); condition != "" {
+			conditions = append(conditions, condition)
+		}
+	}
+	return "WHERE " + strings.Join(conditions, " AND "), args
+}
+
+func analyticsScopeConditions(scope analyticsQueryScope) ([]string, []any) {
+	var conditions []string
+	var args []any
+	namespaces := dedupeAnalyticsStrings(scope.Namespaces)
+	if len(namespaces) > 0 {
+		conditions = append(conditions, "namespace IN "+sqlPlaceholders(len(namespaces)))
+		args = appendStringArgs(args, namespaces)
+	}
+	teamIDs := dedupeAnalyticsStrings(scope.TeamIDs)
+	if len(teamIDs) > 0 {
+		conditions = append(conditions, analyticsTeamIDExpression+" IN "+sqlPlaceholders(len(teamIDs)))
+		args = appendStringArgs(args, teamIDs)
+	}
+	return conditions, args
+}
+
+func sqlPlaceholders(count int) string {
+	if count <= 0 {
+		return "()"
+	}
+	parts := make([]string, count)
+	for i := range parts {
+		parts[i] = "?"
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+func appendStringArgs(args []any, values []string) []any {
+	for _, value := range values {
+		args = append(args, value)
+	}
+	return args
+}
+
+func dedupeAnalyticsStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 // handleEventsFilter handles GET /api/events/filter requests.

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -1003,7 +1003,7 @@ async function loadUserDashboardServers() {
     const data = authPrincipal?.role === "admin"
       ? { servers: await loadFleetServers() }
       : await fetchJSON("/runtime/servers");
-    userDashboardServersCache = Array.isArray(data.servers) ? data.servers : [];
+    userDashboardServersCache = filterUserDashboardServers(Array.isArray(data.servers) ? data.servers : []);
     syncUserAnalyticsServerSelect();
     renderUserDashboardServers();
     renderUserDashboardSummary();
@@ -1074,6 +1074,21 @@ function syncUserAnalyticsServerSelect() {
   const exists = userDashboardServersCache.some((server) => operationServerKey(server) === previous);
   selectedUserAnalyticsServerKey = exists ? previous : "";
   select.value = selectedUserAnalyticsServerKey;
+}
+
+function filterUserDashboardServers(servers) {
+  if (authPrincipal?.role === "admin") {
+    return servers;
+  }
+  return servers.filter((server) => !isSharedCatalogNamespace(server?.namespace));
+}
+
+function isSharedCatalogNamespace(namespace) {
+  const normalized = String(namespace || "").trim();
+  if (!normalized) return false;
+  return normalized === "mcp-servers" || namespaceScopes.some((scope) =>
+    String(scope?.namespace || "").trim() === normalized && scope?.is_shared
+  );
 }
 
 function renderUserDashboardSummary() {

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -14,6 +14,8 @@ let serversCache = [];
 let publishPolicyCache = null;
 let selectedServerKey = "";
 let selectedServerEventsCache = [];
+let userDashboardServersCache = [];
+let userDashboardAnalyticsCache = null;
 let operationsServersCache = [];
 let operationsEventsCache = [];
 let operationsAuditCache = [];
@@ -24,6 +26,7 @@ let userAPIKeyClearTimer = null;
 let serverSearchQuery = "";
 let serverStatusFilter = "all";
 let selectedOperationsServerKey = "";
+let selectedUserAnalyticsServerKey = "";
 let namespaceScopes = [];
 let selectedNamespace = defaults.namespace || "";
 
@@ -255,6 +258,8 @@ function initTabs() {
         loadDashboardSummary();
         loadDashboardAnalytics();
         loadEvents();
+      } else if (target === "userdashboard") {
+        loadUserDashboard();
       } else if (target === "governance") {
         loadGrants();
         loadSessions();
@@ -870,6 +875,7 @@ async function logout() {
   selectedNamespace = namespaceScopes[0]?.namespace || "";
   syncScopeSelector();
   resetDashboard();
+  resetUserDashboard();
   resetGovernance();
   resetUserAPIKeys();
   activateTab("servers");
@@ -921,6 +927,8 @@ function loadActiveTab() {
     loadDashboardSummary();
     loadDashboardAnalytics();
     loadEvents();
+  } else if (active === "userdashboard") {
+    loadUserDashboard();
   } else if (active === "servers") {
     loadServers();
   } else if (active === "governance") {
@@ -956,6 +964,257 @@ function resetDashboard() {
     '<tr><td colspan="2" class="empty">No decisions yet.</td></tr>';
   document.getElementById("events-body").innerHTML =
     '<tr><td colspan="6" class="empty">No events yet.</td></tr>';
+}
+
+function resetUserDashboard() {
+  userDashboardServersCache = [];
+  userDashboardAnalyticsCache = null;
+  setText("userdash-server-total", "-");
+  setText("userdash-ready-total", "-");
+  setText("userdash-events", "-");
+  setText("userdash-denied", "-");
+  setText("userdash-error-rate", "-");
+  const serverBody = document.getElementById("user-dashboard-servers-body");
+  const breakdownBody = document.getElementById("user-analytics-breakdown-body");
+  const toolsBody = document.getElementById("user-analytics-tools-body");
+  const recentBody = document.getElementById("user-analytics-recent-body");
+  if (serverBody) serverBody.innerHTML = '<tr><td colspan="5" class="empty">No MCP servers found.</td></tr>';
+  if (breakdownBody) breakdownBody.innerHTML = '<tr><td colspan="6" class="empty">No usage yet.</td></tr>';
+  if (toolsBody) toolsBody.innerHTML = '<tr><td colspan="4" class="empty">No tool calls yet.</td></tr>';
+  if (recentBody) recentBody.innerHTML = '<tr><td colspan="4" class="empty">No recent activity.</td></tr>';
+}
+
+async function loadUserDashboard() {
+  if (!authenticated) {
+    resetUserDashboard();
+    showAuthModal();
+    return;
+  }
+  await Promise.allSettled([loadUserDashboardServers(), loadUserDashboardAnalytics()]);
+  renderUserDashboardSummary();
+}
+
+async function loadUserDashboardServers() {
+  const tbody = document.getElementById("user-dashboard-servers-body");
+  if (tbody) {
+    tbody.innerHTML = '<tr><td colspan="5" class="empty">Loading MCP servers...</td></tr>';
+  }
+  try {
+    const data = authPrincipal?.role === "admin"
+      ? { servers: await loadFleetServers() }
+      : await fetchJSON("/runtime/servers");
+    userDashboardServersCache = Array.isArray(data.servers) ? data.servers : [];
+    syncUserAnalyticsServerSelect();
+    renderUserDashboardServers();
+    renderUserDashboardSummary();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load user dashboard servers:", err);
+    userDashboardServersCache = [];
+    syncUserAnalyticsServerSelect();
+    renderUserDashboardSummary();
+    if (tbody) {
+      tbody.innerHTML = '<tr><td colspan="5" class="empty">Error loading MCP servers.</td></tr>';
+    }
+  }
+}
+
+async function loadUserDashboardAnalytics() {
+  const breakdownBody = document.getElementById("user-analytics-breakdown-body");
+  if (breakdownBody) {
+    breakdownBody.innerHTML = '<tr><td colspan="6" class="empty">Loading usage...</td></tr>';
+  }
+  try {
+    const data = await fetchJSON(`/user/analytics/usage?${userAnalyticsQuery()}`);
+    userDashboardAnalyticsCache = data || null;
+    renderUserDashboardAnalytics(data);
+    renderUserDashboardSummary();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load user analytics:", err);
+    userDashboardAnalyticsCache = null;
+    renderUserDashboardSummary();
+    renderUserAnalyticsError();
+  }
+}
+
+function userAnalyticsQuery() {
+  const params = new URLSearchParams();
+  params.set("limit", "10");
+  params.set("window_days", document.getElementById("user-analytics-window")?.value || "7");
+  const selected = userAnalyticsSelectedServer();
+  if (selected.namespace) params.set("namespace", selected.namespace);
+  if (selected.name) params.set("server", selected.name);
+  return params.toString();
+}
+
+function userAnalyticsSelectedServer() {
+  const key = selectedUserAnalyticsServerKey || "";
+  const idx = key.indexOf("/");
+  if (idx < 0) {
+    return { namespace: "", name: "" };
+  }
+  return {
+    namespace: key.slice(0, idx),
+    name: key.slice(idx + 1),
+  };
+}
+
+function syncUserAnalyticsServerSelect() {
+  const select = document.getElementById("user-analytics-server");
+  if (!select) return;
+  const previous = selectedUserAnalyticsServerKey;
+  select.innerHTML = '<option value="">All servers</option>';
+  userDashboardServersCache.forEach((server) => {
+    const option = document.createElement("option");
+    option.value = operationServerKey(server);
+    option.textContent = `${server.namespace || "-"} / ${server.name || "-"}`;
+    select.appendChild(option);
+  });
+  const exists = userDashboardServersCache.some((server) => operationServerKey(server) === previous);
+  selectedUserAnalyticsServerKey = exists ? previous : "";
+  select.value = selectedUserAnalyticsServerKey;
+}
+
+function renderUserDashboardSummary() {
+  const total = userDashboardServersCache.length;
+  const ready = userDashboardServersCache.filter((server) => server.status === "Ready").length;
+  const totals = userDashboardAnalyticsCache?.totals || {};
+  const events = Number(totals.events || 0);
+  const denied = Number(totals.denied || 0);
+  setText("userdash-server-total", formatNumber(total));
+  setText("userdash-ready-total", formatNumber(ready));
+  setText("userdash-events", formatNumber(events));
+  setText("userdash-denied", formatNumber(denied));
+  setText("userdash-error-rate", events > 0 ? `${Math.round((denied / events) * 100)}%` : "-");
+}
+
+function renderUserDashboardServers() {
+  const tbody = document.getElementById("user-dashboard-servers-body");
+  if (!tbody) return;
+  if (!userDashboardServersCache.length) {
+    tbody.innerHTML = '<tr><td colspan="5" class="empty">No MCP servers found.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  userDashboardServersCache.forEach((server) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(server.name || "-", server.namespace || "-"));
+    row.appendChild(createBadgeCell(server.status || "Unknown", serverBadgeClass(server.status)));
+    row.appendChild(createTextCell(operationInventoryLabel(server)));
+    row.appendChild(createEndpointCell(server.endpoint));
+    row.appendChild(createUserServerActionsCell(server));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function createUserServerActionsCell(server) {
+  const cell = document.createElement("td");
+  const actions = document.createElement("div");
+  actions.className = "table-action-row";
+
+  const analyticsButton = document.createElement("button");
+  analyticsButton.type = "button";
+  analyticsButton.className = "ghost action-btn";
+  analyticsButton.textContent = "Analytics";
+  analyticsButton.addEventListener("click", () => {
+    selectedUserAnalyticsServerKey = operationServerKey(server);
+    const select = document.getElementById("user-analytics-server");
+    if (select) select.value = selectedUserAnalyticsServerKey;
+    loadUserDashboardAnalytics();
+  });
+  actions.appendChild(analyticsButton);
+
+  if (server.endpoint) {
+    const copyButton = document.createElement("button");
+    copyButton.type = "button";
+    copyButton.className = "ghost action-btn";
+    copyButton.textContent = "Copy URL";
+    copyButton.addEventListener("click", () => copyTextToClipboard(server.endpoint, "Endpoint copied"));
+    actions.appendChild(copyButton);
+  }
+
+  cell.appendChild(actions);
+  return cell;
+}
+
+function renderUserDashboardAnalytics(data) {
+  renderUserAnalyticsBreakdown(data?.servers || []);
+  renderUserAnalyticsTools(data?.tools || []);
+  renderUserAnalyticsRecent(data?.recent || []);
+}
+
+function renderUserAnalyticsBreakdown(rows) {
+  const tbody = document.getElementById("user-analytics-breakdown-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="6" class="empty">No usage yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(item.server || "-", item.namespace || "-"));
+    row.appendChild(createTextCell(formatNumber(item.events || 0)));
+    row.appendChild(createTextCell(formatNumber(item.allowed || 0)));
+    row.appendChild(createTextCell(formatNumber(item.denied || 0)));
+    row.appendChild(createTextCell(formatNumber(item.unique_humans || 0)));
+    row.appendChild(createTextCell(formatNumber(item.unique_agents || 0)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderUserAnalyticsTools(rows) {
+  const tbody = document.getElementById("user-analytics-tools-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No tool calls yet.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(item.server || "-", ""));
+    row.appendChild(createTextCell(item.tool_name || "-"));
+    row.appendChild(createTextCell(formatNumber(item.events || 0)));
+    row.appendChild(createTextCell(formatNumber(item.denied || 0)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderUserAnalyticsRecent(rows) {
+  const tbody = document.getElementById("user-analytics-recent-body");
+  if (!tbody) return;
+  if (!rows.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No recent activity.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  rows.forEach((item) => {
+    const row = document.createElement("tr");
+    row.appendChild(createTextCell(formatDateTime(item.timestamp)));
+    row.appendChild(createIdentityCell(item.server || "-", item.namespace || ""));
+    row.appendChild(createTextCell(item.tool_name || item.event_type || "-"));
+    row.appendChild(createBadgeCell(item.decision || "unknown", decisionBadgeClass(item.decision)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderUserAnalyticsError() {
+  const breakdownBody = document.getElementById("user-analytics-breakdown-body");
+  const toolsBody = document.getElementById("user-analytics-tools-body");
+  const recentBody = document.getElementById("user-analytics-recent-body");
+  if (breakdownBody) breakdownBody.innerHTML = '<tr><td colspan="6" class="empty">Error loading usage.</td></tr>';
+  if (toolsBody) toolsBody.innerHTML = '<tr><td colspan="4" class="empty">Error loading tools.</td></tr>';
+  if (recentBody) recentBody.innerHTML = '<tr><td colspan="4" class="empty">Error loading recent activity.</td></tr>';
 }
 
 function resetGovernance() {
@@ -1526,6 +1785,16 @@ function initDashboard() {
   document.getElementById("analytics-limit")?.addEventListener("change", () => {
     loadDashboardAnalytics();
   });
+  document.getElementById("refresh-user-dashboard")?.addEventListener("click", () => {
+    loadUserDashboard();
+  });
+  document.getElementById("user-analytics-window")?.addEventListener("change", () => {
+    loadUserDashboardAnalytics();
+  });
+  document.getElementById("user-analytics-server")?.addEventListener("change", (event) => {
+    selectedUserAnalyticsServerKey = event.target.value || "";
+    loadUserDashboardAnalytics();
+  });
   document.getElementById("refresh-servers")?.addEventListener("click", () => {
     loadServers();
   });
@@ -1577,7 +1846,7 @@ function applyRoleVisibility() {
 
 function resolveActiveTab() {
   const active = document.querySelector(".tab.active")?.dataset.tab;
-  if (active && (isAdminUser() || active === "userkeys" || active === "servers")) {
+  if (active && (isAdminUser() || active === "userkeys" || active === "servers" || active === "userdashboard")) {
     return active;
   }
   return "servers";

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -181,7 +181,7 @@
             <strong class="metric-value" id="userdash-denied">-</strong>
           </div>
           <div class="metric-card">
-            <span class="metric-label">Error Rate</span>
+            <span class="metric-label">Deny Rate</span>
             <strong class="metric-value" id="userdash-error-rate">-</strong>
           </div>
         </div>

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -20,8 +20,8 @@
           <span id="auth-role" class="link-badge hidden"></span>
           <button id="auth-open" type="button" class="link-badge hidden">Sign In</button>
           <button id="auth-logout" type="button" class="link-badge hidden">Sign Out</button>
-          <a href="/grafana" target="_blank" class="link-badge">Grafana</a>
-          <a href="/prometheus" target="_blank" class="link-badge">Prometheus</a>
+          <a href="/grafana" target="_blank" class="link-badge hidden" data-admin-only="true">Grafana</a>
+          <a href="/prometheus" target="_blank" class="link-badge hidden" data-admin-only="true">Prometheus</a>
         </div>
       </header>
 
@@ -36,6 +36,17 @@
           aria-selected="true"
         >
           MCP Servers
+        </button>
+        <button
+          id="tab-button-userdashboard"
+          class="tab"
+          data-tab="userdashboard"
+          role="tab"
+          type="button"
+          aria-controls="tab-userdashboard"
+          aria-selected="false"
+        >
+          My Dashboard
         </button>
         <button
           id="tab-button-userkeys"
@@ -140,6 +151,148 @@
           <div class="server-inspector hidden" id="server-detail-panel"></div>
           <div class="server-grid" id="servers-grid">
             <div class="component-card loading">Loading servers...</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- User Dashboard Tab -->
+      <section
+        id="tab-userdashboard"
+        class="tab-content"
+        role="tabpanel"
+        aria-labelledby="tab-button-userdashboard"
+        hidden
+      >
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <span class="metric-label">My Servers</span>
+            <strong class="metric-value" id="userdash-server-total">-</strong>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Ready</span>
+            <strong class="metric-value" id="userdash-ready-total">-</strong>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Requests</span>
+            <strong class="metric-value" id="userdash-events">-</strong>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Denied</span>
+            <strong class="metric-value" id="userdash-denied">-</strong>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Error Rate</span>
+            <strong class="metric-value" id="userdash-error-rate">-</strong>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>My MCP Activity</h2>
+              <p class="panel-kicker">Usage for MCP servers in your user and team namespaces.</p>
+            </div>
+            <div class="panel-actions">
+              <select id="user-analytics-server" aria-label="Filter analytics by MCP server">
+                <option value="">All servers</option>
+              </select>
+              <select id="user-analytics-window" aria-label="Analytics time range">
+                <option value="1">24 hours</option>
+                <option value="7" selected>7 days</option>
+                <option value="30">30 days</option>
+                <option value="90">90 days</option>
+              </select>
+              <button class="ghost" id="refresh-user-dashboard" type="button">Refresh</button>
+            </div>
+          </div>
+
+          <div class="analytics-grid">
+            <section class="analytics-section">
+              <h3>Deployed Servers</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Status</th>
+                      <th>Inventory</th>
+                      <th>Endpoint</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody id="user-dashboard-servers-body">
+                    <tr>
+                      <td colspan="5" class="empty">No MCP servers found.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="analytics-section">
+              <h3>Per-server Usage</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Requests</th>
+                      <th>Allow</th>
+                      <th>Deny</th>
+                      <th>Humans</th>
+                      <th>Agents</th>
+                    </tr>
+                  </thead>
+                  <tbody id="user-analytics-breakdown-body">
+                    <tr>
+                      <td colspan="6" class="empty">No usage yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="analytics-section">
+              <h3>Top Tools</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Tool</th>
+                      <th>Requests</th>
+                      <th>Deny</th>
+                    </tr>
+                  </thead>
+                  <tbody id="user-analytics-tools-body">
+                    <tr>
+                      <td colspan="4" class="empty">No tool calls yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section class="analytics-section">
+              <h3>Recent Activity</h3>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>Server</th>
+                      <th>Tool</th>
+                      <th>Decision</th>
+                    </tr>
+                  </thead>
+                  <tbody id="user-analytics-recent-body">
+                    <tr>
+                      <td colspan="4" class="empty">No recent activity.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
           </div>
         </div>
       </section>

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -933,6 +933,13 @@ tr:hover td {
   font-size: 12px;
 }
 
+.table-action-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
 /* Modal */
 .modal {
   position: fixed;


### PR DESCRIPTION
## Summary

- Add `/api/user/analytics/usage` for authenticated user/team-scoped MCP analytics with namespace and team filters enforced before ClickHouse queries run.
- Extend the analytics response with request buckets and recent activity while preserving the existing admin dashboard shape.
- Add a UI `My Dashboard` tab showing deployed MCP servers, per-server analytics, top tools, recent activity, and time/server filters.
- Hide direct Grafana/Prometheus links from non-admin users and document that scoped observability access is deferred to #181.

## Validation

- `go test ./... -count=1` in `services/api`
- `go test ./... -count=1` in `services/ui`
- `node --check services/ui/static/app.js`
- `git diff --check`
- commit hook suite: gitleaks, gofmt, staticcheck, go vet, Go unit tests, generated file drift