### PR TITLE
feat(operator): analytics emission on by default

### DIFF
--- a/api/v1alpha1/deepcopy_test.go
+++ b/api/v1alpha1/deepcopy_test.go
@@ -256,7 +256,6 @@ func TestMCPServerSpecDeepCopy(t *testing.T) {
 			StripPrefix: "/test-server",
 		},
 		Analytics: &AnalyticsConfig{
-			Enabled:   true,
 			IngestURL: "http://analytics.default.svc/api/events",
 			Source:    "test-server",
 			EventType: "mcp.request",

--- a/api/v1alpha1/mcpserver_types.go
+++ b/api/v1alpha1/mcpserver_types.go
@@ -140,7 +140,9 @@ type MCPServerSpec struct {
 	Gateway *GatewayConfig `json:"gateway,omitempty"`
 
 	// Analytics configures audit/analytics emission for the gateway sidecar.
-	// Analytics is only applied when Gateway is enabled.
+	// Analytics is only applied when Gateway is enabled. Emission is on by
+	// default whenever the operator has an analytics ingest URL configured;
+	// set Analytics.Disabled to true to opt this server out.
 	Analytics *AnalyticsConfig `json:"analytics,omitempty"`
 
 	// Rollout configures deployment rollout behavior for this server.
@@ -252,8 +254,11 @@ type GatewayConfig struct {
 // AnalyticsConfig configures analytics emission from the gateway sidecar.
 // +kubebuilder:object:generate=true
 type AnalyticsConfig struct {
-	// Enabled turns on analytics emission from the gateway sidecar.
-	Enabled bool `json:"enabled,omitempty"`
+	// Disabled suppresses analytics emission from the gateway sidecar for this
+	// server. Analytics is on by default whenever the operator has an analytics
+	// ingest URL configured (via Spec.Analytics.IngestURL or the operator's
+	// MCP_SENTINEL_INGEST_URL env). Set Disabled to true to opt out per server.
+	Disabled bool `json:"disabled,omitempty"`
 
 	// IngestURL is the analytics ingest endpoint.
 	IngestURL string `json:"ingestURL,omitempty"`

--- a/api/v1alpha1/validation.go
+++ b/api/v1alpha1/validation.go
@@ -50,6 +50,7 @@ const (
 	defaultSessionUpstream = "Authorization"
 
 	defaultAnalyticsEventType    = "mcp.request"
+	defaultAnalyticsSourceSuffix = "-gateway"
 	defaultRolloutStrategy       = RolloutStrategyRollingUpdate
 	defaultRolloutMaxUnavailable = "25%"
 	defaultRolloutMaxSurge       = "25%"
@@ -186,9 +187,9 @@ func (r *MCPServer) Default() {
 		}
 	}
 
-	if r.Spec.Analytics != nil && r.Spec.Analytics.Enabled {
+	if r.Spec.Analytics != nil && !r.Spec.Analytics.Disabled {
 		if strings.TrimSpace(r.Spec.Analytics.Source) == "" {
-			r.Spec.Analytics.Source = strings.TrimSpace(r.Name)
+			r.Spec.Analytics.Source = strings.TrimSpace(r.Name) + defaultAnalyticsSourceSuffix
 		}
 		if strings.TrimSpace(r.Spec.Analytics.EventType) == "" {
 			r.Spec.Analytics.EventType = defaultAnalyticsEventType
@@ -280,8 +281,12 @@ func (r *MCPServer) validate() error {
 		allErrs = append(allErrs, field.Required(specPath.Child("auth", "issuerURL"), "auth.issuerURL is required when auth.mode is oauth"))
 	}
 	if r.Spec.Gateway == nil || !r.Spec.Gateway.Enabled {
-		if r.Spec.Analytics != nil && r.Spec.Analytics.Enabled {
-			allErrs = append(allErrs, field.Invalid(specPath.Child("analytics", "enabled"), true, "analytics requires gateway.enabled"))
+		if r.Spec.Analytics != nil && !r.Spec.Analytics.Disabled &&
+			(strings.TrimSpace(r.Spec.Analytics.IngestURL) != "" ||
+				strings.TrimSpace(r.Spec.Analytics.Source) != "" ||
+				strings.TrimSpace(r.Spec.Analytics.EventType) != "" ||
+				r.Spec.Analytics.APIKeySecretRef != nil) {
+			allErrs = append(allErrs, field.Forbidden(specPath.Child("analytics"), "analytics emission requires gateway.enabled; set spec.analytics.disabled to true or enable the gateway"))
 		}
 	}
 	if r.Spec.Rollout != nil && r.Spec.Rollout.Strategy == RolloutStrategyCanary {
@@ -304,7 +309,7 @@ func (r *MCPServer) validate() error {
 		}
 	}
 
-	if r.Spec.Analytics != nil && r.Spec.Analytics.Enabled {
+	if r.Spec.Analytics != nil && !r.Spec.Analytics.Disabled {
 		if r.Spec.Analytics.APIKeySecretRef != nil {
 			if strings.TrimSpace(r.Spec.Analytics.APIKeySecretRef.Name) == "" {
 				allErrs = append(allErrs, field.Required(specPath.Child("analytics", "apiKeySecretRef", "name"), "secret name is required"))

--- a/config/crd/bases/mcpruntime.org_mcpservers.yaml
+++ b/config/crd/bases/mcpruntime.org_mcpservers.yaml
@@ -61,7 +61,9 @@ spec:
               analytics:
                 description: |-
                   Analytics configures audit/analytics emission for the gateway sidecar.
-                  Analytics is only applied when Gateway is enabled.
+                  Analytics is only applied when Gateway is enabled. Emission is on by
+                  default whenever the operator has an analytics ingest URL configured;
+                  set Analytics.Disabled to true to opt this server out.
                 properties:
                   apiKeySecretRef:
                     description: APIKeySecretRef points to a secret key containing
@@ -75,9 +77,12 @@ spec:
                     - key
                     - name
                     type: object
-                  enabled:
-                    description: Enabled turns on analytics emission from the gateway
-                      sidecar.
+                  disabled:
+                    description: |-
+                      Disabled suppresses analytics emission from the gateway sidecar for this
+                      server. Analytics is on by default whenever the operator has an analytics
+                      ingest URL configured (via Spec.Analytics.IngestURL or the operator's
+                      MCP_SENTINEL_INGEST_URL env). Set Disabled to true to opt out per server.
                     type: boolean
                   eventType:
                     description: EventType is the event type label attached to emitted

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,7 @@ flowchart LR
 
 ### Validation rules in code
 
-- `analytics.enabled` requires `gateway.enabled`.
+- Analytics emission requires `gateway.enabled`; setting `analytics.disabled: true` (or omitting the analytics block) is the way to opt out per server.
 - `gateway.port` must differ from `spec.port`.
 - Every listed `tools[]` entry must declare `sideEffect`.
 - Canary rollouts require positive `canaryReplicas` strictly less than total replicas.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -713,7 +713,7 @@ Start with the smallest useful `MCPServer` and add features only when you need t
 - `spec.port` is the port your MCP server process listens on inside the container.
 - `spec.publicPathPrefix` controls the public route prefix. `payments` becomes `/payments/mcp`.
 - `spec.gateway.enabled` turns on brokered access and policy enforcement.
-- `spec.analytics.enabled` turns on audit and analytics emission for governed traffic.
+- Analytics emission is on by default for governed traffic when the operator has an analytics ingest URL configured. Set `spec.analytics.disabled: true` to opt this server out, or pass an explicit `spec.analytics.ingestURL` to override the operator default.
 
 Use this minimal pattern for most first deployments:
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -216,8 +216,11 @@ var (
 <a id="api-types-type-analyticsconfig-struct"></a>
 ```text
 type AnalyticsConfig struct {
-	// Enabled turns on analytics emission from the gateway sidecar.
-	Enabled bool `json:"enabled,omitempty"`
+	// Disabled suppresses analytics emission from the gateway sidecar for this
+	// server. Analytics is on by default whenever the operator has an analytics
+	// ingest URL configured (via Spec.Analytics.IngestURL or the operator's
+	// MCP_SENTINEL_INGEST_URL env). Set Disabled to true to opt out per server.
+	Disabled bool `json:"disabled,omitempty"`
 
 	// IngestURL is the analytics ingest endpoint.
 	IngestURL string `json:"ingestURL,omitempty"`
@@ -904,7 +907,9 @@ type MCPServerSpec struct {
 	Gateway *GatewayConfig `json:"gateway,omitempty"`
 
 	// Analytics configures audit/analytics emission for the gateway sidecar.
-	// Analytics is only applied when Gateway is enabled.
+	// Analytics is only applied when Gateway is enabled. Emission is on by
+	// default whenever the operator has an analytics ingest URL configured;
+	// set Analytics.Disabled to true to opt this server out.
 	Analytics *AnalyticsConfig `json:"analytics,omitempty"`
 
 	// Rollout configures deployment rollout behavior for this server.
@@ -1488,13 +1493,15 @@ func ResolveRegistryHost() string
 <a id="metadata-helpers-type-analyticsconfig-struct"></a>
 ```text
 type AnalyticsConfig struct {
-	Enabled         bool          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Disabled        bool          `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 	IngestURL       string        `yaml:"ingestURL,omitempty" json:"ingestURL,omitempty"`
 	Source          string        `yaml:"source,omitempty" json:"source,omitempty"`
 	EventType       string        `yaml:"eventType,omitempty" json:"eventType,omitempty"`
 	APIKeySecretRef *SecretKeyRef `yaml:"apiKeySecretRef,omitempty" json:"apiKeySecretRef,omitempty"`
 }
     AnalyticsConfig configures analytics emission from the gateway sidecar.
+    Emission is on by default whenever the operator has an analytics ingest URL
+    configured; set Disabled to true to opt out per server.
 
 ```
 

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -66,8 +66,11 @@ spec:
   The public route prefix. `payments` becomes `/payments/mcp`.
 - `spec.gateway.enabled`
   Sends requests through the broker path so policy and session checks run before tool calls.
-- `spec.analytics.enabled`
-  Emits governed request data into the Sentinel stack.
+- `spec.analytics`
+  Analytics emission to the Sentinel stack is on by default whenever the
+  operator has an ingest URL configured (via `MCP_SENTINEL_INGEST_URL` or
+  `spec.analytics.ingestURL`). Set `spec.analytics.disabled: true` to opt
+  this server out.
 
 ### Common edits
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -26,7 +26,7 @@ classDiagram
       +tools[]
       +auth, policy, session
       +gateway.enabled
-      +analytics.enabled
+      +analytics.disabled
       +rollout
       +status
     }

--- a/internal/operator/constants.go
+++ b/internal/operator/constants.go
@@ -59,3 +59,13 @@ const (
 	// RequeueDelayNotReady is the delay before requeueing when resources are not ready.
 	RequeueDelayNotReady = 10 // seconds
 )
+
+// Analytics defaults applied when the gateway sidecar emits events.
+const (
+	// defaultAnalyticsEventType is the event type label attached to analytics
+	// events when the user has not overridden Spec.Analytics.EventType.
+	defaultAnalyticsEventType = "mcp.request"
+	// defaultAnalyticsSourceSuffix is appended to the MCPServer name to derive
+	// the analytics Source label when Spec.Analytics.Source is empty.
+	defaultAnalyticsSourceSuffix = "-gateway"
+)

--- a/internal/operator/controller.go
+++ b/internal/operator/controller.go
@@ -206,10 +206,19 @@ func (r *MCPServerReconciler) validateGatewayConfig(ctx context.Context, mcpServ
 		}
 	}
 
-	if analyticsEnabled(mcpServer) {
-		if err := r.requireSpecField(ctx, mcpServer, logger, "analytics ingest URL", mcpServer.Spec.Analytics.IngestURL,
-			"analytics.ingestURL is required when analytics.enabled is true"); err != nil {
-			return err
+	// Only surface a missing-URL error when the user explicitly attached an
+	// AnalyticsConfig (and did not opt out via Disabled) while neither the
+	// server spec nor the operator fallback provides an ingest URL. With the
+	// default-on behavior, a missing URL elsewhere means "no analytics
+	// available" — a non-error state.
+	if mcpServer.Spec.Analytics != nil && !mcpServer.Spec.Analytics.Disabled {
+		specURL := strings.TrimSpace(mcpServer.Spec.Analytics.IngestURL)
+		opURL := strings.TrimSpace(r.DefaultAnalyticsIngestURL)
+		if specURL == "" && opURL == "" {
+			if err := r.requireSpecField(ctx, mcpServer, logger, "analytics ingest URL", "",
+				"analytics.ingestURL is required when spec.analytics is set; set spec.analytics.ingestURL, configure MCP_SENTINEL_INGEST_URL on the operator, or set spec.analytics.disabled to true"); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -342,7 +351,7 @@ func (r *MCPServerReconciler) setDefaults(mcpServer *mcpv1alpha1.MCPServer) {
 		mcpServer.Spec.IngressHost = strings.TrimSpace(r.DefaultIngressHost)
 	}
 
-	if analyticsEnabled(mcpServer) {
+	if mcpServer.Spec.Analytics != nil && !mcpServer.Spec.Analytics.Disabled {
 		if strings.TrimSpace(mcpServer.Spec.Analytics.IngestURL) == "" {
 			mcpServer.Spec.Analytics.IngestURL = strings.TrimSpace(r.DefaultAnalyticsIngestURL)
 		}

--- a/internal/operator/controller_test.go
+++ b/internal/operator/controller_test.go
@@ -418,7 +418,6 @@ func TestSetDefaults(t *testing.T) {
 					Enabled: true,
 				},
 				Analytics: &mcpv1alpha1.AnalyticsConfig{
-					Enabled:   true,
 					IngestURL: "http://analytics.default.svc/api/events",
 				},
 			},
@@ -435,7 +434,7 @@ func TestSetDefaults(t *testing.T) {
 		if mcpServer.Spec.Analytics == nil {
 			t.Fatal("expected analytics defaults to be applied")
 		}
-		assertEqual(t, "analyticsSource", mcpServer.Spec.Analytics.Source, "gateway-server")
+		assertEqual(t, "analyticsSource", mcpServer.Spec.Analytics.Source, "gateway-server-gateway")
 		assertEqual(t, "analyticsEventType", mcpServer.Spec.Analytics.EventType, "mcp.request")
 	})
 
@@ -447,9 +446,7 @@ func TestSetDefaults(t *testing.T) {
 				Gateway: &mcpv1alpha1.GatewayConfig{
 					Enabled: true,
 				},
-				Analytics: &mcpv1alpha1.AnalyticsConfig{
-					Enabled: true,
-				},
+				Analytics: &mcpv1alpha1.AnalyticsConfig{},
 			},
 		}
 
@@ -566,7 +563,6 @@ func TestReconcileDeploymentAddsGatewaySidecar(t *testing.T) {
 				Port:    8091,
 			},
 			Analytics: &mcpv1alpha1.AnalyticsConfig{
-				Enabled:   true,
 				IngestURL: "http://analytics.default.svc/api/events",
 				Source:    "gateway-server",
 				EventType: "mcp.request",

--- a/internal/operator/deployment.go
+++ b/internal/operator/deployment.go
@@ -416,19 +416,39 @@ func (r *MCPServerReconciler) buildGatewayContainer(mcpServer *mcpv1alpha1.MCPSe
 	if mcpServer.Spec.Gateway.StripPrefix != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "STRIP_PREFIX", Value: mcpServer.Spec.Gateway.StripPrefix})
 	}
-	if analyticsEnabled(mcpServer) {
+	if r.analyticsEnabled(mcpServer) {
+		analytics := mcpServer.Spec.Analytics
+		ingestURL := ""
+		source := mcpServer.Name + defaultAnalyticsSourceSuffix
+		eventType := defaultAnalyticsEventType
+		var apiKeyRef *mcpv1alpha1.SecretKeyRef
+		if analytics != nil {
+			if v := strings.TrimSpace(analytics.IngestURL); v != "" {
+				ingestURL = v
+			}
+			if v := strings.TrimSpace(analytics.Source); v != "" {
+				source = v
+			}
+			if v := strings.TrimSpace(analytics.EventType); v != "" {
+				eventType = v
+			}
+			apiKeyRef = analytics.APIKeySecretRef
+		}
+		if ingestURL == "" {
+			ingestURL = strings.TrimSpace(r.DefaultAnalyticsIngestURL)
+		}
 		envVars = append(envVars,
-			corev1.EnvVar{Name: "ANALYTICS_INGEST_URL", Value: mcpServer.Spec.Analytics.IngestURL},
-			corev1.EnvVar{Name: "ANALYTICS_SOURCE", Value: mcpServer.Spec.Analytics.Source},
-			corev1.EnvVar{Name: "ANALYTICS_EVENT_TYPE", Value: mcpServer.Spec.Analytics.EventType},
+			corev1.EnvVar{Name: "ANALYTICS_INGEST_URL", Value: ingestURL},
+			corev1.EnvVar{Name: "ANALYTICS_SOURCE", Value: source},
+			corev1.EnvVar{Name: "ANALYTICS_EVENT_TYPE", Value: eventType},
 		)
-		if ref := mcpServer.Spec.Analytics.APIKeySecretRef; ref != nil {
+		if apiKeyRef != nil {
 			envVars = append(envVars, corev1.EnvVar{
 				Name: "ANALYTICS_API_KEY",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{Name: ref.Name},
-						Key:                  ref.Key,
+						LocalObjectReference: corev1.LocalObjectReference{Name: apiKeyRef.Name},
+						Key:                  apiKeyRef.Key,
 					},
 				},
 			})
@@ -614,6 +634,23 @@ func serverUsesOAuth(mcpServer *mcpv1alpha1.MCPServer) bool {
 	return mcpServer != nil && mcpServer.Spec.Auth != nil && mcpServer.Spec.Auth.Mode == mcpv1alpha1.AuthModeOAuth
 }
 
-func analyticsEnabled(mcpServer *mcpv1alpha1.MCPServer) bool {
-	return mcpServer != nil && mcpServer.Spec.Analytics != nil && mcpServer.Spec.Analytics.Enabled
+// analyticsEnabled reports whether the gateway sidecar should emit analytics
+// for this MCPServer. Analytics is on by default whenever an ingest URL is
+// available — either from the server spec or the operator-level fallback —
+// unless the server explicitly opts out via Spec.Analytics.Disabled.
+func (r *MCPServerReconciler) analyticsEnabled(mcpServer *mcpv1alpha1.MCPServer) bool {
+	if mcpServer == nil {
+		return false
+	}
+	if mcpServer.Spec.Analytics != nil && mcpServer.Spec.Analytics.Disabled {
+		return false
+	}
+	url := ""
+	if mcpServer.Spec.Analytics != nil {
+		url = strings.TrimSpace(mcpServer.Spec.Analytics.IngestURL)
+	}
+	if url == "" {
+		url = strings.TrimSpace(r.DefaultAnalyticsIngestURL)
+	}
+	return url != ""
 }

--- a/pkg/metadata/crd_generator.go
+++ b/pkg/metadata/crd_generator.go
@@ -152,7 +152,7 @@ func GenerateCRD(server *ServerMetadata, outputPath string) error {
 
 	if server.Analytics != nil {
 		mcpServer.Spec.Analytics = &mcpv1alpha1.AnalyticsConfig{
-			Enabled:   server.Analytics.Enabled,
+			Disabled:  server.Analytics.Disabled,
 			IngestURL: server.Analytics.IngestURL,
 			Source:    server.Analytics.Source,
 			EventType: server.Analytics.EventType,

--- a/pkg/metadata/crd_generator_test.go
+++ b/pkg/metadata/crd_generator_test.go
@@ -167,7 +167,6 @@ func TestGenerateCRD(t *testing.T) {
 				},
 			},
 			Analytics: &AnalyticsConfig{
-				Enabled:   true,
 				IngestURL: "http://analytics.default.svc/api/events",
 				Source:    "gateway-server",
 				EventType: "mcp.request",
@@ -240,7 +239,8 @@ func TestGenerateCRD(t *testing.T) {
 		assertMapStringValue(t, secretKeyRef, "key", "openai")
 
 		analytics := assertMapValue(t, spec, "analytics")
-		assertMapBoolValue(t, analytics, "enabled", true)
+		// "disabled" is omitted from output when false (omitempty); analytics
+		// is on by default whenever the operator has an ingest URL.
 		assertMapStringValue(t, analytics, "ingestURL", "http://analytics.default.svc/api/events")
 		assertMapStringValue(t, analytics, "source", "gateway-server")
 		assertMapStringValue(t, analytics, "eventType", "mcp.request")

--- a/pkg/metadata/loader.go
+++ b/pkg/metadata/loader.go
@@ -152,9 +152,9 @@ func setDefaults(server *ServerMetadata) {
 			server.Gateway.UpstreamURL = fmt.Sprintf("http://127.0.0.1:%d", server.Port)
 		}
 	}
-	if server.Analytics != nil && server.Analytics.Enabled {
+	if server.Analytics != nil && !server.Analytics.Disabled {
 		if server.Analytics.Source == "" {
-			server.Analytics.Source = server.Name
+			server.Analytics.Source = server.Name + "-gateway"
 		}
 		if server.Analytics.EventType == "" {
 			server.Analytics.EventType = "mcp.request"

--- a/pkg/metadata/loader_test.go
+++ b/pkg/metadata/loader_test.go
@@ -86,9 +86,8 @@ func TestLoadFromFile(t *testing.T) {
 							},
 						},
 						Analytics: &AnalyticsConfig{
-							Enabled:   true,
 							IngestURL: "http://analytics.custom-namespace.svc/api/events",
-							Source:    "custom-server",
+							Source:    "custom-server-gateway",
 							EventType: "mcp.request",
 							APIKeySecretRef: &SecretKeyRef{
 								Name: "analytics-creds",
@@ -262,7 +261,6 @@ func TestSetDefaults(t *testing.T) {
 					},
 				},
 				Analytics: &AnalyticsConfig{
-					Enabled:   true,
 					IngestURL: "http://analytics.default.svc/api/events",
 				},
 				Rollout: &RolloutConfig{
@@ -314,9 +312,8 @@ func TestSetDefaults(t *testing.T) {
 					},
 				},
 				Analytics: &AnalyticsConfig{
-					Enabled:   true,
 					IngestURL: "http://analytics.default.svc/api/events",
-					Source:    "gateway-server",
+					Source:    "gateway-server-gateway",
 					EventType: "mcp.request",
 				},
 				Rollout: &RolloutConfig{
@@ -570,7 +567,7 @@ func analyticsConfigEqual(a, b *AnalyticsConfig) bool {
 	if a == nil || b == nil {
 		return false
 	}
-	return a.Enabled == b.Enabled &&
+	return a.Disabled == b.Disabled &&
 		a.IngestURL == b.IngestURL &&
 		a.Source == b.Source &&
 		a.EventType == b.EventType &&

--- a/pkg/metadata/schema.go
+++ b/pkg/metadata/schema.go
@@ -208,8 +208,10 @@ type GatewayConfig struct {
 }
 
 // AnalyticsConfig configures analytics emission from the gateway sidecar.
+// Emission is on by default whenever the operator has an analytics ingest URL
+// configured; set Disabled to true to opt out per server.
 type AnalyticsConfig struct {
-	Enabled         bool          `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Disabled        bool          `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 	IngestURL       string        `yaml:"ingestURL,omitempty" json:"ingestURL,omitempty"`
 	Source          string        `yaml:"source,omitempty" json:"source,omitempty"`
 	EventType       string        `yaml:"eventType,omitempty" json:"eventType,omitempty"`

--- a/pkg/metadata/testdata/valid.yaml
+++ b/pkg/metadata/testdata/valid.yaml
@@ -30,7 +30,6 @@ servers:
         requiredTrust: high
         sideEffect: destructive
     analytics:
-      enabled: true
       ingestURL: http://analytics.custom-namespace.svc/api/events
       apiKeySecretRef:
         name: analytics-creds

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -4532,6 +4532,8 @@ grafana_password = os.environ["GRAFANA_ADMIN_PASSWORD"]
 loki_base = os.environ["LOKI_BASE"]
 sentinel_base = os.environ["SENTINEL_BASE"]
 gateway_trace_services = (f"{server_name}-gateway", f"{oauth_server_name}-gateway")
+server_gateway_source, oauth_gateway_source = gateway_trace_services
+expected_gateway_sources = {server_gateway_source, oauth_gateway_source}
 
 
 import os as _os; exec(open(_os.environ["E2E_HELPERS"]).read())
@@ -4928,8 +4930,8 @@ sources = wait_for_json(
     lambda doc: all(
         int(item.get("count", 0)) >= 1
         for item in doc.get("sources", [])
-        if item.get("source") in {server_name, oauth_server_name}
-    ) and {item.get("source") for item in doc.get("sources", [])} >= {server_name, oauth_server_name},
+        if item.get("source") in expected_gateway_sources
+    ) and {item.get("source") for item in doc.get("sources", [])} >= expected_gateway_sources,
     headers=headers,
     description="analytics sources",
 ).get("sources", [])
@@ -5043,14 +5045,14 @@ for rpc_method in expected_gateway_rpc_methods:
         f"missing oauth gateway audit event for {rpc_method}: {oauth_routing_methods}",
     )
 check(
-    source_counts.get(server_name, 0) >= 1,
-    f"gateway source counts include {server_name}",
-    f"missing gateway source counts for {server_name}: {source_counts}",
+    source_counts.get(server_gateway_source, 0) >= 1,
+    f"gateway source counts include {server_gateway_source}",
+    f"missing gateway source counts for {server_gateway_source}: {source_counts}",
 )
 check(
-    source_counts.get(oauth_server_name, 0) >= 1,
-    f"gateway source counts include {oauth_server_name}",
-    f"missing gateway source counts for {oauth_server_name}: {source_counts}",
+    source_counts.get(oauth_gateway_source, 0) >= 1,
+    f"gateway source counts include {oauth_gateway_source}",
+    f"missing gateway source counts for {oauth_gateway_source}: {source_counts}",
 )
 for event_type in ("mcp.request", "pii.check", "service.route.check"):
     check(
@@ -5199,8 +5201,8 @@ rows = [
     ("audit.oauth_allow_aaa_ping", str(len(oauth_allow_aaa_ping))),
     ("audit.oauth_deny_events", str(len(oauth_deny_events))),
     ("audit.rpc_methods", str(len(routing_methods))),
-    ("analytics.source.gateway", str(source_counts.get(server_name, 0))),
-    ("analytics.source.oauth", str(source_counts.get(oauth_server_name, 0))),
+    ("analytics.source.gateway", str(source_counts.get(server_gateway_source, 0))),
+    ("analytics.source.oauth", str(source_counts.get(oauth_gateway_source, 0))),
     ("analytics.type.mcp.request", str(event_type_counts.get("mcp.request", 0))),
     ("analytics.type.pii.check", str(event_type_counts.get("pii.check", 0))),
     ("analytics.type.service.route.check", str(event_type_counts.get("service.route.check", 0))),

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -2680,7 +2680,6 @@ servers:
           cpu: 1m
           memory: 32Mi
     analytics:
-      enabled: true
       ingestURL: "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events"
       apiKeySecretRef:
         name: ${SERVER_SECRET_NAME}
@@ -3720,7 +3719,6 @@ servers:
           cpu: 1m
           memory: 32Mi
     analytics:
-      enabled: true
       ingestURL: "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events"
       apiKeySecretRef:
         name: ${SERVER_SECRET_NAME}


### PR DESCRIPTION
Closes #49.

## Motivation

Today every MCPServer must hand-set `spec.analytics.enabled: true` for the gateway sidecar to emit. That contradicts the issue's framing — platform telemetry should be the default whenever the operator has Sentinel configured, not a per-server opt-in. User servers also shouldn't have to know what Sentinel is. The proxy sidecar is platform-owned and already on the request path; it's the canonical emitter.

## Behavior change (breaking, alpha-acceptable)

CRD: `AnalyticsConfig.Enabled bool` → `AnalyticsConfig.Disabled bool`. Zero-value (false) means "emit"; explicit `disabled: true` opts out. Matches existing repo precedent (`MCPAccessGrantSpec.Disabled`, `MCPAgentSessionSpec.Revoked`).

## Migration

- `analytics: {enabled: true}` → drop the field. It's the new default whenever the operator has an ingest URL.
- `analytics: {enabled: false}` (opting out) → convert to `analytics: {disabled: true}`.
- Clusters with no Sentinel installed (operator has no `MCP_SENTINEL_INGEST_URL` and no per-server `analytics.ingestURL`): no change — analytics stays off naturally.

## Operator gate

`analyticsEnabled` is now a method on the reconciler so it can read `r.DefaultAnalyticsIngestURL`. Returns true when:
1. `Spec.Analytics` is nil OR `Spec.Analytics.Disabled` is false, AND
2. an ingest URL is available — either `Spec.Analytics.IngestURL` or the operator-level fallback.

The previous strict validation gate (refused to reconcile when `Analytics.Enabled: true` but `IngestURL` empty) is relaxed: a missing URL on a non-explicit server is a non-error "no analytics" state. The validation only errors when the user explicitly attached an `AnalyticsConfig` (e.g. with a Source or APIKeySecretRef) and neither side provides a URL.

## New per-server defaults

- `Spec.Analytics.Source` defaults to `<server-name>-gateway` when empty (was bare `<server-name>`; the suffix makes it unambiguous that the source is the gateway sidecar, not the user container).
- `Spec.Analytics.EventType` defaults to `mcp.request` when empty.

## Coordination with the in-flight rename

This PR does NOT do the `mcp-proxy` → `mcp-gateway` rename. That's tracked on a separate branch by another agent. The overlap is minor — both PRs touch `internal/operator/deployment.go` and `controller.go`, but in different ways (rename = string sweep, this PR = logic change). They should rebase cleanly on each other.

## Test plan

- [x] `make -f Makefile.operator generate manifests` — CRD regenerated (Analytics field switched to `disabled` in `config/crd/bases/mcpruntime.org_mcpservers.yaml`)
- [x] `python3 docs/scripts/generate_go_package_reference.py` — internals doc regenerated
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -s -l .` — clean
- [x] `go test ./... -count=1` from repo root — **all 50+ packages pass**, including `api/v1alpha1`, `internal/operator`, `pkg/metadata`, golden, integration
- [x] `bash -n test/e2e/kind.sh` — clean

## What got touched

20 files, all in the main module:

- CRD shape: `api/v1alpha1/mcpserver_types.go`, `api/v1alpha1/validation.go`, `config/crd/bases/mcpruntime.org_mcpservers.yaml`, `api/v1alpha1/deepcopy_test.go`
- Operator gate: `internal/operator/{constants,controller,deployment}.go`, `internal/operator/controller_test.go`
- Metadata mirror type: `pkg/metadata/{schema,loader,crd_generator}.go`, `pkg/metadata/{loader_test,crd_generator_test}.go`, `pkg/metadata/testdata/valid.yaml`
- E2E manifests: `test/e2e/kind.sh` (dropped redundant `enabled: true` lines)
- Docs: `docs/runtime.md`, `docs/api.md`, `docs/getting-started.md`, `docs/publish-mcp-server.md`, `docs/internals/go-package-reference.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)