### PR TITLE
fix(ui): remove catalog details action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,14 +226,22 @@ jobs:
           python3 --version
           rg --version
 
+      - name: Configure E2E resource names
+        run: |
+          suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          port=$((20000 + ((GITHUB_RUN_ID + GITHUB_RUN_ATTEMPT) % 20000)))
+          {
+            echo "CLUSTER_NAME=mcp-e2e-${suffix}"
+            echo "LOCAL_REGISTRY_NAME=mcp-e2e-registry-${suffix}"
+            echo "LOCAL_REGISTRY_PORT=${port}"
+          } >> "${GITHUB_ENV}"
+
       - name: Run kind e2e
         env:
-          CLUSTER_NAME: mcp-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/.e2e-artifacts/kind
           E2E_SCENARIOS: ${{ github.actor == 'dependabot[bot]' && 'smoke-auth,governance' || 'all' }}
           E2E_IMAGE_BUILD_PARALLELISM: "1"
           E2E_IMAGE_MIRROR_PARALLELISM: "1"
-          LOCAL_REGISTRY_NAME: mcp-e2e-registry-${{ github.run_id }}-${{ github.run_attempt }}
         run: bash test/e2e/kind.sh
 
       - name: Upload e2e artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,10 +228,12 @@ jobs:
 
       - name: Run kind e2e
         env:
+          CLUSTER_NAME: mcp-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/.e2e-artifacts/kind
           E2E_SCENARIOS: ${{ github.actor == 'dependabot[bot]' && 'smoke-auth,governance' || 'all' }}
           E2E_IMAGE_BUILD_PARALLELISM: "1"
           E2E_IMAGE_MIRROR_PARALLELISM: "1"
+          LOCAL_REGISTRY_NAME: mcp-e2e-registry-${{ github.run_id }}-${{ github.run_attempt }}
         run: bash test/e2e/kind.sh
 
       - name: Upload e2e artifacts

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -356,6 +356,14 @@ func TestStaticAppMovesTenantRetireActionToMyActivity(t *testing.T) {
 			t.Fatalf("app missing %q", want)
 		}
 	}
+	for _, unwanted := range []string{
+		`detailsButton`,
+		`detailsButton.textContent = "Details"`,
+	} {
+		if strings.Contains(source, unwanted) {
+			t.Fatalf("app should not render catalog details action %q", unwanted)
+		}
+	}
 }
 
 func TestStaticAppRemovesCatalogDetailsAction(t *testing.T) {

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -367,25 +367,10 @@ func TestStaticAppRemovesCatalogDetailsAction(t *testing.T) {
 	for _, unwanted := range []string{
 		`detailsButton`,
 		`detailsButton.textContent = "Details"`,
-	} {
-		if strings.Contains(source, unwanted) {
-			t.Fatalf("app should not render catalog details action %q", unwanted)
-		}
-	}
-}
-
-func TestStaticAppRemovesCatalogDetailsAction(t *testing.T) {
-	body, err := os.ReadFile("static/app.js")
-	if err != nil {
-		t.Fatalf("read static app: %v", err)
-	}
-	source := string(body)
-	for _, unwanted := range []string{
-		`detailsButton.textContent = "Details"`,
 		`detailsButton.addEventListener("click", () => selectServer(server))`,
 	} {
 		if strings.Contains(source, unwanted) {
-			t.Fatalf("app should not keep catalog details action %q", unwanted)
+			t.Fatalf("app should not render catalog details action %q", unwanted)
 		}
 	}
 }

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -356,6 +356,14 @@ func TestStaticAppMovesTenantRetireActionToMyActivity(t *testing.T) {
 			t.Fatalf("app missing %q", want)
 		}
 	}
+}
+
+func TestStaticAppRemovesCatalogDetailsAction(t *testing.T) {
+	body, err := os.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read static app: %v", err)
+	}
+	source := string(body)
 	for _, unwanted := range []string{
 		`detailsButton`,
 		`detailsButton.textContent = "Details"`,


### PR DESCRIPTION
## Summary
- remove the server catalog card Details action that was crowding the UI
- keep card click/keyboard selection and existing copy/retire actions intact
- update the static UI test so the removed action cannot return silently

## Tests
- cd services/ui && go test ./... -count=1
- MCP_RUNTIME_CONFIG_DIR=$(mktemp -d) git commit hook: gitleaks, go fmt, staticcheck, go vet, go unit tests, generated file drift