### PR TITLE
fix(api): allow cross-team adapter sessions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,14 +226,22 @@ jobs:
           python3 --version
           rg --version
 
+      - name: Configure E2E resource names
+        run: |
+          suffix="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          port=$((20000 + ((GITHUB_RUN_ID + GITHUB_RUN_ATTEMPT) % 20000)))
+          {
+            echo "CLUSTER_NAME=mcp-e2e-${suffix}"
+            echo "LOCAL_REGISTRY_NAME=mcp-e2e-registry-${suffix}"
+            echo "LOCAL_REGISTRY_PORT=${port}"
+          } >> "${GITHUB_ENV}"
+
       - name: Run kind e2e
         env:
-          CLUSTER_NAME: mcp-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/.e2e-artifacts/kind
           E2E_SCENARIOS: ${{ github.actor == 'dependabot[bot]' && 'smoke-auth,governance' || 'all' }}
           E2E_IMAGE_BUILD_PARALLELISM: "1"
           E2E_IMAGE_MIRROR_PARALLELISM: "1"
-          LOCAL_REGISTRY_NAME: mcp-e2e-registry-${{ github.run_id }}-${{ github.run_attempt }}
         run: bash test/e2e/kind.sh
 
       - name: Upload e2e artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,10 +228,12 @@ jobs:
 
       - name: Run kind e2e
         env:
+          CLUSTER_NAME: mcp-e2e-${{ github.run_id }}-${{ github.run_attempt }}
           E2E_ARTIFACT_DIR: ${{ github.workspace }}/.e2e-artifacts/kind
           E2E_SCENARIOS: ${{ github.actor == 'dependabot[bot]' && 'smoke-auth,governance' || 'all' }}
           E2E_IMAGE_BUILD_PARALLELISM: "1"
           E2E_IMAGE_MIRROR_PARALLELISM: "1"
+          LOCAL_REGISTRY_NAME: mcp-e2e-registry-${{ github.run_id }}-${{ github.run_attempt }}
         run: bash test/e2e/kind.sh
 
       - name: Upload e2e artifacts

--- a/services/api/internal/runtimeapi/adapter.go
+++ b/services/api/internal/runtimeapi/adapter.go
@@ -204,8 +204,11 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 }
 
 func adapterPrincipalTeamIDs(p principal) []string {
-	seen := map[string]struct{}{}
-	out := []string{}
+	if len(p.Teams) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(p.Teams))
+	out := make([]string, 0, len(p.Teams))
 	for _, team := range p.Teams {
 		id := strings.TrimSpace(team.ID)
 		if id == "" {
@@ -286,7 +289,7 @@ func matchingAdapterGrantTeamID(subj sentinelaccess.SubjectRef, humanID, agentID
 		return defaultTeamID, true
 	}
 	for _, teamID := range teamIDs {
-		if strings.TrimSpace(teamID) == grantTeamID {
+		if teamID == grantTeamID {
 			return grantTeamID, true
 		}
 	}

--- a/services/api/internal/runtimeapi/adapter.go
+++ b/services/api/internal/runtimeapi/adapter.go
@@ -116,11 +116,8 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	teamID, err := principalTeamForNamespace(principal, req.Namespace)
-	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
-		return
-	}
+	teamIDs := adapterPrincipalTeamIDs(principal)
+	defaultTeamID := defaultAdapterSessionTeamID(principal, req.Namespace, teamIDs)
 
 	requestedTrust, err := parseAdapterTrust(req.RequestedTrust)
 	if err != nil {
@@ -136,7 +133,7 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	grant, err := s.selectAdapterGrant(ctx, req.Namespace, req.ServerName, humanID, req.AgentID, teamID)
+	grant, teamID, err := s.selectAdapterGrant(ctx, req.Namespace, req.ServerName, humanID, req.AgentID, teamIDs, defaultTeamID, principal.Role == roleAdmin)
 	if err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 		return
@@ -206,22 +203,31 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 	})
 }
 
-// principalTeamForNamespace resolves the team identity the principal must hold
-// for the supplied namespace. Admin principals (no team binding) are allowed
-// to operate without a team; everyone else must be a member of the team that
-// owns the namespace.
-func principalTeamForNamespace(p principal, namespace string) (string, error) {
-	namespace = strings.TrimSpace(namespace)
-	if namespace == "" {
-		return "", errors.New("namespace is required")
+func adapterPrincipalTeamIDs(p principal) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, team := range p.Teams {
+		id := strings.TrimSpace(team.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
 	}
+	return out
+}
+
+func defaultAdapterSessionTeamID(p principal, namespace string, teamIDs []string) string {
 	if team, ok := p.TeamForNamespace(namespace); ok {
-		return strings.TrimSpace(team.ID), nil
+		return strings.TrimSpace(team.ID)
 	}
-	if p.Role == roleAdmin {
-		return "", nil
+	if len(teamIDs) == 1 {
+		return teamIDs[0]
 	}
-	return "", fmt.Errorf("principal is not a member of namespace %q", namespace)
+	return ""
 }
 
 // selectAdapterGrant lists enabled MCPAccessGrants in namespace whose serverRef
@@ -229,12 +235,16 @@ func principalTeamForNamespace(p principal, namespace string) (string, error) {
 // field empty (wildcard). When multiple grants match, the one with the highest
 // MaxTrust wins; ties are broken by oldest creationTimestamp so the result is
 // deterministic across replicas.
-func (s *RuntimeServer) selectAdapterGrant(ctx context.Context, namespace, serverName, humanID, agentID, teamID string) (*sentinelaccess.MCPAccessGrant, error) {
+func (s *RuntimeServer) selectAdapterGrant(ctx context.Context, namespace, serverName, humanID, agentID string, teamIDs []string, defaultTeamID string, allowAnyTeam bool) (*sentinelaccess.MCPAccessGrant, string, error) {
 	grants, err := s.accessMgr.ListGrants(ctx, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("list grants in %s: %w", namespace, err)
+		return nil, "", fmt.Errorf("list grants in %s: %w", namespace, err)
 	}
-	var matches []sentinelaccess.MCPAccessGrant
+	type grantMatch struct {
+		grant  sentinelaccess.MCPAccessGrant
+		teamID string
+	}
+	var matches []grantMatch
 	for _, g := range grants.Items {
 		if g.Spec.Disabled {
 			continue
@@ -242,41 +252,48 @@ func (s *RuntimeServer) selectAdapterGrant(ctx context.Context, namespace, serve
 		if g.Spec.ServerRef.Name != serverName {
 			continue
 		}
-		if !subjectMatches(g.Spec.Subject, humanID, agentID, teamID) {
+		teamID, ok := matchingAdapterGrantTeamID(g.Spec.Subject, humanID, agentID, teamIDs, defaultTeamID, allowAnyTeam)
+		if !ok {
 			continue
 		}
-		matches = append(matches, g)
+		matches = append(matches, grantMatch{grant: g, teamID: teamID})
 	}
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no enabled MCPAccessGrant in %s matches server=%q humanID=%q agentID=%q",
+		return nil, "", fmt.Errorf("no enabled MCPAccessGrant in %s matches server=%q humanID=%q agentID=%q",
 			namespace, serverName, humanID, agentID)
 	}
 	sort.SliceStable(matches, func(i, j int) bool {
-		ti := trustRank(matches[i].Spec.MaxTrust)
-		tj := trustRank(matches[j].Spec.MaxTrust)
+		ti := trustRank(matches[i].grant.Spec.MaxTrust)
+		tj := trustRank(matches[j].grant.Spec.MaxTrust)
 		if ti != tj {
 			return ti > tj
 		}
-		return matches[i].CreationTimestamp.Time.Before(matches[j].CreationTimestamp.Time)
+		return matches[i].grant.CreationTimestamp.Time.Before(matches[j].grant.CreationTimestamp.Time)
 	})
 	g := matches[0]
-	return &g, nil
+	return &g.grant, g.teamID, nil
 }
 
-// subjectMatches treats empty fields on the grant's subject as wildcards,
-// preserving the SubjectRef semantics already used by the gateway when
-// evaluating policy at runtime.
-func subjectMatches(subj sentinelaccess.SubjectRef, humanID, agentID, teamID string) bool {
+func matchingAdapterGrantTeamID(subj sentinelaccess.SubjectRef, humanID, agentID string, teamIDs []string, defaultTeamID string, allowAnyTeam bool) (string, bool) {
 	if subj.HumanID != "" && subj.HumanID != humanID {
-		return false
+		return "", false
 	}
 	if subj.AgentID != "" && subj.AgentID != agentID {
-		return false
+		return "", false
 	}
-	if subj.TeamID != "" && subj.TeamID != teamID {
-		return false
+	grantTeamID := strings.TrimSpace(subj.TeamID)
+	if grantTeamID == "" {
+		return defaultTeamID, true
 	}
-	return true
+	for _, teamID := range teamIDs {
+		if strings.TrimSpace(teamID) == grantTeamID {
+			return grantTeamID, true
+		}
+	}
+	if allowAnyTeam {
+		return grantTeamID, true
+	}
+	return "", false
 }
 
 // adapterSessionName derives a deterministic resource name from the caller's

--- a/services/api/internal/runtimeapi/adapter.go
+++ b/services/api/internal/runtimeapi/adapter.go
@@ -104,7 +104,11 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 	if req.Namespace == "" {
 		// Default to the principal's primary namespace so single-team callers
 		// don't have to pass it on every request.
-		req.Namespace = principal.Namespace
+		req.Namespace = strings.TrimSpace(principal.Namespace)
+	}
+	if req.Namespace == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace is required"})
+		return
 	}
 
 	humanID := strings.TrimSpace(principal.Subject)

--- a/services/api/internal/runtimeapi/adapter_test.go
+++ b/services/api/internal/runtimeapi/adapter_test.go
@@ -287,6 +287,21 @@ func TestAdapterSessionRequiresServerName(t *testing.T) {
 	}
 }
 
+func TestAdapterSessionRequiresResolvedNamespace(t *testing.T) {
+	fx := newAdapterTestFixture(t)
+	fx.principal.Namespace = ""
+	req := adapterRequest(t, adapterSessionRequest{ServerName: "demo", AgentID: "ops-agent"})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s, want 400", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "namespace is required") {
+		t.Fatalf("body = %q, want namespace validation error", w.Body.String())
+	}
+}
+
 func TestAdapterSessionRejectsTTLBeyondHardCap(t *testing.T) {
 	d, err := parseAdapterTTL("48h")
 	if err != nil {

--- a/services/api/internal/runtimeapi/adapter_test.go
+++ b/services/api/internal/runtimeapi/adapter_test.go
@@ -123,6 +123,63 @@ func TestAdapterSessionIssuesNewSessionFromMatchingGrant(t *testing.T) {
 	}
 }
 
+func TestAdapterSessionIssuesCrossTeamSessionFromGrantedTeam(t *testing.T) {
+	grant := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "globex-to-acme", Namespace: "mcp-team-acme"},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef: mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:   mcpv1alpha1.SubjectRef{AgentID: "ops-agent", TeamID: "team-globex"},
+			MaxTrust:  mcpv1alpha1.TrustLevel("low"),
+		},
+	}
+	fx := newAdapterTestFixture(t, grant)
+	fx.principal.Namespace = "mcp-team-globex"
+	fx.principal.Teams = []platformstore.PrincipalTeam{
+		{ID: "team-globex", Namespace: "mcp-team-globex"},
+	}
+	req := adapterRequest(t, adapterSessionRequest{
+		ServerName: "demo",
+		Namespace:  "mcp-team-acme",
+		AgentID:    "ops-agent",
+	})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	got := decodeAdapterResponse(t, w)
+	if got.TeamID != "team-globex" {
+		t.Fatalf("teamID = %q, want team-globex", got.TeamID)
+	}
+}
+
+func TestAdapterSessionRejectsGrantForUnheldTeam(t *testing.T) {
+	grant := mcpv1alpha1.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "globex-to-acme", Namespace: "mcp-team-acme"},
+		Spec: mcpv1alpha1.MCPAccessGrantSpec{
+			ServerRef: mcpv1alpha1.ServerReference{Name: "demo", Namespace: "mcp-team-acme"},
+			Subject:   mcpv1alpha1.SubjectRef{AgentID: "ops-agent", TeamID: "team-globex"},
+			MaxTrust:  mcpv1alpha1.TrustLevel("low"),
+		},
+	}
+	fx := newAdapterTestFixture(t, grant)
+	req := adapterRequest(t, adapterSessionRequest{
+		ServerName: "demo",
+		Namespace:  "mcp-team-acme",
+		AgentID:    "ops-agent",
+	})
+	req = req.WithContext(withPrincipal(req.Context(), fx.principal))
+	w := httptest.NewRecorder()
+	fx.server.HandleAdapterSession(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s, want 403", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "no enabled MCPAccessGrant") {
+		t.Fatalf("body = %q, want 'no enabled MCPAccessGrant'", w.Body.String())
+	}
+}
+
 func TestAdapterSessionRejectsWhenNoGrantMatches(t *testing.T) {
 	fx := newAdapterTestFixture(t) // no grants
 	req := adapterRequest(t, adapterSessionRequest{
@@ -203,16 +260,19 @@ func TestAdapterSessionPicksHighestTrustWithDeterministicTiebreak(t *testing.T) 
 		},
 	}
 	fx := newAdapterTestFixture(t, low, newer, older)
-	g, err := fx.server.selectAdapterGrant(
+	g, teamID, err := fx.server.selectAdapterGrant(
 		t.Context(),
 		"mcp-team-acme", "demo",
-		"user-123", "ops-agent", "team-acme",
+		"user-123", "ops-agent", []string{"team-acme"}, "team-acme", false,
 	)
 	if err != nil {
 		t.Fatalf("selectAdapterGrant: %v", err)
 	}
 	if g.Name != "g-older" {
 		t.Fatalf("selected = %q, want g-older (highest trust, oldest first for tiebreak)", g.Name)
+	}
+	if teamID != "team-acme" {
+		t.Fatalf("teamID = %q, want team-acme", teamID)
 	}
 }
 

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -145,6 +145,25 @@ func TestStaticAppHidesProtectedTabsWhenSignedOut(t *testing.T) {
 	}
 }
 
+func TestStaticAppDefaultsAdminsToAllNamespaceGovernance(t *testing.T) {
+	body, err := os.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read static app: %v", err)
+	}
+	source := string(body)
+	for _, want := range []string{
+		`function adminAllNamespaceScope()`,
+		`is_admin_fleet: true`,
+		`return "all namespaces";`,
+		`authPrincipal?.role === "admin" && namespaceScopes.length > 1`,
+		`namespaceScopes = [adminAllNamespaceScope(), ...namespaceScopes]`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("admin governance scope missing %q", want)
+		}
+	}
+}
+
 func TestStaticAppHidesUserAPIKeysWithoutUserIdentity(t *testing.T) {
 	index, err := os.ReadFile("static/index.html")
 	if err != nil {

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -110,6 +110,9 @@ function scopedPath(path) {
 }
 
 function namespaceScopeLabel(item) {
+  if (item?.is_admin_fleet || item?.scope === "all") {
+    return "all namespaces";
+  }
   if (item?.is_public || item?.scope === "public") {
     return `public / ${item.namespace}`;
   }
@@ -184,6 +187,15 @@ function publicPreviewScopes() {
   }];
 }
 
+function adminAllNamespaceScope() {
+  return {
+    namespace: "",
+    scope: "all",
+    scope_name: "All namespaces",
+    is_admin_fleet: true,
+  };
+}
+
 async function loadNamespaceScopes() {
   if (!authenticated) {
     namespaceScopes = publicCatalogEnabled ? publicPreviewScopes() : [];
@@ -199,8 +211,13 @@ async function loadNamespaceScopes() {
     console.error("Failed to load namespaces:", err);
     namespaceScopes = [];
   }
-  if (authPrincipal?.role !== "admin" && namespaceScopes.length > 1) {
+  if (authPrincipal?.role === "admin" && namespaceScopes.length > 1) {
+    namespaceScopes = [adminAllNamespaceScope(), ...namespaceScopes];
+  } else if (authPrincipal?.role !== "admin" && namespaceScopes.length > 1) {
     namespaceScopes = [{ namespace: "", scope: "catalog", is_catalog: true }, ...namespaceScopes];
+  }
+  if (namespaceScopes.some((item) => item.is_admin_fleet) && (!selectedNamespace || selectedNamespace === defaults.namespace)) {
+    selectedNamespace = "";
   }
   if (namespaceScopes.some((item) => item.is_catalog) && (!selectedNamespace || selectedNamespace === defaults.namespace)) {
     selectedNamespace = "";


### PR DESCRIPTION
## What changed
- Updated adapter session issuance to evaluate grants against the caller's team memberships instead of only the target server namespace team.
- Issues the MCPAgentSession using the team ID from the selected grant, so cross-team grants render usable gateway identities.
- Added tests for successful cross-team adapter sessions and rejection when the caller does not hold the granted team.

## Why
Cross-team access such as Globex using an Acme server through an MCPAccessGrant failed because the platform derived the session team ID from Acme's namespace. The rendered grant expected Globex's team ID, so session creation returned 403 and the adapter could not start.

## Validation
- `go test ./internal/runtimeapi -run 'TestAdapterSession' -count=1` from `services/api`
- `go test ./internal/runtimeapi -count=1` from `services/api`
- Pre-commit hook suite during commit with isolated `MCP_RUNTIME_CONFIG_DIR`: gitleaks, go fmt, staticcheck, go vet, root go unit tests, generated-file drift
- Same targeted adapter tests passed on `devbox2` after copying the patch for live validation