### PR TITLE
fix(setup): avoid duplicate traefik plugin mounts

### DIFF
--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -2203,6 +2203,26 @@ func TestEnsureRepoManagedTraefikMiddlewareResourcesAppliesMiddlewareSupportToEx
 	}
 }
 
+func TestPatchTraefikDeploymentForFileMiddlewareSupportTreatsMountPathAsIdempotent(t *testing.T) {
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			cmd := &core.MockCommand{Args: spec.Args}
+			switch {
+			case commandHasArgs(spec, "get", "deployment", "traefik", "-n", "traefik", "-o", "json"):
+				cmd.OutputData = []byte(`{"spec":{"template":{"spec":{"containers":[{"name":"traefik","args":["--providers.file.filename=/etc/traefik/dynamic/dynamic.yml","--providers.file.watch=true","--experimental.localplugins.pii-redactor.modulename=github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor"],"volumeMounts":[{"name":"traefik-dynamic","mountPath":"/etc/traefik/dynamic"},{"name":"traefik-plugin-source","mountPath":"/plugins-local/src/github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor"},{"name":"traefik-plugin-storage","mountPath":"/plugins-storage"}]}],"volumes":[{"name":"traefik-dynamic"},{"name":"traefik-plugin-source"},{"name":"traefik-plugin-storage"}]}}}}`)
+			case commandHasArgs(spec, "patch", "deployment", "traefik", "-n", "traefik", "--type=json"):
+				t.Fatalf("did not expect duplicate patch when middleware mount paths already exist: %v", spec.Args)
+			}
+			return cmd
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	if err := patchTraefikDeploymentForFileMiddlewareSupport(kubectl, "traefik"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestEnsureRepoManagedTraefikMiddlewareResourcesSkipsWhenMissing(t *testing.T) {
 	mock := &core.MockExecutor{
 		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -1984,28 +1984,31 @@ func patchTraefikDeploymentForFileMiddlewareSupport(kubectl core.KubectlRunner, 
 			Value: "--experimental.localplugins.pii-redactor.modulename=github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor",
 		})
 	}
-	if !hasVolumeMount(container.VolumeMounts, "traefik-dynamic", "/etc/traefik/dynamic") {
+	addDynamicMount := !hasVolumeMountPath(container.VolumeMounts, "/etc/traefik/dynamic")
+	if addDynamicMount {
 		ops = append(ops, jsonPatchOperation{
 			Op:    "add",
 			Path:  fmt.Sprintf("/spec/template/spec/containers/%d/volumeMounts/-", containerIndex),
 			Value: map[string]any{"name": "traefik-dynamic", "mountPath": "/etc/traefik/dynamic", "readOnly": true},
 		})
 	}
-	if !hasVolumeMount(container.VolumeMounts, "traefik-plugin-source", "/plugins-local/src/github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor") {
+	addPluginSourceMount := !hasVolumeMountPath(container.VolumeMounts, "/plugins-local/src/github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor")
+	if addPluginSourceMount {
 		ops = append(ops, jsonPatchOperation{
 			Op:    "add",
 			Path:  fmt.Sprintf("/spec/template/spec/containers/%d/volumeMounts/-", containerIndex),
 			Value: map[string]any{"name": "traefik-plugin-source", "mountPath": "/plugins-local/src/github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor", "readOnly": true},
 		})
 	}
-	if !hasVolumeMount(container.VolumeMounts, "traefik-plugins", "/plugins-storage") {
+	addPluginStorageMount := !hasVolumeMountPath(container.VolumeMounts, "/plugins-storage")
+	if addPluginStorageMount {
 		ops = append(ops, jsonPatchOperation{
 			Op:    "add",
 			Path:  fmt.Sprintf("/spec/template/spec/containers/%d/volumeMounts/-", containerIndex),
 			Value: map[string]any{"name": "traefik-plugins", "mountPath": "/plugins-storage"},
 		})
 	}
-	if !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-dynamic") {
+	if addDynamicMount && !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-dynamic") {
 		ops = append(ops, jsonPatchOperation{
 			Op:   "add",
 			Path: "/spec/template/spec/volumes/-",
@@ -2018,14 +2021,14 @@ func patchTraefikDeploymentForFileMiddlewareSupport(kubectl core.KubectlRunner, 
 			},
 		})
 	}
-	if !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-plugin-source") {
+	if addPluginSourceMount && !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-plugin-source") {
 		ops = append(ops, jsonPatchOperation{
 			Op:    "add",
 			Path:  "/spec/template/spec/volumes/-",
 			Value: map[string]any{"name": "traefik-plugin-source", "configMap": map[string]any{"name": "traefik-plugin-pii-redactor"}},
 		})
 	}
-	if !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-plugins") {
+	if addPluginStorageMount && !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-plugins") {
 		ops = append(ops, jsonPatchOperation{
 			Op:    "add",
 			Path:  "/spec/template/spec/volumes/-",
@@ -2076,12 +2079,12 @@ func containsString(values []string, target string) bool {
 	return false
 }
 
-func hasVolumeMount(mounts []struct {
+func hasVolumeMountPath(mounts []struct {
 	Name      string `json:"name"`
 	MountPath string `json:"mountPath"`
-}, name, mountPath string) bool {
+}, mountPath string) bool {
 	for _, mount := range mounts {
-		if mount.Name == name && mount.MountPath == mountPath {
+		if mount.MountPath == mountPath {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
- make Traefik middleware patching idempotent by mountPath, not only volume name
- avoid adding duplicate /plugins-storage mounts when the HTTP overlay already uses traefik-plugin-storage
- add a regression test for the Kind E2E failure shape from run 26091453896

## Testing
- go test ./internal/cli/setup -run 'TraefikMiddleware|TraefikDeploymentForFileMiddleware' -count=1
- go test ./internal/cli/setup -count=1
- go test ./internal/cli/... -count=1
- git diff --check