### PR TITLE
fix(sentinel): close audit drop and login attempt gaps

### DIFF
--- a/services/api/platform_auth.go
+++ b/services/api/platform_auth.go
@@ -21,6 +21,10 @@ const (
 	apiLoginLockoutMax  = 5 * time.Minute
 )
 const (
+	apiLoginAttemptIdleTTL    = 30 * time.Minute
+	apiLoginAttemptMaxEntries = 4096
+)
+const (
 	platformSignupRequestMaxBytes        = 4 * 1024
 	platformPasswordLoginRequestMaxBytes = 4 * 1024
 	platformOIDCLoginRequestMaxBytes     = 8 * 1024
@@ -43,6 +47,7 @@ type passwordUserEnsurer interface {
 type apiLoginAttempt struct {
 	failures    int
 	lockedUntil time.Time
+	lastSeen    time.Time
 }
 
 type apiLoginAttemptTracker struct {
@@ -61,8 +66,14 @@ func newAPILoginAttemptTracker(nowFn func() time.Time) *apiLoginAttemptTracker {
 func (t *apiLoginAttemptTracker) allow(key string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	state := t.entries[key]
 	now := t.nowFunc()
+	t.pruneLocked(now)
+	state, ok := t.entries[key]
+	if !ok {
+		return true
+	}
+	state.lastSeen = now
+	t.entries[key] = state
 	if state.lockedUntil.IsZero() || !state.lockedUntil.After(now) {
 		return true
 	}
@@ -73,20 +84,53 @@ func (t *apiLoginAttemptTracker) recordFailure(key string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	now := t.nowFunc()
+	t.pruneLocked(now)
 	state := t.entries[key]
 	state.failures++
 	state.lockedUntil = now.Add(lockoutDurationForFailures(state.failures))
+	state.lastSeen = now
 	t.entries[key] = state
+	t.enforceMaxLocked()
 	return state.failures
 }
 
 func (t *apiLoginAttemptTracker) recordSuccess(key string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	now := t.nowFunc()
+	t.pruneLocked(now)
 	state := t.entries[key]
 	failures := state.failures
 	delete(t.entries, key)
 	return failures
+}
+
+func (t *apiLoginAttemptTracker) pruneLocked(now time.Time) {
+	if apiLoginAttemptIdleTTL <= 0 {
+		return
+	}
+	for key, state := range t.entries {
+		if state.lastSeen.IsZero() || (now.Sub(state.lastSeen) > apiLoginAttemptIdleTTL && !state.lockedUntil.After(now)) {
+			delete(t.entries, key)
+		}
+	}
+}
+
+func (t *apiLoginAttemptTracker) enforceMaxLocked() {
+	for len(t.entries) > apiLoginAttemptMaxEntries {
+		var oldestKey string
+		var oldestSeen time.Time
+		for key, state := range t.entries {
+			if oldestKey == "" || state.lastSeen.Before(oldestSeen) {
+				oldestKey = key
+				oldestSeen = state.lastSeen
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(t.entries, oldestKey)
+	}
 }
 
 func lockoutDurationForFailures(failures int) time.Duration {

--- a/services/api/platform_auth_test.go
+++ b/services/api/platform_auth_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -97,5 +98,42 @@ func TestOpenPlatformStoreWithRetryRetriesUntilSuccess(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("open attempts = %d, want 2", calls)
+	}
+}
+
+func TestAPILoginAttemptTrackerPrunesIdleEntries(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newAPILoginAttemptTracker(func() time.Time {
+		return now
+	})
+
+	tracker.recordFailure("client-old")
+	now = now.Add(apiLoginAttemptIdleTTL + time.Second)
+	tracker.recordFailure("client-new")
+
+	if _, ok := tracker.entries["client-old"]; ok {
+		t.Fatal("idle login attempt entry was not pruned")
+	}
+	if _, ok := tracker.entries["client-new"]; !ok {
+		t.Fatal("new login attempt entry missing")
+	}
+}
+
+func TestAPILoginAttemptTrackerCapsRetainedEntries(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newAPILoginAttemptTracker(func() time.Time {
+		return now
+	})
+
+	for i := 0; i < apiLoginAttemptMaxEntries+1; i++ {
+		tracker.recordFailure(fmt.Sprintf("client-%d", i))
+		now = now.Add(time.Millisecond)
+	}
+
+	if got := len(tracker.entries); got != apiLoginAttemptMaxEntries {
+		t.Fatalf("login attempt entries = %d, want %d", got, apiLoginAttemptMaxEntries)
+	}
+	if _, ok := tracker.entries["client-0"]; ok {
+		t.Fatal("oldest login attempt entry was not evicted")
 	}
 }

--- a/services/mcp-gateway/analytics.go
+++ b/services/mcp-gateway/analytics.go
@@ -72,8 +72,8 @@ func (s *gatewayServer) emitIfEnabled(ctx context.Context, event events.Envelope
 		return
 	}
 	s.analyticsMu.Lock()
-	defer s.analyticsMu.Unlock()
 	if s.analyticsClosed {
+		s.analyticsMu.Unlock()
 		return
 	}
 	item := analyticsEvent{
@@ -82,7 +82,11 @@ func (s *gatewayServer) emitIfEnabled(ctx context.Context, event events.Envelope
 	}
 	select {
 	case queue <- item:
+		s.analyticsMu.Unlock()
 	default:
+		dropped := s.analyticsDropped.Add(1)
+		s.analyticsMu.Unlock()
+		log.Printf("gateway analytics queue full; dropped event total=%d source=%q event_type=%q", dropped, event.Source, event.EventType)
 	}
 }
 

--- a/services/mcp-gateway/main_test.go
+++ b/services/mcp-gateway/main_test.go
@@ -489,6 +489,9 @@ func TestEmitIfEnabledDropsWhenQueueIsFull(t *testing.T) {
 	default:
 		t.Fatal("analytics queue unexpectedly drained")
 	}
+	if got := proxy.analyticsDropped.Load(); got != 1 {
+		t.Fatalf("analytics dropped count = %d, want 1", got)
+	}
 }
 
 func TestStopAnalyticsDispatcherDrainsQueue(t *testing.T) {

--- a/services/mcp-gateway/types.go
+++ b/services/mcp-gateway/types.go
@@ -79,6 +79,7 @@ type gatewayServer struct {
 	analyticsOnce         sync.Once
 	analyticsWG           sync.WaitGroup
 	analyticsClosed       bool
+	analyticsDropped      atomic.Uint64
 	oauthMu               sync.Mutex
 	oauthProviders        map[string]*oauthProvider
 	policyState           atomic.Value

--- a/services/ui/main.go
+++ b/services/ui/main.go
@@ -39,6 +39,8 @@ const (
 	defaultLoginFailureWindow     = 15 * time.Minute
 	defaultLoginFailureThreshold  = 5
 	defaultLoginLockoutDuration   = 5 * time.Minute
+	loginAttemptIdleTTL           = 30 * time.Minute
+	loginAttemptMaxClients        = 4096
 	loginFailureLogEvery          = 3
 	loginRequestMaxBytes          = 8 * 1024
 )
@@ -84,6 +86,7 @@ type loginAttemptTracker struct {
 type loginClientState struct {
 	tokens         int
 	lastRefill     time.Time
+	lastSeen       time.Time
 	failures       int
 	failuresExpire time.Time
 	lockedUntil    time.Time
@@ -721,8 +724,10 @@ func (t *loginAttemptTracker) allow(clientID string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	state := t.stateForLocked(clientID)
 	now := t.now()
+	t.pruneLocked(now)
+	state := t.stateForLocked(clientID, now)
+	state.lastSeen = now
 	refillLoginTokens(state, now)
 	if now.Before(state.lockedUntil) {
 		return false
@@ -731,6 +736,7 @@ func (t *loginAttemptTracker) allow(clientID string) bool {
 		return false
 	}
 	state.tokens--
+	t.enforceMaxLocked()
 	return true
 }
 
@@ -738,8 +744,10 @@ func (t *loginAttemptTracker) recordFailure(clientID string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	state := t.stateForLocked(clientID)
 	now := t.now()
+	t.pruneLocked(now)
+	state := t.stateForLocked(clientID, now)
+	state.lastSeen = now
 	if now.After(state.failuresExpire) {
 		state.failures = 0
 	}
@@ -748,6 +756,7 @@ func (t *loginAttemptTracker) recordFailure(clientID string) int {
 	if state.failures >= loginFailureThreshold {
 		state.lockedUntil = now.Add(loginLockoutDuration)
 	}
+	t.enforceMaxLocked()
 	return state.failures
 }
 
@@ -755,7 +764,13 @@ func (t *loginAttemptTracker) recordSuccess(clientID string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	state := t.stateForLocked(clientID)
+	now := t.now()
+	t.pruneLocked(now)
+	state := t.clients[clientID]
+	if state == nil {
+		return 0
+	}
+	state.lastSeen = now
 	prior := state.failures
 	state.failures = 0
 	state.failuresExpire = time.Time{}
@@ -763,14 +778,41 @@ func (t *loginAttemptTracker) recordSuccess(clientID string) int {
 	return prior
 }
 
-func (t *loginAttemptTracker) stateForLocked(clientID string) *loginClientState {
+func (t *loginAttemptTracker) stateForLocked(clientID string, now time.Time) *loginClientState {
 	state := t.clients[clientID]
 	if state == nil {
-		now := t.now()
-		state = &loginClientState{tokens: loginRateLimitCapacity, lastRefill: now}
+		state = &loginClientState{tokens: loginRateLimitCapacity, lastRefill: now, lastSeen: now}
 		t.clients[clientID] = state
 	}
 	return state
+}
+
+func (t *loginAttemptTracker) pruneLocked(now time.Time) {
+	if loginAttemptIdleTTL <= 0 {
+		return
+	}
+	for clientID, state := range t.clients {
+		if state.lastSeen.IsZero() || (now.Sub(state.lastSeen) > loginAttemptIdleTTL && !now.Before(state.lockedUntil)) {
+			delete(t.clients, clientID)
+		}
+	}
+}
+
+func (t *loginAttemptTracker) enforceMaxLocked() {
+	for len(t.clients) > loginAttemptMaxClients {
+		var oldestClientID string
+		var oldestSeen time.Time
+		for clientID, state := range t.clients {
+			if oldestClientID == "" || state.lastSeen.Before(oldestSeen) {
+				oldestClientID = clientID
+				oldestSeen = state.lastSeen
+			}
+		}
+		if oldestClientID == "" {
+			return
+		}
+		delete(t.clients, oldestClientID)
+	}
 }
 
 func refillLoginTokens(state *loginClientState, now time.Time) {

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -982,6 +982,45 @@ func TestHandleLoginSuccessResetsFailureCounter(t *testing.T) {
 	}
 }
 
+func TestLoginAttemptTrackerPrunesIdleClients(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newLoginAttemptTracker(func() time.Time {
+		return now
+	})
+
+	tracker.recordFailure("client-old")
+	now = now.Add(loginAttemptIdleTTL + time.Second)
+	tracker.recordFailure("client-new")
+
+	if _, ok := tracker.clients["client-old"]; ok {
+		t.Fatal("idle login attempt client was not pruned")
+	}
+	if _, ok := tracker.clients["client-new"]; !ok {
+		t.Fatal("new login attempt client missing")
+	}
+}
+
+func TestLoginAttemptTrackerCapsRetainedClients(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newLoginAttemptTracker(func() time.Time {
+		return now
+	})
+
+	for i := 0; i < loginAttemptMaxClients+1; i++ {
+		if !tracker.allow(fmt.Sprintf("client-%d", i)) {
+			t.Fatalf("client-%d should be allowed on first attempt", i)
+		}
+		now = now.Add(time.Millisecond)
+	}
+
+	if got := len(tracker.clients); got != loginAttemptMaxClients {
+		t.Fatalf("login attempt clients = %d, want %d", got, loginAttemptMaxClients)
+	}
+	if _, ok := tracker.clients["client-0"]; ok {
+		t.Fatal("oldest login attempt client was not evicted")
+	}
+}
+
 func useLoginAttemptTrackerForTest(t *testing.T) func() {
 	t.Helper()
 	previous := loginAttempts


### PR DESCRIPTION
## Summary

Fixes #146.

- Count and log mcp-gateway analytics events dropped because the bounded queue is full.
- Bound API login-attempt state with idle eviction and a maximum retained entry count.
- Bound UI login-attempt state with idle eviction and a maximum retained client count, including the pre-decode allow path.

## Validation

- `go test ./... -count=1` in `services/mcp-gateway`, `services/api`, `services/ui`, and `services/processor`
- `go test -race ./... -count=1` in `services/mcp-gateway`, `services/api`, `services/ui`, and `services/processor`
- pre-commit hooks during commit: gitleaks, go fmt, staticcheck, go vet, go unit tests, generated file drift

## Security notes

- No secrets or credentials are logged; the analytics drop log only includes drop count, source, and event type.
- Login attempt trackers remain per-process throttles but no longer retain attacker-controlled keys indefinitely.