### PR TITLE
fix(test): refresh kind kubeconfig before restart smoke

### DIFF
--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -5622,10 +5622,8 @@ fi
 
 echo "[cli] checking sentinel restart command"
 # The full E2E stack packs single-node Kind tightly, so avoid requiring surge CPU for this restart smoke.
-export KUBECONFIG="${KUBECONFIG_FILE}"
-kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
-kubectl patch deployment mcp-sentinel-api -n mcp-sentinel --type merge -p '{"spec":{"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":0,"maxUnavailable":1}}}}' >/dev/null
 refresh_kind_kubeconfig
+kubectl patch deployment mcp-sentinel-api -n mcp-sentinel --type merge -p '{"spec":{"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":0,"maxUnavailable":1}}}}' >/dev/null
 KUBECONFIG="${KUBECONFIG_FILE}" ./bin/mcp-runtime sentinel restart api
 rollout_status_with_logs mcp-sentinel deploy mcp-sentinel-api 180s
 


### PR DESCRIPTION
## Summary
- refresh the Kind kubeconfig immediately before the Sentinel restart smoke
- avoid using a stale or missing `kind-mcp-e2e` context late in E2E cleanup

## Verification
- `bash -n test/e2e/kind.sh`
- `git diff --check`
- commit hook: gitleaks, staticcheck, go vet