### PR TITLE
[codex] Fix admin API-key panel and add skill regression coverage

### DIFF
--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -60,7 +60,7 @@ Current line counts:
 237  k8s-hardening-audit/SKILL.md
 358  mcp-spec-compliance/SKILL.md
 279  qa-cluster-bringup/SKILL.md
-221  qa-e2e-operations/SKILL.md
+257  qa-e2e-operations/SKILL.md
 253  qa-e2e-perf/SKILL.md
 329  qa-e2e-security/SKILL.md
 283  qa-e2e-ui/SKILL.md
@@ -126,6 +126,32 @@ requires live cluster/browser/API evidence for the relevant surface, including
 negative or denied cases where the feature has auth, policy, protocol, or
 role-gating behavior. If the live path cannot run, the result is **blocked**,
 not passed by substituting static checks.
+
+## CI And Test Coverage Audit
+
+The skills are not one giant test runner. Coverage is routed by change surface,
+with CI remaining the source of truth for exact commands. As of this audit, every
+CI/test surface has an owning skill:
+
+| CI/test surface | Owning skill path | Coverage status |
+|---|---|---|
+| `gofmt`, `go vet`, `staticcheck` | `qa-e2e-operations` | CI parity gate for merge/release readiness |
+| Root unit tests and `test/integration` envtest | `qa-e2e-operations` | CI parity gate; envtest asset setup included |
+| Sentinel service module tests (`services/api`, `ingest`, `processor`, `mcp-gateway`, `ui`) | `qa-e2e-operations` plus focused QA skills | CI parity gate plus live rollout checks |
+| CLI golden tests | `repo-guidance-sync`, `qa-e2e-operations`, `qa-e2e-ui` | Docs/help drift and UI-adjacent CLI changes |
+| `test/e2e/scenarios_test.sh` selector validation | `qa-e2e-operations` | CI parity gate covers scenario parsing edge cases |
+| Kind E2E `all` plus cached `smoke-auth,governance` | `qa-cluster-bringup`, `qa-e2e-operations`, `qa-e2e-security`, `mcp-spec-compliance` | Full merge gate and targeted live regression gates |
+| Browser UI workflows and responsive checks | `qa-e2e-ui` | Browser evidence required; curl-only pass is blocked |
+| Benchmarks under `test/benchmark` | `qa-e2e-operations`, `qa-e2e-perf` | CI benchmark plus live baseline comparison |
+| Generated CRD/manifests and Go package docs drift | `qa-e2e-operations`, `repo-guidance-sync` | Exact generator commands and `git diff --exit-code` |
+| Gitleaks, gosec, Trivy, dependency review | `security-audit`, `security-audit-platform`, `supply-chain-audit` | Security scan selection and supply-chain workflow audit |
+| Repository and operator image SBOMs | `supply-chain-audit` | SBOM generation/diff and image scan guidance |
+| Docs and website validation/deploy assumptions | `repo-guidance-sync` | Docs build, generated-doc drift, and stale guidance checks |
+
+Audit result: the skills can route all current CI/test surfaces, but they still
+do not enumerate every individual unit test case. That is intentional; the skill
+contract is to select and run the right suite, then add or update concrete tests
+when a behavior gap is found.
 
 For `qa-e2e-ui`, the current smoke coverage includes role-based navigation,
 auth flows, key tabs, network/API evidence, console evidence, static assets,

--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -58,12 +58,12 @@ Current line counts:
 
 ```text
 237  k8s-hardening-audit/SKILL.md
-352  mcp-spec-compliance/SKILL.md
-273  qa-cluster-bringup/SKILL.md
-216  qa-e2e-operations/SKILL.md
-247  qa-e2e-perf/SKILL.md
-324  qa-e2e-security/SKILL.md
-277  qa-e2e-ui/SKILL.md
+358  mcp-spec-compliance/SKILL.md
+279  qa-cluster-bringup/SKILL.md
+221  qa-e2e-operations/SKILL.md
+253  qa-e2e-perf/SKILL.md
+329  qa-e2e-security/SKILL.md
+283  qa-e2e-ui/SKILL.md
  59  repo-guidance-sync/SKILL.md
 265  security-audit-platform/SKILL.md
 100  security-audit/SKILL.md
@@ -120,6 +120,12 @@ checks that match the requested scope:
    AGENTS.md, runbook, or contributor guidance updates.
 6. `.codex/skills/scripts/validate_skill_evals.py` checks that every skill's
    eval and trigger prompt manifests stay structurally usable.
+
+The live QA skills now carry an explicit regression evidence contract: a pass
+requires live cluster/browser/API evidence for the relevant surface, including
+negative or denied cases where the feature has auth, policy, protocol, or
+role-gating behavior. If the live path cannot run, the result is **blocked**,
+not passed by substituting static checks.
 
 For `qa-e2e-ui`, the current smoke coverage includes role-based navigation,
 auth flows, key tabs, network/API evidence, console evidence, static assets,

--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -1,0 +1,140 @@
+# MCP Runtime Agent Skills
+
+Last checked: 2026-05-18.
+
+This directory contains MCP Runtime's repo-local Agent Skills. The format is
+based on the public Agent Skills guidance:
+
+- Overview: https://agentskills.io/home
+- Specification: https://agentskills.io/specification
+- Best practices: https://agentskills.io/skill-creation/best-practices
+- Evaluating skills: https://agentskills.io/skill-creation/evaluating-skills
+- Using scripts: https://agentskills.io/skill-creation/using-scripts
+
+## Layout
+
+Each skill lives in its own directory and must contain `SKILL.md`.
+
+```text
+.codex/skills/
+  <skill-name>/
+    SKILL.md
+    agents/openai.yaml
+    evals/evals.json
+    evals/trigger_queries.json
+    references/        # optional, loaded only when needed
+    scripts/           # optional, reusable helpers owned by that skill
+  scripts/
+    validate_skill_evals.py
+```
+
+`agents/openai.yaml` is client-specific metadata for OpenAI/Codex surfaces. It
+is intentionally outside the core Agent Skills spec, which requires only
+`SKILL.md` with `name` and `description` frontmatter.
+
+## Agent Skills Compliance Snapshot
+
+The current repo-local skills follow the core Agent Skills structure:
+
+- 11 skills have a `SKILL.md`.
+- Every skill `name` matches its directory name.
+- Every skill name uses lowercase letters, numbers, and hyphens only.
+- Every `description` is non-empty and below the 1024-character limit.
+- Every main `SKILL.md` is below the recommended 500-line ceiling.
+- Every skill now has a minimal `evals/evals.json` suite with realistic prompts,
+  expected outputs, and objective assertions.
+- Every skill also has `evals/trigger_queries.json` with should-trigger and
+  should-not-trigger prompts for description tuning.
+- `.codex/skills/scripts/validate_skill_evals.py` validates every eval and
+  trigger manifest so malformed regression prompts fail fast.
+- MCP live transport details are split into
+  `mcp-spec-compliance/references/live-conformance.md`.
+- Large UI coverage detail is split into
+  `qa-e2e-ui/references/ui-coverage.md` for progressive disclosure.
+- Shared report templates are referenced through relative paths such as
+  `../_shared/FINDINGS-TEMPLATE.md`.
+
+Current line counts:
+
+```text
+237  k8s-hardening-audit/SKILL.md
+352  mcp-spec-compliance/SKILL.md
+273  qa-cluster-bringup/SKILL.md
+216  qa-e2e-operations/SKILL.md
+247  qa-e2e-perf/SKILL.md
+324  qa-e2e-security/SKILL.md
+277  qa-e2e-ui/SKILL.md
+ 59  repo-guidance-sync/SKILL.md
+265  security-audit-platform/SKILL.md
+100  security-audit/SKILL.md
+200  supply-chain-audit/SKILL.md
+139  mcp-spec-compliance/references/live-conformance.md
+308  qa-e2e-ui/references/ui-coverage.md
+```
+
+Current gap against the fuller Agent Skills evaluation guidance: the skills now
+have output and trigger prompt suites plus a local manifest validator, but there
+is not yet a model-backed runner that executes each case with-skill versus
+baseline and aggregates pass rates, timing, trigger rates, or token costs. Today
+we validate skill/eval structure and run MCP Runtime product regression suites
+that the skills instruct agents to run.
+
+## Regression Timing
+
+These timings were measured on 2026-05-18 from the repo root on an existing
+`kind-mcp-runtime` contributor cluster.
+
+| Check | Command or flow | Time observed | What it covers |
+|---|---|---:|---|
+| Skill frontmatter validation | `quick_validate.py` over all skill dirs | 0.59s | Required `SKILL.md` metadata and basic structure |
+| Skill eval JSON validation | `python -m json.tool` over `*/evals/*.json` | 0.72s | Output and trigger eval prompt suites parse as JSON for all 11 skills |
+| Skill eval schema validation | `.codex/skills/scripts/validate_skill_evals.py` | 0.08s | Eval IDs, prompts, assertions, trigger positives, and trigger negatives for all 11 skills |
+| OpenAI skill metadata smoke | shell check over `agents/openai.yaml` | 0.13s | Client metadata files exist with display name, short description, and default prompt |
+| UI service unit tests | `cd services/ui && go test ./... -race -count=1` | 6.99s | UI server handlers, config, auth/session behavior covered by Go tests |
+| CLI golden tests | `go test ./test/golden/... -count=1` | 4.64s | CLI help/output drift that can affect docs and UI-adjacent flows |
+| UI static syntax | `node --check services/ui/static/app.js` | 0.30s | Browser bundle JavaScript parses |
+| UI skill validation | `quick_validate.py .codex/skills/qa-e2e-ui` | 0.07s | `qa-e2e-ui` format after edits |
+| UI browser smoke | Playwright against `http://localhost:18080/` | about 4-6 min manual | Signed-out state, tenant login, admin login, tabs, UI-triggered API 200s, console sanity, and mobile overflow |
+| Cached Kind e2e smoke/governance | `E2E_CACHE_MODE=1 E2E_SCENARIOS=smoke-auth,governance CLUSTER_NAME=mcp-runtime E2E_KEEP_CLUSTER=1 bash test/e2e/kind.sh` | 630.62s, about 10m31s | Real cluster auth, grant/session governance, gateway policy, CLI flows, ingress, registry auth |
+
+The cached Kind e2e command initially failed after 1m17s because a manual
+port-forward was already using `localhost:18080`. That was an environment
+collision from the QA session, not a product regression. The port-forward was
+stopped and the command was rerun.
+
+## How Skill-Based Regression Works Today
+
+The QA skills are run as guided workflows, not as one monolithic test binary.
+The agent activates the relevant skill, reads its `SKILL.md`, and then runs the
+checks that match the requested scope:
+
+1. `qa-cluster-bringup` creates or recovers the real Kind test-mode cluster.
+2. `qa-e2e-ui` uses browser tooling first, then supports findings with curl,
+   static asset checks, UI Go tests, golden tests, and optional cached Kind e2e.
+3. `qa-e2e-security`, `qa-e2e-operations`, `qa-e2e-perf`, and
+   `mcp-spec-compliance` cover runtime security, operations, performance, and
+   protocol-specific regressions against the same live cluster.
+4. Audit skills use `../_shared/FINDINGS-TEMPLATE.md` so findings stay
+   comparable across security, supply chain, Kubernetes, and protocol reviews.
+5. `repo-guidance-sync` checks whether code or behavior changes require docs,
+   AGENTS.md, runbook, or contributor guidance updates.
+6. `.codex/skills/scripts/validate_skill_evals.py` checks that every skill's
+   eval and trigger prompt manifests stay structurally usable.
+
+For `qa-e2e-ui`, the current smoke coverage includes role-based navigation,
+auth flows, key tabs, network/API evidence, console evidence, static assets,
+and responsive sanity. Full UI coverage is broader and lives in
+`qa-e2e-ui/references/ui-coverage.md`; it includes forms, filters, destructive
+actions, empty/error states, and public-host defenses. Destructive UI actions
+must use temporary `qa-audit-*` objects only.
+
+## Gaps To Close
+
+- Record with-skill versus baseline results, timing, and pass rates in an eval
+  workspace, following the Agent Skills evaluation guidance.
+- Add a model-backed trigger-eval runner that measures trigger rates over
+  `evals/trigger_queries.json` for each skill.
+- Script the UI browser smoke so the 4-6 minute manual pass becomes repeatable
+  and produces durable evidence.
+- Keep future reusable helpers in `scripts/`, make them non-interactive, add
+  `--help`, use structured output, and pin dependencies.

--- a/.codex/skills/_shared/FINDINGS-TEMPLATE.md
+++ b/.codex/skills/_shared/FINDINGS-TEMPLATE.md
@@ -39,7 +39,7 @@ cause reappears, list additional locations under `Other locations`.
 ```
 [SEV-{Critical|High|Medium|Low|Info}] <short title, imperative>
 Component: <operator | gateway | sentinel-api | sentinel-ui | sentinel-ingest |
-            sentinel-processor | mcp-proxy | registry | traefik | crd | ci |
+            sentinel-processor | mcp-gateway | registry | traefik | crd | ci |
             other>
 Location:  <path>:<line>            # use N/A only for design-level findings
 CWE:       CWE-XXX                  # omit if no clean mapping

--- a/.codex/skills/k8s-hardening-audit/SKILL.md
+++ b/.codex/skills/k8s-hardening-audit/SKILL.md
@@ -10,7 +10,7 @@ description: Audit MCP Runtime Kubernetes posture — RBAC, ServiceAccounts, Pod
 Use this skill to assess MCP Runtime's cluster posture: RBAC graph, Pod
 Security Standards, NetworkPolicy enforcement, manifest hygiene, and CIS
 benchmark compliance. Findings use the shared template at
-`.codex/skills/_shared/FINDINGS-TEMPLATE.md`.
+`../_shared/FINDINGS-TEMPLATE.md`.
 
 For runtime authn/authz, gateway policy, and protocol fuzzing, use
 `security-audit-platform`. For images and supply chain, use
@@ -224,7 +224,7 @@ alpha project, Medium when targeting production.
 
 ## Step 9 — Report
 
-Use `.codex/skills/_shared/FINDINGS-TEMPLATE.md`. In the Summary include:
+Use `../_shared/FINDINGS-TEMPLATE.md`. In the Summary include:
 
 - Namespaces audited and their PSS levels.
 - ServiceAccount count and how many have `*` or cluster-scoped verbs.

--- a/.codex/skills/k8s-hardening-audit/evals/evals.json
+++ b/.codex/skills/k8s-hardening-audit/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "k8s-hardening-audit",
+  "evals": [
+    {
+      "id": "rbac-pss-networkpolicy-review",
+      "prompt": "Review the Kubernetes manifests I changed under k8s/ and config/ for RBAC, service account, pod security, and NetworkPolicy hardening gaps.",
+      "expected_output": "A Kubernetes hardening review that inventories affected namespaces and resources, checks RBAC/PSS/NetworkPolicy/securityContext/secret access, and reports concrete findings with file references.",
+      "assertions": [
+        "Mentions RBAC, Pod Security Standards, NetworkPolicies, securityContext, and secret access",
+        "Uses ../_shared/FINDINGS-TEMPLATE.md for findings",
+        "Separates skipped live-cluster checks from completed static checks"
+      ]
+    },
+    {
+      "id": "cluster-cis-posture",
+      "prompt": "Run a cluster hardening sweep on the contributor Kind cluster and tell me whether our namespaces still meet the expected security posture.",
+      "expected_output": "A live-cluster posture report that confirms the current context, runs Kubernetes inventory and CIS-relevant checks, and records any environment blockers explicitly.",
+      "assertions": [
+        "Confirms the target cluster before live checks",
+        "Includes namespace-scoped posture results",
+        "Records commands run and checks skipped"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/k8s-hardening-audit/evals/trigger_queries.json
+++ b/.codex/skills/k8s-hardening-audit/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "k8s-hardening-audit",
+  "queries": [
+    {
+      "query": "Audit the RBAC, service accounts, pod security labels, and NetworkPolicies in k8s/ after this manifest change.",
+      "should_trigger": true
+    },
+    {
+      "query": "Do a Kubernetes hardening review of the live contributor cluster namespaces.",
+      "should_trigger": true
+    },
+    {
+      "query": "Check if this Go handler validates request JSON correctly.",
+      "should_trigger": false
+    },
+    {
+      "query": "Update the docs for the setup command flags.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/mcp-spec-compliance/SKILL.md
+++ b/.codex/skills/mcp-spec-compliance/SKILL.md
@@ -103,8 +103,8 @@ grep -rIn 'DefaultProtocolVersion\|protocolVersion\|Mcp-Protocol-Version\|MCP-Pr
   -- internal/ services/ examples/ docs/ pkg/ cmd/
 
 # Streamable HTTP transport contract in the gateway:
-sed -n '1,$p' services/mcp-proxy/rpc.go services/mcp-proxy/proxy.go \
-  services/mcp-proxy/types.go 2>/dev/null | grep -nE \
+sed -n '1,$p' services/mcp-gateway/rpc.go services/mcp-gateway/proxy.go \
+  services/mcp-gateway/types.go 2>/dev/null | grep -nE \
   'jsonrpc|method|Mcp-Session-Id|content-type|text/event-stream|application/json|notifications/initialized|tools/(list|call)|initialize'
 
 # Agent adapter (stdio <-> HTTP shim) protocol surface.
@@ -170,7 +170,7 @@ done
 echo "Schema validation: $fail invalid envelopes"
 ```
 
-Any **invalid** envelope in `services/mcp-proxy/`, `examples/`, or
+Any **invalid** envelope in `services/mcp-gateway/`, `examples/`, or
 `internal/agentadapter/` is a finding (the runtime is emitting / asserting
 non-spec shapes). Invalid envelopes in `test/golden/`, `test/integration/`,
 or e2e fixtures are findings on the test, not the runtime, but track them
@@ -213,7 +213,7 @@ for cap in $caps; do
 done
 ```
 
-Cross-check: any method the gateway forwards (`services/mcp-proxy/rpc.go`
+Cross-check: any method the gateway forwards (`services/mcp-gateway/rpc.go`
 method allow-list) that is **not** present in `initialize.capabilities`
 should be flagged — the gateway should not encourage clients to call a
 capability the server did not advertise.

--- a/.codex/skills/mcp-spec-compliance/SKILL.md
+++ b/.codex/skills/mcp-spec-compliance/SKILL.md
@@ -26,6 +26,12 @@ Goals:
 - Distinguish "spec says X, runtime does X" from "spec says X, runtime does Y"
   from "spec is silent, runtime does Y by choice."
 
+Regression evidence contract: static schema/code checks are only half of this
+skill. For protocol-affecting changes, run live `initialize`, positive
+`tools/call`, and malformed/unsupported-version negative cases against the Kind
+cluster. If upstream fetch or live transport checks cannot run, report the
+result **blocked** for that surface.
+
 Non-goals:
 
 - Auth/grant/session policy enforcement → `qa-e2e-security`.

--- a/.codex/skills/mcp-spec-compliance/SKILL.md
+++ b/.codex/skills/mcp-spec-compliance/SKILL.md
@@ -172,157 +172,16 @@ either way.
 
 ## Step 5 — Live transport conformance (against the Kind cluster)
 
-Precondition: `qa-cluster-bringup` has run, port-forward is up, demo server
-deployed with a valid grant/session.
+Precondition: `qa-cluster-bringup` has run, port-forward is up, and a demo
+server is deployed with a valid grant/session. For this dynamic portion, read
+`references/live-conformance.md` and run its sub-suite exactly:
 
-```bash
-kubectl config current-context | grep -qx kind-mcp-runtime \
-  || { echo "Run qa-cluster-bringup first"; exit 1; }
-BASE=http://localhost:18080/go-example-mcp/mcp
-PROTO="$SPEC_REV"
-H=(-H "content-type: application/json"
-   -H "accept: application/json, text/event-stream"
-   -H "Mcp-Protocol-Version: $PROTO"
-   -H "X-MCP-Human-ID: local-user"
-   -H "X-MCP-Agent-ID: local-agent"
-   -H "X-MCP-Agent-Session: local-session")
-```
-
-### 5a. `initialize` response conformance
-
-```bash
-MCP_SPEC_TMP="${MCP_SPEC_TMP:-$(mktemp -d)}"
-trap 'rm -rf "$MCP_SPEC_TMP"' EXIT
-INIT="$(curl -sS "${H[@]}" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
-        "protocolVersion":"'"$PROTO"'",
-        "capabilities":{},
-        "clientInfo":{"name":"qa-spec-compliance","version":"0"}}}' "$BASE")"
-echo "$INIT" | jq .
-echo "$INIT" > "$MCP_SPEC_TMP/mcp-init.json"
-"$JV" "$SCHEMA" "$MCP_SPEC_TMP/mcp-init.json" 2>&1 | head -10
-
-# Required fields per spec lifecycle: protocolVersion, capabilities, serverInfo.
-echo "$INIT" | jq -e '.result.protocolVersion == "'"$PROTO"'"' >/dev/null \
-  || echo "FAIL: server did not echo or downgrade protocolVersion correctly"
-echo "$INIT" | jq -e '.result.capabilities | type == "object"' >/dev/null \
-  || echo "FAIL: capabilities missing or wrong type"
-echo "$INIT" | jq -e '.result.serverInfo.name and .result.serverInfo.version' >/dev/null \
-  || echo "FAIL: serverInfo missing name/version"
-```
-
-### 5b. Streamable HTTP transport headers
-
-```bash
-# Mcp-Session-Id MUST be issued on initialize when the server is stateful
-# (per Streamable HTTP). Capture and re-use; verify it survives one round-trip.
-SESSION="$(curl -si "${H[@]}" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{
-        "protocolVersion":"'"$PROTO"'","capabilities":{},
-        "clientInfo":{"name":"qa","version":"0"}}}' "$BASE" \
-  | awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' | tr -d '\r')"
-[ -n "$SESSION" ] || echo "FAIL: server did not issue Mcp-Session-Id"
-
-# Content-Type negotiation: JSON request should get JSON response by default;
-# event-stream only when server elects to stream.
-curl -sSI "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' "$BASE" \
-  | tr -d '\r' | grep -iE '^Content-Type:' | head -1
-
-# DELETE on the MCP endpoint terminates the session (per Streamable HTTP).
-# A subsequent request with the same session MUST fail.
-curl -sS -X DELETE "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -o "$MCP_SPEC_TMP/del.out" -w "delete=%{http_code}\n" "$BASE"
-curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -d '{"jsonrpc":"2.0","id":99,"method":"tools/list"}' "$BASE" \
-  | grep -qiE 'error|session|invalid' \
-  || echo "FAIL: session reuse after DELETE was accepted"
-```
-
-If `DELETE` returns 405 or the server silently accepts post-DELETE calls,
-that is a transport-spec violation. If the runtime intentionally treats
-`Mcp-Session-Id` as platform-governance only (decoupled from MCP protocol
-session), record that as an **intentional deviation** in the report and link
-to the design rationale in code/docs — do not flag it as a bug without
-context.
-
-### 5c. `tools/list` shape
-
-```bash
-TOOLS="$(curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}' "$BASE")"
-echo "$TOOLS" | jq -e '.result.tools | type == "array" and length > 0' >/dev/null \
-  || echo "FAIL: tools/list missing or empty"
-echo "$TOOLS" | jq -e '.result.tools | all(.name and (.inputSchema | type == "object"))' >/dev/null \
-  || echo "FAIL: tool entry missing required name or inputSchema"
-echo "$TOOLS" > "$MCP_SPEC_TMP/mcp-tools.json"
-"$JV" "$SCHEMA" "$MCP_SPEC_TMP/mcp-tools.json" 2>&1 | head -10
-```
-
-### 5d. `tools/call` result envelope
-
-```bash
-CALL="$(curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call",
-       "params":{"name":"add","arguments":{"a":2,"b":3}}}' "$BASE")"
-echo "$CALL" | jq -e '.result.content | type == "array"' >/dev/null \
-  || echo "FAIL: tools/call result.content must be array"
-echo "$CALL" | jq -e '.result.content[0].type and .result.content[0].text != null' >/dev/null \
-  || echo "FAIL: content[0] missing required type/text"
-echo "$CALL" > "$MCP_SPEC_TMP/mcp-call.json"
-"$JV" "$SCHEMA" "$MCP_SPEC_TMP/mcp-call.json" 2>&1 | head -10
-```
-
-### 5e. JSON-RPC error mapping
-
-The spec inherits JSON-RPC 2.0 error codes (`-32700`/`-32600`/`-32601`/`-32602`/`-32603`)
-and adds MCP-specific application errors. Probe each:
-
-```bash
-# Parse error: invalid JSON.
-curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  --data-binary '{not json' "$BASE" \
-  | jq -e '.error.code == -32700' >/dev/null \
-  || echo "FAIL: parse error should map to -32700"
-
-# Method not found.
-curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -d '{"jsonrpc":"2.0","id":5,"method":"definitely/not/a/method"}' "$BASE" \
-  | jq -e '.error.code == -32601' >/dev/null \
-  || echo "FAIL: unknown method should map to -32601"
-
-# Invalid params (tool exists, wrong args).
-curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
-  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call",
-       "params":{"name":"add","arguments":{"a":"not-a-number"}}}' "$BASE" \
-  | jq -e '.error.code == -32602 or (.result.isError == true)' >/dev/null \
-  || echo "FAIL: invalid params should map to -32602 or isError result"
-```
-
-MCP allows tool-execution errors to surface either as a top-level
-`error.code` or as `result.isError=true` with content; both shapes are
-spec-legal but should be **consistent** for a given runtime. Flag any tool
-that mixes both for similar failure modes.
-
-### 5f. Protocol-version negotiation
-
-```bash
-# Unsupported version: the server SHOULD respond with a version it supports,
-# not echo the unsupported one.
-RESP="$(curl -sS "${H[@]/Mcp-Protocol-Version: $PROTO/Mcp-Protocol-Version: 1999-01-01}" \
-  -d '{"jsonrpc":"2.0","id":7,"method":"initialize","params":{
-        "protocolVersion":"1999-01-01","capabilities":{},
-        "clientInfo":{"name":"qa","version":"0"}}}' "$BASE")"
-echo "$RESP" | jq -e '.result.protocolVersion != "1999-01-01"' >/dev/null \
-  || echo "FAIL: server echoed unsupported protocolVersion"
-
-# Missing header: behavior is implementation-defined; record what the runtime
-# does so docs and clients stay aligned.
-curl -sS -H "content-type: application/json" -H "accept: application/json, text/event-stream" \
-  -d '{"jsonrpc":"2.0","id":8,"method":"initialize","params":{
-        "protocolVersion":"'"$PROTO"'","capabilities":{},
-        "clientInfo":{"name":"qa","version":"0"}}}' "$BASE" | jq -e '.result // .error' >/dev/null
-```
+- initialize response conformance
+- Streamable HTTP headers and `Mcp-Session-Id`
+- `tools/list` shape
+- `tools/call` result envelope
+- JSON-RPC error mapping
+- protocol-version negotiation
 
 ## Step 6 — Capability advertisement vs implementation
 
@@ -431,7 +290,7 @@ echo "Draft-schema validation failures: $fail (informational)"
 
 ## Step 10 — Severity rubric (compliance-specific)
 
-Map findings to `_shared/FINDINGS-TEMPLATE.md` severities using this
+Map findings to `../_shared/FINDINGS-TEMPLATE.md` severities using this
 domain-specific rubric. Pick the highest that applies:
 
 - **Critical** — Runtime claims protocol version X, but a conforming X
@@ -453,7 +312,7 @@ domain-specific rubric. Pick the highest that applies:
 
 ## Step 11 — Report
 
-Use the structure in `_shared/FINDINGS-TEMPLATE.md`. The report header must
+Use the structure in `../_shared/FINDINGS-TEMPLATE.md`. The report header must
 state the pinned spec revision, the upstream `SPEC_REF` and commit SHA used
 for the fetch, and the runtime commit SHA under audit — none of those
 findings are interpretable without that triple.

--- a/.codex/skills/mcp-spec-compliance/evals/evals.json
+++ b/.codex/skills/mcp-spec-compliance/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "mcp-spec-compliance",
+  "evals": [
+    {
+      "id": "protocol-version-bump",
+      "prompt": "Validate whether MCP Runtime still conforms to the upstream MCP spec after we changed the protocol version constant.",
+      "expected_output": "A spec compliance audit that pins SPEC_REV/SPEC_REF, fetches upstream schema/spec artifacts, inventories runtime claims, runs static schema checks, and runs live transport probes when the Kind cluster is available.",
+      "assertions": [
+        "States the spec revision and upstream ref under audit",
+        "Reads references/live-conformance.md for live transport probes",
+        "Reports findings against ../_shared/FINDINGS-TEMPLATE.md"
+      ]
+    },
+    {
+      "id": "streamable-http-conformance",
+      "prompt": "Check the gateway against Streamable HTTP requirements: initialize, Mcp-Session-Id, content negotiation, tools/list, tools/call, and JSON-RPC errors.",
+      "expected_output": "A live MCP transport conformance report with command evidence for initialize, headers/session behavior, tools/list, tools/call, error mapping, and protocol negotiation.",
+      "assertions": [
+        "Uses the live Kind precondition from the skill",
+        "Captures command evidence for each transport sub-suite",
+        "Distinguishes intentional deviations from runtime bugs"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/mcp-spec-compliance/evals/trigger_queries.json
+++ b/.codex/skills/mcp-spec-compliance/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "mcp-spec-compliance",
+  "queries": [
+    {
+      "query": "Validate MCP Runtime against the upstream MCP protocol revision and Streamable HTTP transport requirements.",
+      "should_trigger": true
+    },
+    {
+      "query": "We changed the protocolVersion constant; compare runtime behavior against the MCP spec schema.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run a security check for API key authorization and audit logs.",
+      "should_trigger": false
+    },
+    {
+      "query": "Perf test tools/call latency under concurrent load.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/mcp-spec-compliance/references/live-conformance.md
+++ b/.codex/skills/mcp-spec-compliance/references/live-conformance.md
@@ -1,0 +1,139 @@
+# Live MCP Transport Conformance
+
+Use this reference only for Step 5 of `mcp-spec-compliance`, after the static
+schema checks have identified `SPEC_REV`, `SCHEMA`, `JV`, and `SPEC_CACHE`.
+
+Precondition: `qa-cluster-bringup` has run, port-forward is up, and a demo
+server is deployed with a valid grant/session.
+
+```bash
+kubectl config current-context | grep -qx kind-mcp-runtime \
+  || { echo "Run qa-cluster-bringup first"; exit 1; }
+BASE=http://localhost:18080/go-example-mcp/mcp
+PROTO="$SPEC_REV"
+H=(-H "content-type: application/json"
+   -H "accept: application/json, text/event-stream"
+   -H "Mcp-Protocol-Version: $PROTO"
+   -H "X-MCP-Human-ID: local-user"
+   -H "X-MCP-Agent-ID: local-agent"
+   -H "X-MCP-Agent-Session: local-session")
+MCP_SPEC_TMP="${MCP_SPEC_TMP:-$(mktemp -d)}"
+trap 'rm -rf "$MCP_SPEC_TMP"' EXIT
+```
+
+## initialize response
+
+```bash
+INIT="$(curl -sS "${H[@]}" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+        "protocolVersion":"'"$PROTO"'",
+        "capabilities":{},
+        "clientInfo":{"name":"qa-spec-compliance","version":"0"}}}' "$BASE")"
+echo "$INIT" | jq .
+echo "$INIT" > "$MCP_SPEC_TMP/mcp-init.json"
+"$JV" "$SCHEMA" "$MCP_SPEC_TMP/mcp-init.json" 2>&1 | head -10
+
+echo "$INIT" | jq -e '.result.protocolVersion == "'"$PROTO"'"' >/dev/null \
+  || echo "FAIL: server did not echo or downgrade protocolVersion correctly"
+echo "$INIT" | jq -e '.result.capabilities | type == "object"' >/dev/null \
+  || echo "FAIL: capabilities missing or wrong type"
+echo "$INIT" | jq -e '.result.serverInfo.name and .result.serverInfo.version' >/dev/null \
+  || echo "FAIL: serverInfo missing name/version"
+```
+
+## Streamable HTTP headers
+
+```bash
+SESSION="$(curl -si "${H[@]}" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{
+        "protocolVersion":"'"$PROTO"'","capabilities":{},
+        "clientInfo":{"name":"qa","version":"0"}}}' "$BASE" \
+  | awk -F': ' 'tolower($1)=="mcp-session-id"{print $2}' | tr -d '\r')"
+[ -n "$SESSION" ] || echo "FAIL: server did not issue Mcp-Session-Id"
+
+curl -sSI "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' "$BASE" \
+  | tr -d '\r' | grep -iE '^Content-Type:' | head -1
+
+curl -sS -X DELETE "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -o "$MCP_SPEC_TMP/del.out" -w "delete=%{http_code}\n" "$BASE"
+curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":99,"method":"tools/list"}' "$BASE" \
+  | grep -qiE 'error|session|invalid' \
+  || echo "FAIL: session reuse after DELETE was accepted"
+```
+
+If `DELETE` returns 405 or the server accepts post-DELETE calls, record a
+transport-spec violation unless the runtime intentionally decouples
+`Mcp-Session-Id` from platform governance sessions and documents that choice.
+
+## tools/list shape
+
+```bash
+TOOLS="$(curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}' "$BASE")"
+echo "$TOOLS" | jq -e '.result.tools | type == "array" and length > 0' >/dev/null \
+  || echo "FAIL: tools/list missing or empty"
+echo "$TOOLS" | jq -e '.result.tools | all(.name and (.inputSchema | type == "object"))' >/dev/null \
+  || echo "FAIL: tool entry missing required name or inputSchema"
+echo "$TOOLS" > "$MCP_SPEC_TMP/mcp-tools.json"
+"$JV" "$SCHEMA" "$MCP_SPEC_TMP/mcp-tools.json" 2>&1 | head -10
+```
+
+## tools/call result envelope
+
+```bash
+CALL="$(curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call",
+       "params":{"name":"add","arguments":{"a":2,"b":3}}}' "$BASE")"
+echo "$CALL" | jq -e '.result.content | type == "array"' >/dev/null \
+  || echo "FAIL: tools/call result.content must be array"
+echo "$CALL" | jq -e '.result.content[0].type and .result.content[0].text != null' >/dev/null \
+  || echo "FAIL: content[0] missing required type/text"
+echo "$CALL" > "$MCP_SPEC_TMP/mcp-call.json"
+"$JV" "$SCHEMA" "$MCP_SPEC_TMP/mcp-call.json" 2>&1 | head -10
+```
+
+## JSON-RPC error mapping
+
+The spec inherits JSON-RPC 2.0 error codes
+`-32700`/`-32600`/`-32601`/`-32602`/`-32603` and adds MCP-specific application
+errors.
+
+```bash
+curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  --data-binary '{not json' "$BASE" \
+  | jq -e '.error.code == -32700' >/dev/null \
+  || echo "FAIL: parse error should map to -32700"
+
+curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"definitely/not/a/method"}' "$BASE" \
+  | jq -e '.error.code == -32601' >/dev/null \
+  || echo "FAIL: unknown method should map to -32601"
+
+curl -sS "${H[@]}" -H "Mcp-Session-Id: $SESSION" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call",
+       "params":{"name":"add","arguments":{"a":"not-a-number"}}}' "$BASE" \
+  | jq -e '.error.code == -32602 or (.result.isError == true)' >/dev/null \
+  || echo "FAIL: invalid params should map to -32602 or isError result"
+```
+
+MCP allows tool-execution errors to surface either as a top-level `error.code`
+or as `result.isError=true` with content; both shapes are spec-legal but should
+be consistent for similar failure modes.
+
+## Protocol-version negotiation
+
+```bash
+RESP="$(curl -sS "${H[@]/Mcp-Protocol-Version: $PROTO/Mcp-Protocol-Version: 1999-01-01}" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"initialize","params":{
+        "protocolVersion":"1999-01-01","capabilities":{},
+        "clientInfo":{"name":"qa","version":"0"}}}' "$BASE")"
+echo "$RESP" | jq -e '.result.protocolVersion != "1999-01-01"' >/dev/null \
+  || echo "FAIL: server echoed unsupported protocolVersion"
+
+curl -sS -H "content-type: application/json" -H "accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":8,"method":"initialize","params":{
+        "protocolVersion":"'"$PROTO"'","capabilities":{},
+        "clientInfo":{"name":"qa","version":"0"}}}' "$BASE" | jq -e '.result // .error' >/dev/null
+```

--- a/.codex/skills/qa-cluster-bringup/SKILL.md
+++ b/.codex/skills/qa-cluster-bringup/SKILL.md
@@ -15,6 +15,12 @@ and Sentinel stack, deploys the bundled Go MCP server, applies a working
 grant + session, and exits only after a real MCP `tools/call` succeeds through
 Traefik.
 
+Regression evidence contract: this skill is not successful until it records a
+live cluster context, image/build inputs, rollout health, and a real MCP
+`tools/call` result through the public ingress path. If any live gate cannot
+run, report **blocked** with the failing command; do not downgrade to unit tests
+or static checks.
+
 Default policy: **reuse if present, create if missing.** Never tear down an
 existing `kind-mcp-runtime` cluster without explicit user confirmation —
 contributors may have in-flight work on it.

--- a/.codex/skills/qa-cluster-bringup/evals/evals.json
+++ b/.codex/skills/qa-cluster-bringup/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "qa-cluster-bringup",
+  "evals": [
+    {
+      "id": "recover-existing-kind-cluster",
+      "prompt": "Prepare the contributor Kind cluster for e2e QA. Reuse the existing mcp-runtime cluster if it is healthy.",
+      "expected_output": "A cluster bring-up or recovery flow that checks host tools, reuses healthy kind-mcp-runtime, builds the CLI, verifies platform health, exposes ingress, deploys the Go example, applies a grant/session, and gates on a real tools/call.",
+      "assertions": [
+        "Does not delete an existing cluster without explicit approval",
+        "Runs the real MCP traffic gate before declaring success",
+        "Reports cluster, registry, and port-forward state"
+      ]
+    },
+    {
+      "id": "fresh-test-mode-cluster",
+      "prompt": "Create a fresh Kind test-mode MCP Runtime cluster and make it ready for qa-e2e-ui and qa-e2e-security.",
+      "expected_output": "A fresh-cluster setup flow following docs/getting-started.md that installs test mode and exits only after platform and MCP smoke checks pass.",
+      "assertions": [
+        "Uses the documented Kind cluster name and context",
+        "Runs setup --test-mode with the ingress manifest",
+        "Hands off readiness evidence to downstream qa-e2e-* skills"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/qa-cluster-bringup/evals/trigger_queries.json
+++ b/.codex/skills/qa-cluster-bringup/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "qa-cluster-bringup",
+  "queries": [
+    {
+      "query": "Stand up the Kind test-mode MCP Runtime cluster so the e2e skills can run.",
+      "should_trigger": true
+    },
+    {
+      "query": "Recover the contributor cluster and make sure a real MCP tools/call succeeds.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run a browser-only smoke test against the already running UI.",
+      "should_trigger": false
+    },
+    {
+      "query": "Audit Docker base images for CVEs.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-operations/SKILL.md
+++ b/.codex/skills/qa-e2e-operations/SKILL.md
@@ -15,6 +15,11 @@ not envtest. For code-level unit/golden/envtest checks the contributor should
 run `go test` directly per `CLAUDE.md` — this skill exists to catch the
 regressions those tests miss.
 
+Regression evidence contract: every successful report must include live
+`cluster doctor`, rollout/pod status, and the cached Kind `smoke-auth,governance`
+traffic gate unless the diff is explicitly docs-only. If the live cluster or
+traffic gate cannot run, mark the operations result **blocked**, not passed.
+
 ## Step 1 — Confirm precondition
 
 ```bash

--- a/.codex/skills/qa-e2e-operations/SKILL.md
+++ b/.codex/skills/qa-e2e-operations/SKILL.md
@@ -201,7 +201,7 @@ kubectl -n mcp-sentinel rollout status deploy/mcp-sentinel-api --timeout=90s
 
 ## Step 10 — Report
 
-Use the structure in `_shared/FINDINGS-TEMPLATE.md`. One row per command:
+Use the structure in `../_shared/FINDINGS-TEMPLATE.md`. One row per command:
 pass/fail, duration when interesting, the failure line if it failed.
 
 - Lead with mode (head-only | git-range BASE=<sha>), cluster context, commit

--- a/.codex/skills/qa-e2e-operations/SKILL.md
+++ b/.codex/skills/qa-e2e-operations/SKILL.md
@@ -44,7 +44,7 @@ Mode dispatch by changed paths:
 | `internal/operator/**`, `api/v1alpha1/**`, `config/crd/**` | Operator, CRD reconciliation, ingress, generated-file drift |
 | `cmd/operator/**`, `cmd/mcp-runtime/**`, `internal/cli/**` | CLI smoke, generated-file drift |
 | `internal/cli/setup/**`, `pkg/k8sclient/**`, `pkg/manifest/**`, `pkg/metadata/**` | Setup re-run, registry pulls, ingress, rollout |
-| `services/api/**`, `services/ui/**`, `services/ingest/**`, `services/processor/**`, `services/mcp-proxy/**` | Service rollout matrix, gateway sidecar refresh |
+| `services/api/**`, `services/ui/**`, `services/ingest/**`, `services/processor/**`, `services/mcp-gateway/**` | Service rollout matrix, gateway sidecar refresh |
 | `k8s/**`, `config/**` | Manifest re-apply + rollout |
 | `docs/**` only | Skip — not an operations regression surface |
 
@@ -54,7 +54,35 @@ Always include the **Baseline** suite below regardless of diff.
 git diff --name-only "${BASE:-origin/main}"...HEAD
 ```
 
-## Step 3 — Baseline (always run)
+## Step 3 — CI parity gate (pre-merge / release readiness)
+
+When the user asks for "all tests", "can this merge", or release readiness,
+run the CI-equivalent non-cluster checks before the live cluster matrix. Do not
+claim full regression coverage if any required CI parity check is skipped.
+
+```bash
+gofmt -s -l .
+go vet ./...
+staticcheck ./...
+go test -race -count=1 $(go list ./... | grep -v '/test/integration$')
+
+for d in services/api services/ingest services/processor services/mcp-gateway services/ui; do
+  (cd "$d" && go test -race -count=1 ./...)
+done
+
+go test ./test/golden/... -count=1
+go test -run=^$ -bench=. -benchmem -count=1 ./test/benchmark/...
+bash test/e2e/scenarios_test.sh
+
+export KUBEBUILDER_ASSETS="${KUBEBUILDER_ASSETS:-$(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.24.0 use -p path)}"
+go test -race -timeout 30m -count=1 ./test/integration/...
+
+make -f Makefile.operator generate manifests
+python3 docs/scripts/generate_go_package_reference.py
+git diff --exit-code
+```
+
+## Step 4 — Baseline (always run)
 
 ```bash
 ./bin/mcp-runtime status
@@ -73,11 +101,18 @@ E2E_CACHE_MODE=1 E2E_KEEP_CLUSTER=1 CLUSTER_NAME=mcp-runtime \
   E2E_SCENARIOS=smoke-auth,governance bash test/e2e/kind.sh
 ```
 
+For merge readiness after non-doc code changes, also run or verify CI ran the
+full Kind matrix:
+
+```bash
+E2E_SCENARIOS=all bash test/e2e/kind.sh
+```
+
 Reusing the contributor cluster is intentional — `CLAUDE.md` documents that
 `CLUSTER_NAME=mcp-runtime E2E_CACHE_MODE=1 E2E_KEEP_CLUSTER=1` avoids
 creating a duplicate `mcp-e2e` cluster.
 
-## Step 4 — Operator + CRD reconciliation
+## Step 5 — Operator + CRD reconciliation
 
 ```bash
 # Apply an MCPServer change and watch it converge.
@@ -105,7 +140,7 @@ kubectl apply -f /tmp/go-example-access.yaml
   | grep -q local-session || echo "FAIL: policy missing session"
 ```
 
-## Step 5 — CLI smoke + help drift
+## Step 6 — CLI smoke + help drift
 
 Real-cluster CLI behavior (the unit golden suite covers help text — this is
 about behavior).
@@ -128,7 +163,7 @@ Any error that prints a bare Cobra usage dump (no `Error:` framing) is a
 finding; route the report back to `internal/cli/core/errors.go` and
 `pkg/errx/`.
 
-## Step 6 — Setup / registry / ingress regression (only when those areas changed)
+## Step 7 — Setup / registry / ingress regression (only when those areas changed)
 
 ```bash
 # Re-run setup in place (test-mode is idempotent; this catches drift).
@@ -147,7 +182,7 @@ If image pulls fail with `http: server gave HTTP response to HTTPS client`,
 the Kind containerd mirror is missing — that is itself a regression in the
 setup output, not a host issue.
 
-## Step 7 — Service rollout matrix (when services/**/ changed)
+## Step 8 — Service rollout matrix (when services/**/ changed)
 
 For each touched Sentinel service, follow the contributor iterate-on-one
 loop from `docs/getting-started.md#iterate-on-one-sentinel-service`:
@@ -171,21 +206,22 @@ kubectl -n mcp-sentinel set image "deployment/$DEPLOYMENT" \
 kubectl -n mcp-sentinel rollout status "deployment/$DEPLOYMENT" --timeout=120s
 ```
 
-For `services/mcp-proxy/**` changes, also update operator env
+For `services/mcp-gateway/**` changes, also update operator env
 `MCP_GATEWAY_PROXY_IMAGE` and restart the operator (`CLAUDE.md` step under
 **Iterate on one Sentinel service**); then recreate the MCP server pod to
 refresh the sidecar image.
 
-## Step 8 — Generated-file drift
+## Step 9 — Generated-file drift
 
 Drift is a behavioral regression even if unit tests pass.
 
 ```bash
-make generate manifests
-git diff --exit-code api/ config/crd/bases/ || echo "FAIL: regen drift"
+make -f Makefile.operator generate manifests
+python3 docs/scripts/generate_go_package_reference.py
+git diff --exit-code api/ config/crd/bases/ docs/internals/ || echo "FAIL: regen drift"
 ```
 
-## Step 9 — Chaos canary (release-readiness only)
+## Step 10 — Chaos canary (release-readiness only)
 
 Only when explicitly QAing release readiness:
 
@@ -204,7 +240,7 @@ kubectl -n mcp-sentinel rollout status deploy/mcp-sentinel-api --timeout=90s
   | grep -q local-session
 ```
 
-## Step 10 — Report
+## Step 11 — Report
 
 Use the structure in `../_shared/FINDINGS-TEMPLATE.md`. One row per command:
 pass/fail, duration when interesting, the failure line if it failed.

--- a/.codex/skills/qa-e2e-operations/evals/evals.json
+++ b/.codex/skills/qa-e2e-operations/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "qa-e2e-operations",
+  "evals": [
+    {
+      "id": "cli-operator-change",
+      "prompt": "I changed internal/cli and internal/operator code. Verify the live Kind cluster still handles CLI flows, setup assumptions, and reconciliation.",
+      "expected_output": "An operations regression report that confirms qa-cluster-bringup preconditions, chooses the right mode, runs baseline status/doctor/e2e checks, and scopes additional CLI/operator checks to the diff.",
+      "assertions": [
+        "Runs or explicitly skips cached smoke-auth/governance e2e with a reason",
+        "Includes CLI smoke and help drift checks",
+        "Reports each command as pass/fail/skipped"
+      ]
+    },
+    {
+      "id": "service-rollout-regression",
+      "prompt": "Check whether a services/api change regressed rollout health, ingress wiring, or observability in the contributor cluster.",
+      "expected_output": "A live operations QA pass covering platform status, rollout matrix, ingress routes, service logs, and relevant e2e paths for the touched service.",
+      "assertions": [
+        "Verifies rollout readiness for touched services",
+        "Checks ingress and platform status evidence",
+        "Does not reinstall the cluster unless required by the selected mode"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-operations/evals/trigger_queries.json
+++ b/.codex/skills/qa-e2e-operations/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "qa-e2e-operations",
+  "queries": [
+    {
+      "query": "Verify this operator and CLI change does not regress setup, reconciliation, registry, or rollout behavior.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run live-cluster operational QA for ingress wiring and component rollout health.",
+      "should_trigger": true
+    },
+    {
+      "query": "Check whether the UI API Keys tab loads in the browser.",
+      "should_trigger": false
+    },
+    {
+      "query": "Validate MCP JSON-RPC error codes against the protocol spec.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-perf/SKILL.md
+++ b/.codex/skills/qa-e2e-perf/SKILL.md
@@ -17,6 +17,12 @@ Numbers measured on a Kind cluster are not production numbers. The point is
 **relative**: did this branch regress vs `main` or vs the last recorded
 baseline.
 
+Regression evidence contract: do not report a perf pass from a single request
+or current-branch-only sample. A pass requires baseline comparison, warmup,
+scenario sample counts, p50/p95/p99, and the configured regression threshold;
+missing baseline or live cluster access is **blocked** unless the user accepts
+baseline creation as the task.
+
 ## Step 1 — Confirm precondition
 
 ```bash

--- a/.codex/skills/qa-e2e-perf/SKILL.md
+++ b/.codex/skills/qa-e2e-perf/SKILL.md
@@ -49,7 +49,7 @@ kubectl -n mcp-sentinel get deploy -o jsonpath='{range .items[*]}{.metadata.name
 
 | Diff touches | Scenarios to run |
 |---|---|
-| `services/mcp-proxy/**`, `pkg/access/**` | S1, S2 (gateway hot path) |
+| `services/mcp-gateway/**`, `pkg/access/**` | S1, S2 (gateway hot path) |
 | `internal/operator/**` | S4 (reconcile burst) |
 | `services/api/**`, `services/processor/**`, `services/ingest/**` | S3 (analytics) |
 | `services/ui/**` static only | Skip — UI is not the hot path |
@@ -238,7 +238,7 @@ kubectl logs -n mcp-sentinel deploy/mcp-sentinel-processor --since=2m | tail -40
 ```
 
 Record the suspected hot path with file:line references in
-`services/mcp-proxy/**`, `pkg/access/**`, `services/api/**`, or
+`services/mcp-gateway/**`, `pkg/access/**`, `services/api/**`, or
 `internal/operator/**` based on which scenario regressed.
 
 ## Step 10 — Report

--- a/.codex/skills/qa-e2e-perf/evals/evals.json
+++ b/.codex/skills/qa-e2e-perf/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "qa-e2e-perf",
+  "evals": [
+    {
+      "id": "gateway-latency-regression",
+      "prompt": "This gateway change feels slower. Run the real-cluster performance regression matrix and compare it to the stored baseline.",
+      "expected_output": "A performance report with p50/p95/p99 tools/call latency, concurrent throughput, analytics latency, operator burst reconcile timing, and baseline deltas.",
+      "assertions": [
+        "Confirms qa-cluster-bringup preconditions",
+        "Compares p95 against the configured regression threshold",
+        "Stores or updates baseline only when explicitly appropriate"
+      ]
+    },
+    {
+      "id": "api-analytics-hot-path",
+      "prompt": "Perf-check the /api/analytics/usage path under load after this API change.",
+      "expected_output": "A scoped perf pass that runs the analytics latency scenario, records sample counts and p95, and flags regressions above threshold.",
+      "assertions": [
+        "Runs the analytics scenario against the live cluster",
+        "Reports baseline, current, and delta",
+        "Identifies likely hot path files when a regression fires"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-perf/evals/trigger_queries.json
+++ b/.codex/skills/qa-e2e-perf/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "qa-e2e-perf",
+  "queries": [
+    {
+      "query": "Run the real-cluster performance regression matrix for gateway tools/call latency and throughput.",
+      "should_trigger": true
+    },
+    {
+      "query": "This API analytics endpoint feels slower; compare p95 against the stored baseline.",
+      "should_trigger": true
+    },
+    {
+      "query": "Check if API keys are hidden for static admin login.",
+      "should_trigger": false
+    },
+    {
+      "query": "Review Kubernetes RBAC for broad secret access.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-security/SKILL.md
+++ b/.codex/skills/qa-e2e-security/SKILL.md
@@ -309,7 +309,7 @@ done
 
 ## Step 12 — Report
 
-Use the rubric and template in `_shared/FINDINGS-TEMPLATE.md` exactly. Each
+Use the rubric and template in `../_shared/FINDINGS-TEMPLATE.md` exactly. Each
 finding should include:
 
 - The **trust boundary** it crosses (anon→user, user→admin, agent A→agent B,

--- a/.codex/skills/qa-e2e-security/SKILL.md
+++ b/.codex/skills/qa-e2e-security/SKILL.md
@@ -57,7 +57,7 @@ Sub-suites by changed paths:
 | Diff touches | Required sub-suites |
 |---|---|
 | `services/api/**`, `pkg/access/**` | A. Backend auth, B. Grants/sessions, C. Audit |
-| `services/mcp-proxy/**`, `internal/operator/**` (policy/render) | B. Grants/sessions, D. Trust escalation, C. Audit |
+| `services/mcp-gateway/**`, `internal/operator/**` (policy/render) | B. Grants/sessions, D. Trust escalation, C. Audit |
 | `services/ui/**` (middleware, login, proxy) | E. UI security headers, F. Login + lockout, G. UI→API proxy |
 | `config/ingress/**`, `services/traefik-plugins/**` | H. Ingress + PII redactor, E (re-run) |
 | `k8s/**` Secrets / SA / RBAC | Hand off to `k8s-hardening-audit` |
@@ -322,7 +322,7 @@ finding should include:
 - The **command + response code or body fragment** that demonstrates the
   failure (with secrets redacted).
 - A **regression test** suggestion that lands in `services/api/main_test.go`,
-  `services/ui/main_test.go`, `services/mcp-proxy/...`, or `pkg/access/...`.
+  `services/ui/main_test.go`, `services/mcp-gateway/...`, or `pkg/access/...`.
 
 Cross-link to `security-audit` / `security-audit-platform` for any static
 counterpart, to `k8s-hardening-audit` for cluster-policy gaps, and to

--- a/.codex/skills/qa-e2e-security/SKILL.md
+++ b/.codex/skills/qa-e2e-security/SKILL.md
@@ -23,6 +23,11 @@ Threat profiles in scope:
 - **internal pod → secret** (reach API/proxy/operator secrets unprivileged)
   → for cluster RBAC/PSS coverage, defer to `k8s-hardening-audit`.
 
+Regression evidence contract: for each touched security surface, capture at
+least one live allow path and one live deny path, plus audit/log/header evidence
+where that invariant applies. Static code review can explain a finding, but it
+cannot close this skill as passed.
+
 ## Step 1 — Confirm precondition
 
 ```bash

--- a/.codex/skills/qa-e2e-security/evals/evals.json
+++ b/.codex/skills/qa-e2e-security/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "qa-e2e-security",
+  "evals": [
+    {
+      "id": "auth-governance-regression",
+      "prompt": "Verify this auth/governance change did not regress backend auth, grants, sessions, gateway deny paths, or audit events.",
+      "expected_output": "A live security regression report that runs backend auth, grant/session gateway enforcement, audit emission, trust escalation, UI headers, proxy behavior, and log leak checks as warranted.",
+      "assertions": [
+        "Uses live traffic against the Kind cluster",
+        "Separates auth findings from feature-correctness findings",
+        "Uses ../_shared/FINDINGS-TEMPLATE.md for security-sensitive issues"
+      ]
+    },
+    {
+      "id": "ui-api-proxy-security",
+      "prompt": "Check whether a UI to API proxy change still protects admin routes, API keys, cookies, and auth headers.",
+      "expected_output": "A security regression pass focused on UI proxy auth forwarding, admin checks, security headers, login/lockout behavior, and secret leakage in logs.",
+      "assertions": [
+        "Checks browser-visible security behavior and direct HTTP evidence",
+        "Verifies no API keys or session cookies leak to logs or config",
+        "Records any skipped ingress or public-host checks"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-security/evals/trigger_queries.json
+++ b/.codex/skills/qa-e2e-security/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "qa-e2e-security",
+  "queries": [
+    {
+      "query": "Verify auth, grant/session policy, gateway deny paths, and audit events against the live Kind cluster.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run a real traffic security regression for UI headers, login lockout, and secret leaks in logs.",
+      "should_trigger": true
+    },
+    {
+      "query": "Create a Figma screen for the dashboard.",
+      "should_trigger": false
+    },
+    {
+      "query": "Run a full browser feature-correctness pass for every UI form and tab.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-ui/SKILL.md
+++ b/.codex/skills/qa-e2e-ui/SKILL.md
@@ -99,17 +99,13 @@ visible_assertions=<snapshot text or screenshot path>
 
 ## Step 4 - Required UI feature matrix
 
-The final report must include a matrix with this exact shape:
+The final report must include a feature matrix. For full UI audits, or for
+`git-range` audits touching a listed page, read
+`references/ui-coverage.md` and use its exact matrix shape and page checklist.
+Do not load that reference for a narrow smoke check unless a finding needs
+detailed page coverage.
 
-```text
-Page | Feature | Field/control | Action | Expected result | Actual result | Network/API evidence | Console evidence | Status
-```
-
-Use one row per meaningful capability. Do not collapse "Governance works" into
-one row; forms, filters, enable/disable, revoke/unrevoke, empty states, and
-error states are separate capabilities.
-
-Minimum pages:
+Minimum page categories for the full matrix:
 
 - Global App Shell
 - Authentication
@@ -123,330 +119,24 @@ Minimum pages:
 - Responsive / Accessibility
 - Public-host Defense, when applicable
 
-## Step 5 - Role and session flows
-
-Run these browser flows in order. Use the test-mode credentials only in local
-Kind test mode.
-
-Signed out:
-
-- Header shows product title and Sign In.
-- Catalog is visible.
-- Protected tabs/actions open auth modal and do not switch to protected data.
-- Namespace selector behavior matches platform mode.
-- No Google button appears when `MCP_GOOGLE_CLIENT_ID` is empty.
-
-Tenant user (`test@mcpruntime.org` / `test@123`):
-
-- Visible tabs: Server Catalog, My Activity, API Keys, Governance.
-- Hidden tabs: Dashboard, Operations, Platform.
-- Logout resets active tab and clears protected data.
-- A 401 from any UI API call resets auth state or shows a clear unauthorized
-  state without leaving mixed signed-in/signed-out controls.
-
-Admin (`admin@mcpruntime.org` / `admin@123`):
-
-- Visible tabs: Server Catalog, API Keys, Dashboard, Governance, Operations,
-  Platform.
-- Hidden tab fallback works after logout.
-- Auto-refresh starts only for admin dashboard and stops on logout.
-- Grafana and Prometheus header links appear only for admin in dev path mode.
-
-API-key login:
-
-- Retrieve the UI key only when needed and fail fast if it is missing:
-
-```bash
-UI_KEY="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.UI_API_KEY}' | base64 -d)"
-test -n "$UI_KEY" || { echo "FAIL: UI_API_KEY is empty"; exit 1; }
-```
-
-- Valid UI API key logs in as admin and clears the key input after success.
-- Invalid API key returns a visible error and does not clear the field until
-  the user edits it or retries.
-
-Negative auth cases:
-
-- blank form
-- email without password
-- password without email
-- invalid password
-- backend unavailable or network failure, if safely reproducible
-
-## Step 6 - Server Catalog coverage
-
-Drive this from the browser, then cross-check with CLI/Kubernetes.
-
-Namespace selector:
-
-- signed-out tenant mode
-- tenant aggregate catalog
-- user namespace
-- team namespace
-- shared/org namespace
-- admin namespace list
-- public preview namespace in public mode, if configured
-
-Catalog data and filters:
-
-- total servers, ready servers, tool count, publish quota
-- status filters: All, Ready, Issues
-- search by server name, namespace, description, endpoint, status
-- search by tools, prompts, resources, tasks
-- search by inventory labels and server labels
-- no-match state
-
-Server cards:
-
-- title, namespace, description, status, ready pods, endpoint
-- tool/prompt/resource/task counts
-- created date and labels
-- inventory details for string and object forms
-- access JSON / connect config
-- long names/descriptions/labels do not break layout
-
-Actions:
-
-- Details opens the detail panel and loads recent activity.
-- Copy URL and Copy JSON show success or fallback/error feedback.
-- Card Enter/Space selection works where the card is keyboard focusable.
-- Retire is tested only against a temporary `qa-audit-*` MCPServer.
-
-Retire flow:
-
-- Create or use only a `qa-audit-*` server.
-- Cancel leaves the server unchanged.
-- Confirm removes the server.
-- Detail panel resets after removal.
-- Tenant My Activity refreshes after tenant-owned retire, if tested.
-
-Cross-check:
-
-```bash
-./bin/mcp-runtime server list
-kubectl get mcpservers -A
-```
-
-Any UI/CLI count mismatch is a finding unless the UI label clearly describes a
-different metric, such as historical active servers.
-
-## Step 7 - My Activity coverage
-
-Tenant user only:
-
-- Metrics: My Servers, Ready, Requests, Denied, Deny Rate.
-- Deployed Servers table: identity, namespace, status, inventory, endpoint,
-  Analytics action, Copy URL, tenant Retire.
-- Usage controls: All servers, per-server selector, 24h/7d/30d/90d, Refresh.
-- Usage tables: per-server usage, top tools, recent activity.
-- Empty state: no personal servers.
-- Shared catalog servers are excluded from personal count.
-- Analytics empty response and API error render clear states.
-- If a selected server disappears, selector and tables recover cleanly.
-
-## Step 8 - API Keys coverage
-
-Table:
-
-- name, prefix, created timestamp, active/revoked state, revoke action.
-
-Create:
-
-- empty name validation produces visible feedback or native validation.
-- normal name
-- long name
-- special characters
-- duplicate-looking name
-- one-time key display
-- input clearing after success
-- list refresh preserves or intentionally clears the one-time key; record the
-  expected behavior from implementation.
-- automatic one-time key timeout, if implemented.
-
-Revoke:
-
-- modal cancel leaves row active.
-- modal confirm revokes row.
-- error toast or visible error on failed revoke.
-
-Cleanup:
-
-- Revoke all temporary `qa-audit-*` keys before finishing.
-
-## Step 9 - Admin Dashboard coverage
-
-Admin only:
-
-- Summary metrics: Total Events, Active Servers, Active Grants, Active Sessions.
-- Usage metrics: Events, Allowed, Denied, Humans, Agents, Allow Rate, Deny Rate.
-- Decision meter widths match allow/deny rates.
-- Row limit controls: Top 10, Top 25, Top 50.
-- Analytics tables: MCP Servers, Users & Agents, Tools, Decisions.
-- Decision Audit table: time/source/type, human, agent, server/namespace/action,
-  decision badge, policy reason/trust/session.
-- Auto-refresh enabled starts polling; disabled stops polling; logout stops it.
-- Non-admin never starts dashboard polling.
-- Empty/zero, allow-only, deny-only, mixed totals, malformed timestamps, and API
-  errors render usable states when safely reproducible.
-
-Cross-check dashboard current inventory metrics against:
-
-```bash
-./bin/mcp-runtime server list
-./bin/mcp-runtime access grant list --namespace mcp-servers
-./bin/mcp-runtime access session list --namespace mcp-servers
-```
-
-If dashboard metrics are historical rather than current, the UI label must make
-that clear.
-
-## Step 10 - Governance coverage
-
-Summary:
-
-- Active Grants, Disabled Grants, Active Sessions, Revoked Sessions.
-
-Grant list and filters:
-
-- name, namespace, server reference, server namespace fallback
-- human, agent, team, and combined subjects
-- max trust, allowed side effects, active/disabled state
-- filter by grant name, server, human ID, agent ID, team ID, no-match state
-
-Grant form validation:
-
-- missing name
-- missing server
-- no subject
-- no side effects
-- valid `tool:allow`
-- valid `tool:deny`
-- valid `tool:allow:medium`
-- valid tool name containing `:`
-- invalid decision
-- invalid trust
-- malformed line
-
-Grant actions:
-
-- create `qa-audit-*`
-- refresh
-- disable cancel/confirm
-- enable cancel/confirm
-- API error feedback
-- policy render cross-check:
-
-```bash
-./bin/mcp-runtime server policy inspect <server> --namespace <namespace>
-```
-
-Session form validation:
-
-- missing name
-- missing server
-- no subject
-- valid local datetime converted to UTC
-- invalid datetime
-- empty expiry allowed
-
-Session actions:
-
-- create `qa-audit-*`
-- refresh
-- revoke cancel/confirm
-- unrevoke cancel/confirm
-- API error feedback
-- policy/session cross-check:
-
-```bash
-./bin/mcp-runtime access session get <name> --namespace <namespace>
-kubectl get mcpagentsession <name> -n <namespace> -o yaml
-```
-
-## Step 11 - Operations coverage
-
-Admin only:
-
-- Summary metrics: MCP Servers, Ready, Issues, Recent Logins, Users, Images,
-  Deployments, MCP Events.
-- Filters: user/tenant, since datetime, until datetime, Apply, Clear, invalid
-  datetime behavior.
-- Logged-in Users table.
-- MCP Server Health table.
-- Activity Timeline table.
-- MCP Activity table.
-- Images and Deployments table, including long image refs.
-- MCP Server Inspector empty and selected states.
-
-Cross-check Operations server counts with:
-
-```bash
-./bin/mcp-runtime server list
-kubectl get mcpservers -A
-```
-
-Missing namespaces or stale server counts are product findings.
-
-## Step 12 - Platform coverage
-
-Admin only:
-
-- Platform Health component cards: display name, status, ready count, namespace,
-  resource/key, message.
-- Styling for Ready, Degraded, NotReady, unknown.
-- Fleet Health: total servers, ready servers, issues, server table.
-- Fleet empty/error states, if safely reproducible.
-- Component restart selector includes every restartable component documented by
-  the UI. If health shows Grafana/Prometheus but restart omits them, either the
-  UI copy must explain why or it is a finding.
-- Restart no-selection validation must show visible feedback.
-- Restart modal cancel works.
-- Confirm restart only for an explicitly safe temporary target or skip with a
-  documented reason.
-- Open Operations activates Operations and triggers data load.
-
-## Step 13 - Responsive and accessibility coverage
-
-Run at least:
-
-- desktop: 1200x900
-- mobile: 390x844
-
-Check:
-
-- no body-level horizontal overflow unless intentional and documented
-- tab bar scroll behavior on mobile
-- text does not overlap controls or table cells
-- modals fit viewport and remain keyboard usable
-- buttons, inputs, selects, tabs, and dialogs have accessible names/roles
-- Enter/Space work on keyboard-reachable actions
-- focus does not remain trapped in hidden modals after close
-
-Record accessibility snapshot evidence for each major tab.
-
-## Step 14 - Platform mode and extensibility passes
-
-When the task is a broad UI audit, cover:
-
-- tenant mode against current Kind
-- org mode through local UI-server config pass
-- public mode through local UI-server config pass
-
-Extensibility cases:
-
-- duplicate or empty namespace list
-- user, team, shared/org, and public preview namespaces
-- string vs object tools/prompts/resources/tasks
-- server labels and inventory labels
-- unknown status values
-- missing endpoint or missing access JSON
-- new component returned by API appears without code changes
-- platform JWT, UI API-key, OIDC/Google, and direct API-key clients
-
-If a mode or case cannot be exercised, mark it skipped with a reason and the
-command or fixture needed to cover it later.
-
-## Step 15 - Curl smoke and API contract evidence
+## Step 5 - Run role and page coverage
+
+Always use browser evidence for UI conclusions. In `full-ui`, work through the
+page checklist in `references/ui-coverage.md`. In `git-range`, load only the
+sections that match the diff plus Role And Session Flows. In `smoke`, cover:
+
+- dashboard load
+- signed-out protected-action behavior
+- one successful tenant-user or admin login
+- one UI-triggered API call with network evidence
+- one responsive viewport
+- console and failed-network sanity
+
+Create or mutate only temporary `qa-audit-*` objects for destructive actions.
+Record every skipped page/control with the reason and the fixture or cluster
+mode needed to cover it later.
+
+## Step 6 - Curl smoke and API contract evidence
 
 Use curl to support browser findings, not replace them.
 
@@ -455,25 +145,25 @@ Dashboard load:
 ```bash
 curl -sS -o "$QA_TMP/index.html" -w "%{http_code} %{size_download}\n" \
   http://localhost:18080/
-grep -q '<div id="app"' "$QA_TMP/index.html" || echo "FAIL: app root missing"
+grep -q 'Dashboard sections' "$QA_TMP/index.html" || echo "FAIL: dashboard shell missing"
 grep -q 'app.js' "$QA_TMP/index.html" || echo "FAIL: bundle script missing"
+grep -q 'config.js' "$QA_TMP/index.html" || echo "FAIL: config script missing"
 
-curl -sSI http://localhost:18080/static/app.js | tr -d '\r' \
+curl -sSI http://localhost:18080/app.js | tr -d '\r' \
   | grep -qiE '^Content-Type: (text|application)/javascript' \
   || echo "FAIL: app.js content-type"
 
-curl -sS http://localhost:18080/config | jq -e '.' >/dev/null \
-  || echo "FAIL: /config not JSON"
-curl -sS http://localhost:18080/config | jq -e \
-  '[paths(scalars) | join(".")] | map(test("api.?key";"i")) | any | not' \
-  >/dev/null || echo "FAIL: /config exposes an apiKey-shaped field"
+curl -sS http://localhost:18080/config.js | grep -q 'window.MCP_API_BASE' \
+  || echo "FAIL: /config.js missing MCP_API_BASE"
+curl -sS http://localhost:18080/config.js | grep -qi 'api.?key' \
+  && echo "FAIL: /config.js exposes an apiKey-shaped field"
 ```
 
 Static assets:
 
 ```bash
 node --check services/ui/static/app.js
-curl -sS -o "$QA_TMP/app.js" http://localhost:18080/static/app.js
+curl -sS -o "$QA_TMP/app.js" http://localhost:18080/app.js
 node --check "$QA_TMP/app.js"
 ```
 
@@ -481,7 +171,7 @@ Discover API routes from implementation and browser network traffic. Do not
 invent endpoints. If an endpoint path differs from the skill examples, record
 the live route in the report.
 
-## Step 16 - Automated regression checks
+## Step 7 - Automated regression checks
 
 For broad UI audits or UI/API/CLI changes, run the automated checks that match
 the touched surface. Do not run codegen, formatters, setup reinstall, or any
@@ -503,7 +193,7 @@ If a check is unsafe or too expensive for the requested scope, skip it with a
 specific reason. For example, skip Kind e2e when the live contributor cluster is
 busy with unrelated user work or when the user requested a read-only audit.
 
-## Step 17 - Public-host defense
+## Step 8 - Public-host defense
 
 In test mode `MCP_PLATFORM_DOMAIN` is usually unset and `/grafana` +
 `/prometheus` route through the dev path-based gateway. The invariant under
@@ -520,7 +210,7 @@ kubectl get ingress -n mcp-sentinel -o yaml \
 If `mcp-sentinel-platform-ui` does not exist, mark this sub-suite **N/A in
 test mode** and recommend a `MCP_PLATFORM_DOMAIN=*` rerun.
 
-## Step 18 - Safe mutation and cleanup
+## Step 9 - Safe mutation and cleanup
 
 Only mutate temporary resources:
 
@@ -547,7 +237,7 @@ If another command recreates temporary workloads after cleanup, delete them
 again and wait until pods/deployments/services/ingresses disappear before
 finishing.
 
-## Step 19 - Report
+## Step 10 - Report
 
 For UI QA, use this finding shape instead of the security template unless the
 finding is actually security-sensitive:

--- a/.codex/skills/qa-e2e-ui/SKILL.md
+++ b/.codex/skills/qa-e2e-ui/SKILL.md
@@ -26,6 +26,12 @@ defenses, and whether rendered UI data matches backend truth.
 Header / CSP / lockout / secret-leak checks live in `qa-e2e-security`; do not
 duplicate them here unless the symptom is visible in the UI.
 
+Regression evidence contract: a UI pass needs browser evidence, not only curl
+or unit tests. For changed auth, role, or API-key behavior, cover both a
+user-identity session and a no-user-identity or denied session so role-gating
+regressions surface before merge. If browser automation is unavailable, report
+the UI result **blocked**.
+
 ## Step 1 - Confirm preconditions
 
 Do not reinstall the platform or run codegen as part of UI QA. The live

--- a/.codex/skills/qa-e2e-ui/evals/evals.json
+++ b/.codex/skills/qa-e2e-ui/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "qa-e2e-ui",
+  "evals": [
+    {
+      "id": "admin-panel-api-key-bug",
+      "prompt": "The admin panel says failed to load API keys. Reproduce it in the browser, find the broken API/UI path, fix it, and verify both admin login modes.",
+      "expected_output": "A browser-first UI investigation with network evidence, a focused fix, UI unit/static tests, and live verification for static API-key admin and platform-account admin sessions.",
+      "assertions": [
+        "Uses Playwright or Chrome DevTools evidence before concluding",
+        "Checks console errors and failed network requests",
+        "Verifies both API-key admin and platform-account admin behavior"
+      ]
+    },
+    {
+      "id": "full-dashboard-regression",
+      "prompt": "Run a full Sentinel dashboard regression across roles, tabs, forms, filters, responsive layout, and public-host defenses.",
+      "expected_output": "A full UI QA report using the matrix in references/ui-coverage.md, with role-scoped browser evidence, network/API evidence, screenshots or snapshots, cleanup, and skipped checks with reasons.",
+      "assertions": [
+        "Loads references/ui-coverage.md for full-ui mode",
+        "Mutates only qa-audit-* temporary resources",
+        "Runs matching automated checks or records specific skip reasons"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-ui/evals/trigger_queries.json
+++ b/.codex/skills/qa-e2e-ui/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "qa-e2e-ui",
+  "queries": [
+    {
+      "query": "The admin dashboard shows failed to load API keys; reproduce it in the browser and fix the UI/API path.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run full browser QA for Sentinel dashboard roles, tabs, forms, filters, responsive layout, and console errors.",
+      "should_trigger": true
+    },
+    {
+      "query": "Audit GitHub Actions for unpinned actions and weak permissions.",
+      "should_trigger": false
+    },
+    {
+      "query": "Compare our gateway JSON-RPC envelopes to the upstream MCP schema.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/qa-e2e-ui/references/ui-coverage.md
+++ b/.codex/skills/qa-e2e-ui/references/ui-coverage.md
@@ -1,0 +1,308 @@
+# Sentinel UI Coverage Checklist
+
+Use this reference for `full-ui` audits, for `git-range` audits where the diff
+touches a listed page, or when a finding requires detailed UI reproduction.
+For smoke checks, cover only dashboard load, one successful login, one protected
+action, console/network sanity, and the curl smoke in `SKILL.md`.
+
+The report matrix must use this shape:
+
+```text
+Page | Feature | Field/control | Action | Expected result | Actual result | Network/API evidence | Console evidence | Status
+```
+
+Use one row per meaningful capability. Forms, filters, enable/disable,
+revoke/unrevoke, empty states, and error states are separate rows.
+
+## Role And Session Flows
+
+Run browser flows in order. Use test-mode credentials only in local Kind test
+mode.
+
+Signed out:
+
+- Header shows product title and Sign In.
+- Catalog is visible.
+- Protected tabs/actions open auth modal and do not switch to protected data.
+- Namespace selector behavior matches platform mode.
+- No Google button appears when `MCP_GOOGLE_CLIENT_ID` is empty.
+
+Tenant user (`test@mcpruntime.org` / `test@123`):
+
+- Visible tabs: Server Catalog, My Activity, API Keys, Governance.
+- Hidden tabs: Dashboard, Operations, Platform.
+- Logout resets active tab and clears protected data.
+- A 401 from any UI API call resets auth state or shows a clear unauthorized
+  state without leaving mixed signed-in/signed-out controls.
+
+Admin (`admin@mcpruntime.org` / `admin@123`):
+
+- Visible tabs: Server Catalog, API Keys, Dashboard, Governance, Operations,
+  Platform.
+- Hidden tab fallback works after logout.
+- Auto-refresh starts only for admin dashboard and stops on logout.
+- Grafana and Prometheus header links appear only for admin in dev path mode.
+
+API-key login:
+
+```bash
+UI_KEY="$(kubectl get secret mcp-sentinel-secrets -n mcp-sentinel -o jsonpath='{.data.UI_API_KEY}' | base64 -d)"
+test -n "$UI_KEY" || { echo "FAIL: UI_API_KEY is empty"; exit 1; }
+```
+
+- Valid UI API key logs in as admin and clears the key input after success.
+- Invalid API key returns a visible error and does not clear the field until
+  the user edits it or retries.
+- Negative cases: blank form, email without password, password without email,
+  invalid password, and backend unavailable/network failure when safely
+  reproducible.
+
+## Server Catalog
+
+Drive from the browser, then cross-check with CLI/Kubernetes.
+
+Namespace selector:
+
+- signed-out tenant mode
+- tenant aggregate catalog
+- user namespace
+- team namespace
+- shared/org namespace
+- admin namespace list
+- public preview namespace in public mode, if configured
+
+Catalog data and filters:
+
+- total servers, ready servers, tool count, publish quota
+- status filters: All, Ready, Issues
+- search by server name, namespace, description, endpoint, status
+- search by tools, prompts, resources, tasks
+- search by inventory labels and server labels
+- no-match state
+
+Server cards:
+
+- title, namespace, description, status, ready pods, endpoint
+- tool/prompt/resource/task counts
+- created date and labels
+- inventory details for string and object forms
+- access JSON / connect config
+- long names/descriptions/labels do not break layout
+
+Actions:
+
+- Details opens the detail panel and loads recent activity.
+- Copy URL and Copy JSON show success or fallback/error feedback.
+- Card Enter/Space selection works where the card is keyboard focusable.
+- Retire is tested only against a temporary `qa-audit-*` MCPServer.
+- Cancel leaves the server unchanged; confirm removes it; the detail panel
+  resets after removal.
+
+Cross-check:
+
+```bash
+./bin/mcp-runtime server list
+kubectl get mcpservers -A
+```
+
+Any UI/CLI count mismatch is a finding unless the UI label clearly describes a
+different metric, such as historical active servers.
+
+## My Activity
+
+Tenant user only:
+
+- Metrics: My Servers, Ready, Requests, Denied, Deny Rate.
+- Deployed Servers table: identity, namespace, status, inventory, endpoint,
+  Analytics action, Copy URL, tenant Retire.
+- Usage controls: All servers, per-server selector, 24h/7d/30d/90d, Refresh.
+- Usage tables: per-server usage, top tools, recent activity.
+- Empty state: no personal servers.
+- Shared catalog servers are excluded from personal count.
+- Analytics empty response and API error render clear states.
+- If a selected server disappears, selector and tables recover cleanly.
+
+## API Keys
+
+Table:
+
+- name, prefix, created timestamp, active/revoked state, revoke action.
+
+Create:
+
+- empty name validation produces visible feedback or native validation.
+- normal, long, special-character, and duplicate-looking names.
+- one-time key display.
+- input clearing after success.
+- list refresh preserves or intentionally clears the one-time key; record the
+  expected behavior from implementation.
+- automatic one-time key timeout, if implemented.
+
+Revoke:
+
+- modal cancel leaves row active.
+- modal confirm revokes row.
+- error toast or visible error appears on failed revoke.
+
+Cleanup: revoke all temporary `qa-audit-*` keys before finishing.
+
+## Admin Dashboard
+
+Admin only:
+
+- Summary metrics: Total Events, Active Servers, Active Grants, Active Sessions.
+- Usage metrics: Events, Allowed, Denied, Humans, Agents, Allow Rate, Deny Rate.
+- Decision meter widths match allow/deny rates.
+- Row limit controls: Top 10, Top 25, Top 50.
+- Analytics tables: MCP Servers, Users & Agents, Tools, Decisions.
+- Decision Audit table: time/source/type, human, agent, server/namespace/action,
+  decision badge, policy reason/trust/session.
+- Auto-refresh enabled starts polling; disabled stops polling; logout stops it.
+- Non-admin never starts dashboard polling.
+- Empty/zero, allow-only, deny-only, mixed totals, malformed timestamps, and API
+  errors render usable states when safely reproducible.
+
+Cross-check current inventory metrics:
+
+```bash
+./bin/mcp-runtime server list
+./bin/mcp-runtime access grant list --namespace mcp-servers
+./bin/mcp-runtime access session list --namespace mcp-servers
+```
+
+If dashboard metrics are historical rather than current, the UI label must make
+that clear.
+
+## Governance
+
+Summary:
+
+- Active Grants, Disabled Grants, Active Sessions, Revoked Sessions.
+
+Grant list and filters:
+
+- name, namespace, server reference, server namespace fallback
+- human, agent, team, and combined subjects
+- max trust, allowed side effects, active/disabled state
+- filter by grant name, server, human ID, agent ID, team ID, no-match state
+
+Grant form validation:
+
+- missing name, missing server, no subject, no side effects
+- valid `tool:allow`, `tool:deny`, `tool:allow:medium`
+- valid tool name containing `:`
+- invalid decision, invalid trust, malformed line
+
+Grant actions:
+
+- create `qa-audit-*`
+- refresh
+- disable cancel/confirm
+- enable cancel/confirm
+- API error feedback
+- policy render cross-check:
+
+```bash
+./bin/mcp-runtime server policy inspect <server> --namespace <namespace>
+```
+
+Session form validation:
+
+- missing name, missing server, no subject
+- valid local datetime converted to UTC
+- invalid datetime
+- empty expiry allowed
+
+Session actions:
+
+- create `qa-audit-*`
+- refresh
+- revoke cancel/confirm
+- unrevoke cancel/confirm
+- API error feedback
+- policy/session cross-check:
+
+```bash
+./bin/mcp-runtime access session get <name> --namespace <namespace>
+kubectl get mcpagentsession <name> -n <namespace> -o yaml
+```
+
+## Operations
+
+Admin only:
+
+- Summary metrics: MCP Servers, Ready, Issues, Recent Logins, Users, Images,
+  Deployments, MCP Events.
+- Filters: user/tenant, since datetime, until datetime, Apply, Clear, invalid
+  datetime behavior.
+- Logged-in Users table.
+- MCP Server Health table.
+- Activity Timeline table.
+- MCP Activity table.
+- Images and Deployments table, including long image refs.
+- MCP Server Inspector empty and selected states.
+
+Cross-check Operations server counts:
+
+```bash
+./bin/mcp-runtime server list
+kubectl get mcpservers -A
+```
+
+Missing namespaces or stale server counts are product findings.
+
+## Platform
+
+Admin only:
+
+- Platform Health component cards: display name, status, ready count, namespace,
+  resource/key, message.
+- Styling for Ready, Degraded, NotReady, unknown.
+- Fleet Health: total servers, ready servers, issues, server table.
+- Fleet empty/error states, if safely reproducible.
+- Component restart selector includes every restartable component documented by
+  the UI. If health shows Grafana/Prometheus but restart omits them, either the
+  UI copy must explain why or it is a finding.
+- Restart no-selection validation must show visible feedback.
+- Restart modal cancel works.
+- Confirm restart only for an explicitly safe temporary target or skip with a
+  documented reason.
+- Open Operations activates Operations and triggers data load.
+
+## Responsive And Accessibility
+
+Run at least:
+
+- desktop: 1200x900
+- mobile: 390x844
+
+Check:
+
+- no body-level horizontal overflow unless intentional and documented
+- tab bar scroll behavior on mobile
+- text does not overlap controls or table cells
+- modals fit viewport and remain keyboard usable
+- buttons, inputs, selects, tabs, and dialogs have accessible names/roles
+- Enter/Space work on keyboard-reachable actions
+- focus does not remain trapped in hidden modals after close
+
+Record accessibility snapshot evidence for each major tab.
+
+## Platform Mode And Extensibility
+
+For broad UI audits, cover tenant mode against current Kind plus org/public
+mode through local UI-server config passes when practical.
+
+Extensibility cases:
+
+- duplicate or empty namespace list
+- user, team, shared/org, and public preview namespaces
+- string vs object tools/prompts/resources/tasks
+- server labels and inventory labels
+- unknown status values
+- missing endpoint or missing access JSON
+- new component returned by API appears without code changes
+- platform JWT, UI API-key, OIDC/Google, and direct API-key clients
+
+If a mode or case cannot be exercised, mark it skipped with a reason and the
+command or fixture needed to cover it later.

--- a/.codex/skills/repo-guidance-sync/evals/evals.json
+++ b/.codex/skills/repo-guidance-sync/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "repo-guidance-sync",
+  "evals": [
+    {
+      "id": "docs-drift-after-cli-change",
+      "prompt": "I changed CLI command behavior. Review whether README, docs, AGENTS.md, or contributor guidance need updates and make the needed docs edits.",
+      "expected_output": "A docs sync pass that maps the change surface to existing guidance, verifies live CLI help when command docs are affected, updates the nearest existing docs, and runs docs validation.",
+      "assertions": [
+        "Searches existing docs before creating new files",
+        "Verifies CLI docs against live help output when relevant",
+        "Reports docs changed and validation commands run"
+      ]
+    },
+    {
+      "id": "no-docs-needed-decision",
+      "prompt": "This internal refactor should not affect user-facing behavior. Check if docs need changes and explain the decision.",
+      "expected_output": "A concise docs impact assessment that inspects the diff, searches for affected guidance, and either updates docs or explains why no docs are needed.",
+      "assertions": [
+        "Identifies the changed surface",
+        "Searches relevant docs and AGENTS.md",
+        "Gives a clear no-docs-needed rationale when appropriate"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/repo-guidance-sync/evals/trigger_queries.json
+++ b/.codex/skills/repo-guidance-sync/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "repo-guidance-sync",
+  "queries": [
+    {
+      "query": "Review this code change and update README, docs, or AGENTS.md if contributor guidance is now stale.",
+      "should_trigger": true
+    },
+    {
+      "query": "The CLI help changed; sync docs with the live help output.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run a live cluster security regression for auth and gateway policy.",
+      "should_trigger": false
+    },
+    {
+      "query": "Measure gateway p95 latency against the perf baseline.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/scripts/validate_skill_evals.py
+++ b/.codex/skills/scripts/validate_skill_evals.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Validate repo-local Agent Skill eval manifests."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def require(condition: bool, errors: list[str], message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def load_json(path: Path, errors: list[str]) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        errors.append(f"{path}: invalid JSON: {exc}")
+        return None
+    if not isinstance(data, dict):
+        errors.append(f"{path}: top-level value must be an object")
+        return None
+    return data
+
+
+def validate_output_evals(skill: str, path: Path, errors: list[str]) -> None:
+    data = load_json(path, errors)
+    if data is None:
+        return
+
+    require(data.get("skill_name") == skill, errors, f"{path}: skill_name must be {skill!r}")
+    evals = data.get("evals")
+    require(isinstance(evals, list), errors, f"{path}: evals must be a list")
+    if not isinstance(evals, list):
+        return
+    require(len(evals) >= 2, errors, f"{path}: expected at least 2 evals")
+
+    seen_ids: set[str] = set()
+    for index, item in enumerate(evals):
+        prefix = f"{path}: eval {index}"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix}: must be an object")
+            continue
+        eval_id = item.get("id")
+        require(isinstance(eval_id, str) and bool(eval_id.strip()), errors, f"{prefix}: id must be a non-empty string")
+        if isinstance(eval_id, str):
+            require(eval_id not in seen_ids, errors, f"{prefix}: duplicate id {eval_id!r}")
+            seen_ids.add(eval_id)
+        for field in ("prompt", "expected_output"):
+            require(
+                isinstance(item.get(field), str) and bool(item[field].strip()),
+                errors,
+                f"{prefix}: {field} must be a non-empty string",
+            )
+        assertions = item.get("assertions")
+        require(isinstance(assertions, list) and bool(assertions), errors, f"{prefix}: assertions must be a non-empty list")
+        if isinstance(assertions, list):
+            for assertion_index, assertion in enumerate(assertions):
+                require(
+                    isinstance(assertion, str) and bool(assertion.strip()),
+                    errors,
+                    f"{prefix}: assertion {assertion_index} must be a non-empty string",
+                )
+
+
+def validate_trigger_queries(skill: str, path: Path, errors: list[str]) -> None:
+    data = load_json(path, errors)
+    if data is None:
+        return
+
+    require(data.get("skill_name") == skill, errors, f"{path}: skill_name must be {skill!r}")
+    queries = data.get("queries")
+    require(isinstance(queries, list), errors, f"{path}: queries must be a list")
+    if not isinstance(queries, list):
+        return
+    require(len(queries) >= 3, errors, f"{path}: expected at least 3 trigger queries")
+
+    positives = 0
+    negatives = 0
+    for index, item in enumerate(queries):
+        prefix = f"{path}: query {index}"
+        if not isinstance(item, dict):
+            errors.append(f"{prefix}: must be an object")
+            continue
+        require(
+            isinstance(item.get("query"), str) and bool(item["query"].strip()),
+            errors,
+            f"{prefix}: query must be a non-empty string",
+        )
+        should_trigger = item.get("should_trigger")
+        require(isinstance(should_trigger, bool), errors, f"{prefix}: should_trigger must be boolean")
+        if should_trigger is True:
+            positives += 1
+        elif should_trigger is False:
+            negatives += 1
+
+    require(positives >= 2, errors, f"{path}: expected at least 2 should_trigger=true queries")
+    require(negatives >= 1, errors, f"{path}: expected at least 1 should_trigger=false query")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "skills_root",
+        nargs="?",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Path to the .codex/skills directory",
+    )
+    args = parser.parse_args()
+
+    skills_root = args.skills_root.resolve()
+    errors: list[str] = []
+    skill_dirs = sorted(path for path in skills_root.iterdir() if (path / "SKILL.md").is_file())
+    require(bool(skill_dirs), errors, f"{skills_root}: no skill directories found")
+
+    for skill_dir in skill_dirs:
+        skill = skill_dir.name
+        evals_dir = skill_dir / "evals"
+        output_evals = evals_dir / "evals.json"
+        trigger_queries = evals_dir / "trigger_queries.json"
+        require(output_evals.is_file(), errors, f"{output_evals}: missing")
+        require(trigger_queries.is_file(), errors, f"{trigger_queries}: missing")
+        if output_evals.is_file():
+            validate_output_evals(skill, output_evals, errors)
+        if trigger_queries.is_file():
+            validate_trigger_queries(skill, trigger_queries, errors)
+
+    if errors:
+        for error in errors:
+            print(error)
+        return 1
+
+    print(f"validated {len(skill_dirs)} skill eval suites under {skills_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/scripts/validate_skill_evals.py
+++ b/.codex/skills/scripts/validate_skill_evals.py
@@ -17,8 +17,8 @@ def require(condition: bool, errors: list[str], message: str) -> None:
 def load_json(path: Path, errors: list[str]) -> dict[str, Any] | None:
     try:
         data = json.loads(path.read_text())
-    except json.JSONDecodeError as exc:
-        errors.append(f"{path}: invalid JSON: {exc}")
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"{path}: failed to load or parse JSON: {exc}")
         return None
     if not isinstance(data, dict):
         errors.append(f"{path}: top-level value must be an object")
@@ -113,8 +113,16 @@ def main() -> int:
     args = parser.parse_args()
 
     skills_root = args.skills_root.resolve()
+    if not skills_root.is_dir():
+        print(f"{skills_root}: not a directory")
+        return 1
+
     errors: list[str] = []
-    skill_dirs = sorted(path for path in skills_root.iterdir() if (path / "SKILL.md").is_file())
+    try:
+        skill_dirs = sorted(path for path in skills_root.iterdir() if (path / "SKILL.md").is_file())
+    except OSError as exc:
+        print(f"{skills_root}: failed to list skill directories: {exc}")
+        return 1
     require(bool(skill_dirs), errors, f"{skills_root}: no skill directories found")
 
     for skill_dir in skill_dirs:

--- a/.codex/skills/security-audit-platform/SKILL.md
+++ b/.codex/skills/security-audit-platform/SKILL.md
@@ -12,7 +12,7 @@ MCP Runtime, not a PR review. The output is a structured report with a threat
 model, a per-endpoint authn/authz matrix, tenant-isolation probes, protocol
 fuzz results, audit-log integrity tests, TLS hygiene, and DAST against a live
 cluster. Findings use the shared template at
-`.codex/skills/_shared/FINDINGS-TEMPLATE.md`.
+`../_shared/FINDINGS-TEMPLATE.md`.
 
 This skill is intentionally heavy. Expect hours, not minutes. Skip nothing
 silently — every check that did not run becomes a recorded gap.
@@ -256,7 +256,7 @@ manual findings.
 
 ## Step 13 — Report
 
-Use `.codex/skills/_shared/FINDINGS-TEMPLATE.md`. Required sections in the
+Use `../_shared/FINDINGS-TEMPLATE.md`. Required sections in the
 order specified there: Summary, Threat model assumptions, Findings, Scanner
 output, Checks run, Checks skipped, Remediation plan.
 

--- a/.codex/skills/security-audit-platform/SKILL.md
+++ b/.codex/skills/security-audit-platform/SKILL.md
@@ -23,7 +23,7 @@ Produce a STRIDE table per component. Components to cover:
 
 - **operator** (`cmd/operator/`, `internal/operator/`): reconciles `MCPServer`,
   `MCPAccessGrant`, `MCPAgentSession`; injects gateway sidecar.
-- **mcp-proxy / gateway** (`services/mcp-proxy/`): in-pod sidecar enforcing
+- **mcp-gateway** (`services/mcp-gateway/`): in-pod sidecar enforcing
   rendered policy, emitting audit events.
 - **sentinel-api** (`services/api/`): admin and runtime HTTP API.
 - **sentinel-ui** (`services/ui/`): browser UI, login, dashboards.
@@ -130,7 +130,7 @@ Fuzz the proxy/gateway request handling. Targets:
 - Race: parallel `notifications/initialized` for the same session;
   parallel `tools/call` against the same session ID from N goroutines.
 
-If a Go fuzz target exists in `services/mcp-proxy/`:
+If a Go fuzz target exists in `services/mcp-gateway/`:
 `go test -run='^$' -fuzz='Fuzz<Name>' -fuzztime=300s ./...`
 
 If no fuzz target exists at this trust boundary, that absence is itself a

--- a/.codex/skills/security-audit-platform/evals/evals.json
+++ b/.codex/skills/security-audit-platform/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "security-audit-platform",
+  "evals": [
+    {
+      "id": "pre-release-platform-audit",
+      "prompt": "Run a deep pre-release security review of the whole MCP Runtime platform and produce a structured findings report.",
+      "expected_output": "A platform-wide security audit with threat model, authn/authz matrix, tenant isolation probes, protocol fuzzing, audit integrity, TLS/ingress posture, DAST, scanners, and prioritized findings.",
+      "assertions": [
+        "Builds an explicit threat model before tool execution",
+        "Covers every major platform trust boundary",
+        "Uses ../_shared/FINDINGS-TEMPLATE.md and records skipped checks"
+      ]
+    },
+    {
+      "id": "tenant-isolation-red-team",
+      "prompt": "Do a red-team style assessment of tenant isolation, registry exposure, public ingress, and audit integrity.",
+      "expected_output": "A deep security assessment focused on cross-tenant access, registry auth, ingress exposure, audit tampering or gaps, and concrete exploit paths.",
+      "assertions": [
+        "Includes live-cluster probes where safe",
+        "Separates confirmed findings from untested hypotheses",
+        "Provides file and endpoint references for each finding"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/security-audit-platform/evals/trigger_queries.json
+++ b/.codex/skills/security-audit-platform/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "security-audit-platform",
+  "queries": [
+    {
+      "query": "Run a deep platform-wide MCP Runtime security audit before release.",
+      "should_trigger": true
+    },
+    {
+      "query": "Do a red-team style assessment across auth, tenant isolation, registry, ingress, audit logs, and DAST.",
+      "should_trigger": true
+    },
+    {
+      "query": "Review this one-line UI bug fix for security side effects.",
+      "should_trigger": false
+    },
+    {
+      "query": "Bring up the Kind contributor cluster for QA.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/security-audit/SKILL.md
+++ b/.codex/skills/security-audit/SKILL.md
@@ -87,7 +87,7 @@ Standards, NetworkPolicy, and manifest hygiene, use `k8s-hardening-audit`.
 
 4. Report using the shared finding format.
    - Use the template and severity rubric in
-     `.codex/skills/_shared/FINDINGS-TEMPLATE.md`.
+     `../_shared/FINDINGS-TEMPLATE.md`.
    - Lead with findings ordered by severity. Include file and line,
      exploit path, impact, and a specific fix.
    - Separate scanner failures from manual findings.

--- a/.codex/skills/security-audit/evals/evals.json
+++ b/.codex/skills/security-audit/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "security-audit",
+  "evals": [
+    {
+      "id": "change-scoped-auth-review",
+      "prompt": "Review this small auth-related diff for security risks and choose the right tests to run.",
+      "expected_output": "A change-scoped security review that defines the trust boundary, checks auth/role/secret/logging invariants, runs targeted tests, and reports findings or no findings with residual risk.",
+      "assertions": [
+        "Inspects git diff and touched files",
+        "Runs checks matched to the changed surface",
+        "Uses the shared findings template for security issues"
+      ]
+    },
+    {
+      "id": "container-workflow-change",
+      "prompt": "I changed Dockerfiles and GitHub Actions. Audit only the relevant security risks and tell me what checks are required.",
+      "expected_output": "A focused security review covering action permissions, secret exposure, image build risks, dependency scanners, and whether supply-chain-audit should also run.",
+      "assertions": [
+        "Identifies when supply-chain-audit is the better skill",
+        "Checks for untrusted PR and secret exposure risks",
+        "Lists scanners run or skipped"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/security-audit/evals/trigger_queries.json
+++ b/.codex/skills/security-audit/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "security-audit",
+  "queries": [
+    {
+      "query": "Review this auth-related diff for security risks and choose the right checks.",
+      "should_trigger": true
+    },
+    {
+      "query": "This change touches secrets, TLS, registry auth, and API key handling; run a focused security audit.",
+      "should_trigger": true
+    },
+    {
+      "query": "Run a deep platform-wide release security signoff.",
+      "should_trigger": false
+    },
+    {
+      "query": "Update docs after changing a CLI flag.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/.codex/skills/supply-chain-audit/SKILL.md
+++ b/.codex/skills/supply-chain-audit/SKILL.md
@@ -14,7 +14,7 @@ cluster posture — those live in `security-audit-platform` and
 `k8s-hardening-audit`.
 
 Findings use the shared template at
-`.codex/skills/_shared/FINDINGS-TEMPLATE.md`.
+`../_shared/FINDINGS-TEMPLATE.md`.
 
 ## Step 1 — Inventory the build inputs
 
@@ -187,7 +187,7 @@ For every workflow under `.github/workflows/`:
 
 ## Step 10 — Report
 
-Use `.codex/skills/_shared/FINDINGS-TEMPLATE.md`. For supply-chain audits,
+Use `../_shared/FINDINGS-TEMPLATE.md`. For supply-chain audits,
 include in the Summary section:
 
 - Total Go modules and direct vs transitive count.

--- a/.codex/skills/supply-chain-audit/SKILL.md
+++ b/.codex/skills/supply-chain-audit/SKILL.md
@@ -60,11 +60,11 @@ docker build --pull -f services/api/Dockerfile -t mcp-sentinel-api:audit service
 docker build --pull -f services/ui/Dockerfile -t mcp-sentinel-ui:audit services/ui
 docker build --pull -f services/ingest/Dockerfile -t mcp-sentinel-ingest:audit services/ingest
 docker build --pull -f services/processor/Dockerfile -t mcp-sentinel-processor:audit services/processor
-docker build --pull -f services/mcp-proxy/Dockerfile -t mcp-proxy:audit services/mcp-proxy
+docker build --pull -f services/mcp-gateway/Dockerfile -t mcp-sentinel-mcp-gateway:audit services/mcp-gateway
 
 for img in mcp-runtime-operator:audit mcp-sentinel-api:audit \
            mcp-sentinel-ui:audit mcp-sentinel-ingest:audit \
-           mcp-sentinel-processor:audit mcp-proxy:audit; do
+           mcp-sentinel-processor:audit mcp-sentinel-mcp-gateway:audit; do
   trivy image --exit-code 0 --severity CRITICAL,HIGH --ignore-unfixed \
               --vuln-type os,library --format table "$img"
 done
@@ -93,7 +93,7 @@ go install github.com/anchore/syft/cmd/syft@latest
 
 for img in mcp-runtime-operator:audit mcp-sentinel-api:audit \
            mcp-sentinel-ui:audit mcp-sentinel-ingest:audit \
-           mcp-sentinel-processor:audit mcp-proxy:audit; do
+           mcp-sentinel-processor:audit mcp-sentinel-mcp-gateway:audit; do
   out=$(echo "$img" | tr ':/' '__').spdx.json
   syft "$img" -o spdx-json="/tmp/$out"
 done

--- a/.codex/skills/supply-chain-audit/evals/evals.json
+++ b/.codex/skills/supply-chain-audit/evals/evals.json
@@ -1,0 +1,25 @@
+{
+  "skill_name": "supply-chain-audit",
+  "evals": [
+    {
+      "id": "dependency-bump-audit",
+      "prompt": "Audit this dependency bump for vulnerable Go modules, license issues, and CI dependency-review coverage.",
+      "expected_output": "A supply-chain report with Go vulnerability checks, dependency review/licensing notes, SBOM impact when relevant, and prioritized findings.",
+      "assertions": [
+        "Runs or records govulncheck/dependency-review equivalents",
+        "Separates dependency CVEs from runtime security issues",
+        "Uses ../_shared/FINDINGS-TEMPLATE.md for findings"
+      ]
+    },
+    {
+      "id": "container-image-release-audit",
+      "prompt": "Before release, audit our container images, base images, SBOMs, signatures, and GitHub Actions pinning.",
+      "expected_output": "A release supply-chain audit covering image scans, base images, SBOM generation/diff, cosign signatures, action pinning, and secret usage.",
+      "assertions": [
+        "Checks Dockerfiles and built images",
+        "Reviews GitHub Actions for SHA pinning and minimal permissions",
+        "Records scanner versions, commands, and skipped checks"
+      ]
+    }
+  ]
+}

--- a/.codex/skills/supply-chain-audit/evals/trigger_queries.json
+++ b/.codex/skills/supply-chain-audit/evals/trigger_queries.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "supply-chain-audit",
+  "queries": [
+    {
+      "query": "Audit this dependency bump, Dockerfile change, and GitHub Actions update for supply-chain risk.",
+      "should_trigger": true
+    },
+    {
+      "query": "Before release, check SBOMs, image signatures, base images, CVEs, licenses, and action pinning.",
+      "should_trigger": true
+    },
+    {
+      "query": "Verify live gateway deny paths and audit emission.",
+      "should_trigger": false
+    },
+    {
+      "query": "Run browser QA for dashboard tabs and forms.",
+      "should_trigger": false
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -153,13 +153,13 @@ DNS, ingress, TLS, and k3s configuration, start with
 <a class="docs-card" href="multi-team/">
   <span class="docs-card-kicker">Tenancy</span>
   <strong>Multi-team isolation</strong>
-  <span>Use namespaces, RBAC, and naming conventions for team boundaries without adding team fields to runtime CRDs.</span>
+  <span>Use namespaces, RBAC, and stable team IDs for team-owned servers, grants, and sessions.</span>
 </a>
 
 <a class="docs-card" href="cli/">
   <span class="docs-card-kicker">CLI</span>
   <strong>Command reference</strong>
-  <span>Setup, status, registry, server, access, pipeline, and Sentinel commands.</span>
+  <span>Setup, auth, registry, server, access, adapter, team, pipeline, Sentinel, and status commands.</span>
 </a>
 
 <a class="docs-card" href="api/">

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -41,7 +41,7 @@ flowchart LR
 | Area | Start here | Why it matters |
 |---|---|---|
 | CLI entrypoint | [`cmd-mcp-runtime.md`](cmd-mcp-runtime.md) | Shows how the binary starts, wires foldered Cobra commands, and reports errors. |
-| CLI implementation | [`internal-cli.md`](internal-cli.md) | Covers the `internal/cli/root` routing layer plus setup, bootstrap, registry, server, access, status, sentinel, auth, and pipeline behavior. |
+| CLI implementation | [`internal-cli.md`](internal-cli.md) | Covers the `internal/cli/root` routing layer plus setup, bootstrap, registry, server, access, adapter, team, status, sentinel, auth, and pipeline behavior. |
 | Kubernetes API types | [`api-types.md`](api-types.md) | Defines the public CRD shapes consumed by users, tests, and the operator. |
 | Generated Go reference | [`go-package-reference.md`](go-package-reference.md) | Captures `go doc` output for the main contributor-facing packages. |
 | Agent adapters | `internal/agentadapter/`, `internal/cli/adapter/` | HTTP proxy and stdio shim behavior for forwarding agent MCP traffic with issued governance headers; exposed via `mcp-runtime adapter proxy/stdio`. |
@@ -177,6 +177,7 @@ workflows.
 | Change reconciliation behavior | `internal/operator`, API types, k8s helpers | `go test ./internal/operator/... -race -count=1` |
 | Change governance policy | `pkg/access`, `pkg/policy`, `services/api`, `services/mcp-gateway`, access CRDs | targeted package/service tests plus e2e policy scenario |
 | Change agent adapters | `internal/agentadapter`, `internal/cli/adapter`, `docs/agent-adapters.md` | `go test ./internal/agentadapter ./internal/cli/adapter -count=1` |
+| Change team provisioning or membership | `internal/cli/team`, `services/api/internal/runtimeapi`, `services/api/internal/platformstore`, `docs/multi-team.md` | `go test ./internal/cli/team -count=1` plus service API tests inside `services/api` |
 | Change Sentinel event storage | `pkg/events`, `pkg/clickhouse`, `services/ingest`, `services/processor`, `services/api`, `services/mcp-gateway` | package tests plus touched service tests |
 | Change docs site behavior | `docs/mkdocs.yml`, `docs/nginx.conf`, Markdown pages | MkDocs build or docs container build |
 

--- a/docs/internals/cmd-mcp-runtime.md
+++ b/docs/internals/cmd-mcp-runtime.md
@@ -19,11 +19,10 @@ go doc -cmd ./cmd/mcp-runtime
 - Configure a console-oriented zap logger.
 - Print command errors to stderr and return a non-zero process exit.
 
-The entrypoint should not contain business logic for setup, registry, server,
-access, or Sentinel behavior. Route top-level commands through
-`internal/cli/root`. Command folders should own Cobra wiring and, where already
-migrated, package-local managers; shared CLI-only infrastructure lives in
-`internal/cli/core`.
+The entrypoint should not contain business logic for command behavior. Route
+top-level commands through `internal/cli/root`. Command folders should own Cobra
+wiring and, where already migrated, package-local managers; shared CLI-only
+infrastructure lives in `internal/cli/core`.
 
 ## Command Tree
 
@@ -39,8 +38,10 @@ The root command wires these internal command groups:
 | `server` | `internal/cli/server` | `server.go`, `manager.go`, `validation.go`, `build.go`, `build_image.go`, server-owned helpers under `internal/cli/server/` |
 | `pipeline` | `internal/cli/pipeline` | `command.go`, `generate.go`, `deploy.go` |
 | `access` | `internal/cli/access` | `access.go`, `manager.go`, `validation.go` |
+| `adapter` | `internal/cli/adapter` | `adapter.go`, `flags.go`, `platformsession.go`, `proxy.go`, `stdio.go`; transport behavior in `internal/agentadapter` |
 | `auth` | `internal/cli/auth` | `auth.go` |
 | `sentinel` | `internal/cli/sentinel` | `sentinel.go`, `manager.go`, shared workload/probe helpers in `internal/cli/platformstatus` |
+| `team` | `internal/cli/team` | `team.go`, `manager.go` |
 
 When adding a command, wire it here only after the implementation has focused
 package tests and help text is ready for golden snapshots.

--- a/docs/internals/internal-cli.md
+++ b/docs/internals/internal-cli.md
@@ -170,6 +170,38 @@ reach `kubectl`; that validation lives in `internal/cli/access/validation.go`.
 
 Tests: `access/manager_test.go` and `access/validation_test.go`.
 
+## Adapter
+
+`internal/cli/adapter/` provides the `adapter proxy` and `adapter stdio`
+commands. The CLI layer resolves shared flags, optional platform-issued adapter
+sessions from `POST /api/runtime/adapter/sessions`, and explicit
+`MCP_RUNTIME_*` identity values, then delegates HTTP proxy and stdio transport
+behavior to `internal/agentadapter`.
+
+Keep the boundary clear: command parsing, platform-session bootstrap, and
+auto-refresh scheduling live in `internal/cli/adapter`; request forwarding,
+header injection, TLS transport, stdio bridging, and anonymous stdio method
+filtering live in `internal/agentadapter`.
+
+Tests: `adapter/adapter_test.go`, `adapter/platformsession_test.go`, and
+`internal/agentadapter` tests.
+
+## Team
+
+`internal/cli/team/` owns platform team commands. `team list` and `team create`
+call the platform API through `internal/cli/platformapi`; `team init` renders
+local Kubernetes namespace, RBAC, quota, limits, NetworkPolicy, workload service
+account, and bundled Traefik watch manifests before applying them with
+`kubectl`.
+
+Team behavior spans CLI and API code: platform-backed team creation and
+membership routes live in `services/api/internal/runtimeapi`, durable identity
+state lives in `services/api/internal/platformstore`, and user-facing guidance
+lives in `docs/multi-team.md`.
+
+Tests: `team/manager_test.go`; for platform team API changes, run focused tests
+inside `services/api`.
+
 ## Sentinel and Platform API
 
 `internal/cli/sentinel/`, `internal/cli/auth/`, and `internal/cli/platformapi/`

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -145,6 +145,33 @@ func TestStaticAppHidesProtectedTabsWhenSignedOut(t *testing.T) {
 	}
 }
 
+func TestStaticAppHidesUserAPIKeysWithoutUserIdentity(t *testing.T) {
+	index, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("read static index: %v", err)
+	}
+	html := string(index)
+	if got := strings.Count(html, `data-user-identity-required="true"`); got < 2 {
+		t.Fatalf("expected API key tab and panel to require a user identity, got %d markers", got)
+	}
+
+	body, err := os.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read static app: %v", err)
+	}
+	source := string(body)
+	for _, want := range []string{
+		`function hasUserIdentity()`,
+		`String(authPrincipal?.subject || "").trim() !== ""`,
+		`querySelectorAll('[data-user-identity-required="true"]')`,
+		`Sign in with a platform account to manage user API keys.`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("app missing %q", want)
+		}
+	}
+}
+
 func TestStaticAppSearchesServerMetadataLabels(t *testing.T) {
 	body, err := os.ReadFile("static/app.js")
 	if err != nil {

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -1920,6 +1920,10 @@ function isTenantUser() {
   return authenticated === true && !isAdminUser();
 }
 
+function hasUserIdentity() {
+  return authenticated === true && String(authPrincipal?.subject || "").trim() !== "";
+}
+
 function applyRoleVisibility() {
   const authRequired = document.querySelectorAll('[data-auth-required="true"]');
   authRequired.forEach((node) => {
@@ -1932,6 +1936,10 @@ function applyRoleVisibility() {
   const userOnly = document.querySelectorAll('[data-user-only="true"]');
   userOnly.forEach((node) => {
     node.classList.toggle("hidden", !isTenantUser());
+  });
+  const userIdentityRequired = document.querySelectorAll('[data-user-identity-required="true"]');
+  userIdentityRequired.forEach((node) => {
+    node.classList.toggle("hidden", !hasUserIdentity());
   });
   const active = resolveActiveTab();
   activateTab(active);
@@ -2433,6 +2441,13 @@ async function loadUserAPIKeys(options = {}) {
   if (!options.preserveOneTime) {
     clearOneTimeUserAPIKey();
   }
+  if (!hasUserIdentity()) {
+    userAPIKeysCache = [];
+    renderUserAPIKeys();
+    setInlineError("user-api-key-error", "Sign in with a platform account to manage user API keys.");
+    return;
+  }
+  setInlineError("user-api-key-error");
   try {
     const data = await fetchJSON("/user/api-keys");
     userAPIKeysCache = Array.isArray(data.keys) ? data.keys : [];
@@ -2479,6 +2494,12 @@ async function createUserAPIKey() {
   const name = (input?.value || "").trim();
   setInlineError("user-api-key-error");
   input?.removeAttribute("aria-invalid");
+  if (!hasUserIdentity()) {
+    const message = "Sign in with a platform account to manage user API keys.";
+    setInlineError("user-api-key-error", message);
+    showToast(message, "warning");
+    return;
+  }
   if (!name) {
     const message = "Enter a name for the API key.";
     setInlineError("user-api-key-error", message);
@@ -2518,6 +2539,12 @@ async function createUserAPIKey() {
 }
 
 async function revokeUserAPIKey(id) {
+  if (!hasUserIdentity()) {
+    const message = "Sign in with a platform account to manage user API keys.";
+    setInlineError("user-api-key-error", message);
+    showToast(message, "warning");
+    return;
+  }
   try {
     await fetchJSON(`/user/api-keys/${encodePathSegment(id)}/revoke`, { method: "POST" });
     showToast("API key revoked");

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -55,6 +55,7 @@
           class="tab"
           data-tab="userkeys"
           data-auth-required="true"
+          data-user-identity-required="true"
           role="tab"
           type="button"
           aria-controls="tab-userkeys"
@@ -306,6 +307,7 @@
         id="tab-userkeys"
         class="tab-content"
         data-auth-required="true"
+        data-user-identity-required="true"
         role="tabpanel"
         aria-labelledby="tab-button-userkeys"
         hidden


### PR DESCRIPTION
## Summary

- Hide the UI API Keys tab for sessions that do not have a user identity and guard API-key load/create/revoke actions from calling user-scoped endpoints without a subject.
- Add repo-local Agent Skill regression docs, output eval suites, trigger query suites, and a checked-in eval manifest validator.
- Split large UI and MCP spec skill guidance into progressive-disclosure reference files and sync internals docs with current CLI/package layout.

## Root Cause

Static admin API-key login creates an admin principal without a user subject. The UI still exposed the user-scoped API Keys panel, which called `/api/user/api-keys` and returned 401, surfacing as “Failed to load API keys.”

## Validation

- `node --check services/ui/static/app.js`
- `cd services/ui && go test ./... -race -count=1`
- Browser verified static admin API-key login hides the tab while password admin login still loads user API keys.
- `quick_validate.py` over all repo-local skills
- `python -m json.tool` over all `.codex/skills/*/evals/*.json`
- `.codex/skills/scripts/validate_skill_evals.py`
- OpenAI metadata smoke check
- `go test ./test/golden/... -count=1`
- `mkdocs build -f docs/mkdocs.yml --strict`
- `git diff --check`

## Notes

The remaining skills gap is model-backed eval execution: the repo now validates eval manifests structurally, but does not yet aggregate with-skill versus baseline pass rates, trigger rates, timing, or token cost.