### PR TITLE
feat(api): add team user management

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -325,7 +325,9 @@ POST /api/runtime/adapter/sessions     # Issue/reuse an adapter MCPAgentSession 
 GET  /api/runtime/teams                # Admin: all teams; user: caller memberships
 POST /api/runtime/teams                # Admin-only team + namespace provisioning
 GET  /api/runtime/teams/{team}         # Team metadata (admin/member)
+GET  /api/runtime/teams/{team}/members # List team memberships (admin/member)
 POST /api/runtime/teams/{team}/members # Admin/team-owner membership upsert
+POST /api/runtime/teams/{team}/users   # Admin-only password user create/update + team membership
 DELETE /api/runtime/teams/{team}/members/{userID}
 GET  /api/runtime/namespaces           # Allowed namespaces + org catalog metadata
 GET  /api/runtime/namespaces/{namespace}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,7 +53,7 @@ mcp-runtime <group> <subcommand> --help
 | `registry` | Inspect the internal registry, configure an external one, push images. | `status`, `info`, `provision`, `push` |
 | `server` | Manage `MCPServer` resources and operator-facing actions. | `list`, `get`, `create`, `apply`, `deploy`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
 | `access` | Manage `MCPAccessGrant` and `MCPAgentSession` resources that feed the gateway policy layer. | `grant list/get/apply/delete/disable/enable`, `session list/get/apply/delete/revoke/unrevoke` |
-| `team` | Manage internal platform teams and Kubernetes team namespaces. | `list`, `create`, `init` |
+| `team` | Manage internal platform teams, team password users, and Kubernetes team namespaces. | `list`, `create`, `user list`, `user create`, `init` |
 | `sentinel` | Inspect and operate the bundled analytics, gateway, and observability stack. | `status`, `events`, `logs`, `port-forward`, `restart` |
 | `pipeline` | Generate `MCPServer` manifests from metadata and deploy them. | `generate`, `deploy` |
 | `status` | Aggregated platform health (cluster, registry, operator, servers, sentinel). | `status` |
@@ -162,6 +162,12 @@ mcp-runtime auth login \
   --email admin@example.com \
   --password '...'
 
+# `--username` is accepted as an alias for `--email`
+mcp-runtime auth login \
+  --api-url https://platform.example.com \
+  --username globex@example.com \
+  --password '...'
+
 # Record the platform registry host too
 mcp-runtime auth login \
   --api-url https://platform.example.com \
@@ -265,14 +271,22 @@ when inspecting or operating one team's policy resources.
 ```bash
 mcp-runtime team list
 mcp-runtime team create acme --name "Acme"
+mcp-runtime team user create globex \
+  --username globex@example.com \
+  --password '...' \
+  --role member
+mcp-runtime team user list globex
 mcp-runtime team init acme --group acme-mcp-admins
 mcp-runtime team init acme --dry-run
 ```
 
-`team list` and `team create` use the platform API, so run `auth login` or set
-platform API credentials first. `team create` creates a platform team and
-managed namespace, including quota/limits, default-deny NetworkPolicy, service
-account, and repo-managed Traefik watch wiring when bundled Traefik is present.
+`team list`, `team create`, and `team user` use the platform API, so run
+`auth login` or set platform API credentials first. `team create` creates a
+platform team and managed namespace, including quota/limits, default-deny
+NetworkPolicy, service account, and repo-managed Traefik watch wiring when
+bundled Traefik is present. `team user create` is admin-only. It creates or
+updates a password-login user and adds that user to the team as `member` or
+`owner`; use `auth login --username/--email --password` for the user login.
 
 `team init` uses local `kubectl`. It creates the team namespace, restricted
 workload service account, default quota and limits, default-deny NetworkPolicy,

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -2670,6 +2670,7 @@ kubectl clients, terminal output, and test doubles.
 - [`func NewSetupStepFailedError() error`](#cli-core-func-newsetupstepfailederror-error)
 - [`func NewWithSentinel(base error, msg string) error`](#cli-core-func-newwithsentinel-base-error-msg-string-error)
 - [`func Red(msg string) string`](#cli-core-func-red-msg-string-string)
+- [`func ResolveEmailAlias(email, username string) (string, error)`](#cli-core-func-resolveemailalias-email-username-string-string-error)
 - [`func Section(title string)`](#cli-core-func-section-title-string)
 - [`func SetDebugMode(enabled bool)`](#cli-core-func-setdebugmode-enabled-bool)
 - [`func SpinnerStart(msg string) func(success bool, finalMsg string)`](#cli-core-func-spinnerstart-msg-string-func-success-bool-finalmsg-string)
@@ -3178,6 +3179,14 @@ func NewWithSentinel(base error, msg string) error
 ```text
 func Red(msg string) string
     Red returns red text.
+
+```
+
+<a id="cli-core-func-resolveemailalias-email-username-string-string-error"></a>
+```text
+func ResolveEmailAlias(email, username string) (string, error)
+    ResolveEmailAlias returns the single account email represented by --email
+    and the deprecated/alias --username flag.
 
 ```
 
@@ -4573,7 +4582,7 @@ _No package overview is documented._
 - [`type Principal struct`](#cli-platform-api-type-principal-struct)
 - [`type ServerListItem struct`](#cli-platform-api-type-serverlistitem-struct)
 - [`type Team struct`](#cli-platform-api-type-team-struct)
-- [`type TeamMembership struct`](#cli-platform-api-type-teammembership-struct)
+- [`type TeamMembership = platform.TeamMembership`](#cli-platform-api-type-teammembership-platform-teammembership)
 
 <a id="cli-platform-api-functions"></a>
 ### Functions
@@ -4851,18 +4860,9 @@ type Team struct {
 
 ```
 
-<a id="cli-platform-api-type-teammembership-struct"></a>
+<a id="cli-platform-api-type-teammembership-platform-teammembership"></a>
 ```text
-type TeamMembership struct {
-	TeamID        string    `json:"team_id"`
-	TeamSlug      string    `json:"team_slug"`
-	TeamName      string    `json:"team_name"`
-	TeamNamespace string    `json:"team_namespace"`
-	UserID        string    `json:"user_id"`
-	Email         string    `json:"email,omitempty"`
-	Role          string    `json:"role"`
-	CreatedAt     time.Time `json:"created_at"`
-}
+type TeamMembership = platform.TeamMembership
 ```
 
 <a id="cli-platform-status"></a>

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -4551,6 +4551,7 @@ _No package overview is documented._
 - [`func (c *PlatformClient) ApplyRuntimeServerWithScope(ctx context.Context, name, namespace, scope string, spec mcpv1alpha1.MCPServerSpec) (ServerListItem, error)`](#cli-platform-api-func-c-platformclient-applyruntimeserverwithscope-ctx-context-context-name-namespace-scope-string-spec-mcpv1alpha1-mcpserverspec-serverlistitem-error)
 - [`func (c *PlatformClient) CreateAdapterSession(ctx context.Context, req AdapterSessionRequest) (AdapterSession, error)`](#cli-platform-api-func-c-platformclient-createadaptersession-ctx-context-context-req-adaptersessionrequest-adaptersession-error)
 - [`func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Team, error)`](#cli-platform-api-func-c-platformclient-createteam-ctx-context-context-slug-name-string-team-error)
+- [`func (c *PlatformClient) CreateTeamUser(ctx context.Context, slug, email, password, role string) (TeamMembership, error)`](#cli-platform-api-func-c-platformclient-createteamuser-ctx-context-context-slug-email-password-role-string-teammembership-error)
 - [`func (c *PlatformClient) CurrentPrincipal(ctx context.Context) (Principal, error)`](#cli-platform-api-func-c-platformclient-currentprincipal-ctx-context-context-principal-error)
 - [`func (c *PlatformClient) DeleteGrant(ctx context.Context, namespace, name string) error`](#cli-platform-api-func-c-platformclient-deletegrant-ctx-context-context-namespace-name-string-error)
 - [`func (c *PlatformClient) DeleteRuntimeServer(ctx context.Context, namespace, name string) error`](#cli-platform-api-func-c-platformclient-deleteruntimeserver-ctx-context-context-namespace-name-string-error)
@@ -4563,6 +4564,7 @@ _No package overview is documented._
 - [`func (c *PlatformClient) ListNamespaces(ctx context.Context) ([]namespaceListItem, error)`](#cli-platform-api-func-c-platformclient-listnamespaces-ctx-context-context-namespacelistitem-error)
 - [`func (c *PlatformClient) ListRuntimeServers(ctx context.Context, namespace string) ([]ServerListItem, error)`](#cli-platform-api-func-c-platformclient-listruntimeservers-ctx-context-context-namespace-string-serverlistitem-error)
 - [`func (c *PlatformClient) ListSessions(ctx context.Context, namespace string) ([]sentinelaccess.SessionSummary, error)`](#cli-platform-api-func-c-platformclient-listsessions-ctx-context-context-namespace-string-sentinelaccess-sessionsummary-error)
+- [`func (c *PlatformClient) ListTeamMembers(ctx context.Context, slug string) ([]TeamMembership, error)`](#cli-platform-api-func-c-platformclient-listteammembers-ctx-context-context-slug-string-teammembership-error)
 - [`func (c *PlatformClient) ListTeams(ctx context.Context) ([]Team, error)`](#cli-platform-api-func-c-platformclient-listteams-ctx-context-context-team-error)
 - [`func (c *PlatformClient) PostGrantToggle(ctx context.Context, namespace, name, action string) error`](#cli-platform-api-func-c-platformclient-postgranttoggle-ctx-context-context-namespace-name-action-string-error)
 - [`func (c *PlatformClient) PostSessionToggle(ctx context.Context, namespace, name, action string) error`](#cli-platform-api-func-c-platformclient-postsessiontoggle-ctx-context-context-namespace-name-action-string-error)
@@ -4571,6 +4573,7 @@ _No package overview is documented._
 - [`type Principal struct`](#cli-platform-api-type-principal-struct)
 - [`type ServerListItem struct`](#cli-platform-api-type-serverlistitem-struct)
 - [`type Team struct`](#cli-platform-api-type-team-struct)
+- [`type TeamMembership struct`](#cli-platform-api-type-teammembership-struct)
 
 <a id="cli-platform-api-functions"></a>
 ### Functions
@@ -4694,6 +4697,12 @@ func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Tea
 
 ```
 
+<a id="cli-platform-api-func-c-platformclient-createteamuser-ctx-context-context-slug-email-password-role-string-teammembership-error"></a>
+```text
+func (c *PlatformClient) CreateTeamUser(ctx context.Context, slug, email, password, role string) (TeamMembership, error)
+
+```
+
 <a id="cli-platform-api-func-c-platformclient-currentprincipal-ctx-context-context-principal-error"></a>
 ```text
 func (c *PlatformClient) CurrentPrincipal(ctx context.Context) (Principal, error)
@@ -4766,6 +4775,12 @@ func (c *PlatformClient) ListSessions(ctx context.Context, namespace string) ([]
 
 ```
 
+<a id="cli-platform-api-func-c-platformclient-listteammembers-ctx-context-context-slug-string-teammembership-error"></a>
+```text
+func (c *PlatformClient) ListTeamMembers(ctx context.Context, slug string) ([]TeamMembership, error)
+
+```
+
 <a id="cli-platform-api-func-c-platformclient-listteams-ctx-context-context-team-error"></a>
 ```text
 func (c *PlatformClient) ListTeams(ctx context.Context) ([]Team, error)
@@ -4832,6 +4847,21 @@ type Team struct {
 	Name      string    `json:"name"`
 	Namespace string    `json:"namespace"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+```
+
+<a id="cli-platform-api-type-teammembership-struct"></a>
+```text
+type TeamMembership struct {
+	TeamID        string    `json:"team_id"`
+	TeamSlug      string    `json:"team_slug"`
+	TeamName      string    `json:"team_name"`
+	TeamNamespace string    `json:"team_namespace"`
+	UserID        string    `json:"user_id"`
+	Email         string    `json:"email,omitempty"`
+	Role          string    `json:"role"`
+	CreatedAt     time.Time `json:"created_at"`
 }
 ```
 

--- a/docs/internals/internal-cli.md
+++ b/docs/internals/internal-cli.md
@@ -188,11 +188,11 @@ Tests: `adapter/adapter_test.go`, `adapter/platformsession_test.go`, and
 
 ## Team
 
-`internal/cli/team/` owns platform team commands. `team list` and `team create`
-call the platform API through `internal/cli/platformapi`; `team init` renders
-local Kubernetes namespace, RBAC, quota, limits, NetworkPolicy, workload service
-account, and bundled Traefik watch manifests before applying them with
-`kubectl`.
+`internal/cli/team/` owns platform team commands. `team list`, `team create`,
+and `team user` call the platform API through `internal/cli/platformapi`;
+`team init` renders local Kubernetes namespace, RBAC, quota, limits,
+NetworkPolicy, workload service account, and bundled Traefik watch manifests
+before applying them with `kubectl`.
 
 Team behavior spans CLI and API code: platform-backed team creation and
 membership routes live in `services/api/internal/runtimeapi`, durable identity

--- a/docs/multi-team.md
+++ b/docs/multi-team.md
@@ -43,6 +43,10 @@ through the platform-backed team command:
 ```bash
 mcp-runtime auth login --api-url https://platform.example.com
 mcp-runtime team create acme --name "Acme"
+mcp-runtime team user create acme \
+  --username acme-user@example.com \
+  --password '...' \
+  --role member
 mcp-runtime team list
 ```
 
@@ -54,6 +58,17 @@ watch entry. Platform API server writes into that namespace default
 default missing `subject.teamID` to the owning server team, but an explicit
 foreign `subject.teamID` is allowed so a team can delegate access to another
 team's principal.
+
+Use `team user create` as a platform admin when you need a local password-login
+user for a team. The command creates or updates the password identity, adds the
+user to the team as `member` or `owner`, and then the user can sign in with:
+
+```bash
+mcp-runtime auth login \
+  --api-url https://platform.example.com \
+  --username acme-user@example.com \
+  --password '...'
+```
 
 For direct Kubernetes administration, use `team init`:
 

--- a/docs/security/authz-matrix.md
+++ b/docs/security/authz-matrix.md
@@ -61,8 +61,11 @@ Expected codes:
 | `/api/user/api-keys`                                  | GET, POST     | 401  | 200         | 200      | 200       | 401/403    | Lifecycle for user-owned keys. |
 | `/api/user/api-keys/{id}`                             | GET, DEL      | 401  | 200         | 200      | 200       | 401/403    | |
 | `/api/runtime/servers`                                | GET, POST     | 401  | 200         | 200      | 200       | 401/403    | List/create MCP servers. |
-| `/api/runtime/teams`                                  | GET, POST     | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/teams/{id}`                             | GET, PUT, DEL | 401  | 200         | 200      | 200       | 401/403    | |
+| `/api/runtime/teams`                                  | GET           | 401  | 200         | 200      | 200       | 401/403    | |
+| `/api/runtime/teams`                                  | POST          | 401  | 403         | 403      | 200       | 401/403    | Admin-only team + namespace provisioning. |
+| `/api/runtime/teams/{id}`                             | GET           | 401  | 200         | 200      | 200       | 401/403    | Team members can read only their teams; admins can read all teams. |
+| `/api/runtime/teams/{id}/members`                     | GET, POST     | 401  | 200         | 200      | 200       | 401/403    | POST requires admin or team owner. |
+| `/api/runtime/teams/{id}/users`                       | POST          | 401  | 403         | 403      | 200       | 401/403    | Admin-only password user create/update plus membership. |
 | `/api/runtime/namespaces`                             | GET           | 401  | 200         | 200      | 200       | 401/403    | |
 | `/api/runtime/namespaces/{name}`                      | GET           | 401  | 200         | 200      | 200       | 401/403    | |
 | `/api/deployments`                                    | GET           | 401  | 200         | 200      | 200       | 401/403    | |

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -150,7 +150,9 @@ metrics on `METRICS_PORT` (default `9090`).
 | `POST` | `/api/runtime/sessions/{namespace}/{name}/unrevoke` | Set `spec.revoked=false`. |
 | `GET`, `POST` | `/api/runtime/teams` | List teams (admin: all, user: memberships) or create a team+namespace (admin-only). |
 | `GET` | `/api/runtime/teams/{team}` | Read team metadata for admins and team members. |
+| `GET` | `/api/runtime/teams/{team}/members` | List team memberships for admins and team members. |
 | `POST` | `/api/runtime/teams/{team}/members` | Add/update team membership (admin or team owner). |
+| `POST` | `/api/runtime/teams/{team}/users` | Create/update a password-login user and add the user to a team. Admin role required. |
 | `DELETE` | `/api/runtime/teams/{team}/members/{userID}` | Remove team membership (admin or team owner). |
 | `GET` | `/api/runtime/namespaces` | List allowed namespaces and org catalog metadata for caller scope. |
 | `GET` | `/api/runtime/namespaces/{namespace}` | Read one namespace metadata entry when authorized. |

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -112,7 +112,7 @@ func (m *manager) runLogin(cmd *cobra.Command, f loginFlags) error {
 		return errors.New("api URL must include scheme and host")
 	}
 
-	loginEmail, err := resolveLoginEmail(f.email, f.username)
+	loginEmail, err := core.ResolveEmailAlias(f.email, f.username)
 	if err != nil {
 		return err
 	}
@@ -189,18 +189,6 @@ func (m *manager) runLogin(cmd *cobra.Command, f loginFlags) error {
 		fmt.Fprintf(stdout, "Registry host recorded: %s\n", c.RegistryHost)
 	}
 	return nil
-}
-
-func resolveLoginEmail(email, username string) (string, error) {
-	email = strings.TrimSpace(email)
-	username = strings.TrimSpace(username)
-	if email != "" && username != "" && !strings.EqualFold(email, username) {
-		return "", errors.New("--email and --username must match when both are set")
-	}
-	if email != "" {
-		return email, nil
-	}
-	return username, nil
 }
 
 func (m *manager) NewLogoutCmd() *cobra.Command {

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -36,6 +36,7 @@ type manager struct {
 type loginFlags struct {
 	apiURL         string
 	email          string
+	username       string
 	password       string
 	token          string
 	tokenFromStdin bool
@@ -84,6 +85,7 @@ func (m *manager) NewLoginCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&f.apiURL, "api-url", os.Getenv(authfile.EnvAPIURL), "Sentinel API base URL (scheme and host, no /api path)")
 	cmd.Flags().StringVar(&f.email, "email", "", "Platform account email for password login")
+	cmd.Flags().StringVar(&f.username, "username", "", "Alias for --email")
 	cmd.Flags().StringVar(&f.password, "password", "", "Platform account password (prefer interactive prompt or token auth in shared shells)")
 	cmd.Flags().StringVar(&f.token, "token", "", "API token (or use --token-stdin, or the interactive prompt)")
 	cmd.Flags().BoolVar(&f.tokenFromStdin, "token-stdin", false, "Read the token from stdin (non-interactive)")
@@ -110,12 +112,17 @@ func (m *manager) runLogin(cmd *cobra.Command, f loginFlags) error {
 		return errors.New("api URL must include scheme and host")
 	}
 
+	loginEmail, err := resolveLoginEmail(f.email, f.username)
+	if err != nil {
+		return err
+	}
+
 	var token, loginRole string
-	if strings.TrimSpace(f.email) != "" || strings.TrimSpace(f.password) != "" {
-		if strings.TrimSpace(f.email) == "" || strings.TrimSpace(f.password) == "" {
+	if loginEmail != "" || strings.TrimSpace(f.password) != "" {
+		if loginEmail == "" || strings.TrimSpace(f.password) == "" {
 			return errors.New("email and password are both required for password login")
 		}
-		tok, role, err := loginPlatformPassword(context.Background(), apiURL, f.email, f.password)
+		tok, role, err := loginPlatformPassword(context.Background(), apiURL, loginEmail, f.password)
 		if err != nil {
 			return fmt.Errorf("platform login failed: %w", err)
 		}
@@ -182,6 +189,18 @@ func (m *manager) runLogin(cmd *cobra.Command, f loginFlags) error {
 		fmt.Fprintf(stdout, "Registry host recorded: %s\n", c.RegistryHost)
 	}
 	return nil
+}
+
+func resolveLoginEmail(email, username string) (string, error) {
+	email = strings.TrimSpace(email)
+	username = strings.TrimSpace(username)
+	if email != "" && username != "" && !strings.EqualFold(email, username) {
+		return "", errors.New("--email and --username must match when both are set")
+	}
+	if email != "" {
+		return email, nil
+	}
+	return username, nil
 }
 
 func (m *manager) NewLogoutCmd() *cobra.Command {

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -126,3 +126,19 @@ func TestAuthLoginNormalizesTrailingAPIPath(t *testing.T) {
 		t.Fatalf("token = %q, want good", creds.Token)
 	}
 }
+
+func TestResolveLoginEmailAcceptsUsernameAlias(t *testing.T) {
+	got, err := resolveLoginEmail("", "user@example.com")
+	if err != nil {
+		t.Fatalf("resolveLoginEmail() error = %v", err)
+	}
+	if got != "user@example.com" {
+		t.Fatalf("email = %q, want username alias", got)
+	}
+}
+
+func TestResolveLoginEmailRejectsMismatchedAlias(t *testing.T) {
+	if _, err := resolveLoginEmail("user@example.com", "other@example.com"); err == nil {
+		t.Fatal("expected mismatch error")
+	}
+}

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -126,19 +126,3 @@ func TestAuthLoginNormalizesTrailingAPIPath(t *testing.T) {
 		t.Fatalf("token = %q, want good", creds.Token)
 	}
 }
-
-func TestResolveLoginEmailAcceptsUsernameAlias(t *testing.T) {
-	got, err := resolveLoginEmail("", "user@example.com")
-	if err != nil {
-		t.Fatalf("resolveLoginEmail() error = %v", err)
-	}
-	if got != "user@example.com" {
-		t.Fatalf("email = %q, want username alias", got)
-	}
-}
-
-func TestResolveLoginEmailRejectsMismatchedAlias(t *testing.T) {
-	if _, err := resolveLoginEmail("user@example.com", "other@example.com"); err == nil {
-		t.Fatal("expected mismatch error")
-	}
-}

--- a/internal/cli/core/identity.go
+++ b/internal/cli/core/identity.go
@@ -1,0 +1,20 @@
+package core
+
+import (
+	"errors"
+	"strings"
+)
+
+// ResolveEmailAlias returns the single account email represented by --email and
+// the deprecated/alias --username flag.
+func ResolveEmailAlias(email, username string) (string, error) {
+	email = strings.TrimSpace(email)
+	username = strings.TrimSpace(username)
+	if email != "" && username != "" && !strings.EqualFold(email, username) {
+		return "", errors.New("--email and --username must match when both are set")
+	}
+	if email != "" {
+		return email, nil
+	}
+	return username, nil
+}

--- a/internal/cli/core/identity_test.go
+++ b/internal/cli/core/identity_test.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestResolveEmailAliasAcceptsUsernameAlias(t *testing.T) {
+	got, err := ResolveEmailAlias("", "user@example.com")
+	if err != nil {
+		t.Fatalf("ResolveEmailAlias() error = %v", err)
+	}
+	if got != "user@example.com" {
+		t.Fatalf("email = %q, want username alias", got)
+	}
+}
+
+func TestResolveEmailAliasRejectsMismatchedAlias(t *testing.T) {
+	_, err := ResolveEmailAlias("user@example.com", "other@example.com")
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	if !strings.Contains(err.Error(), "must match") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}

--- a/internal/cli/platformapi/client.go
+++ b/internal/cli/platformapi/client.go
@@ -429,7 +429,7 @@ func grantFromV1(g *mcpv1alpha1.MCPAccessGrant) grantAPIBody {
 		Name:               g.Name,
 		Namespace:          ns,
 		ServerRef:          sentinelaccess.ServerReference{Name: g.Spec.ServerRef.Name, Namespace: g.Spec.ServerRef.Namespace},
-		Subject:            sentinelaccess.SubjectRef{HumanID: g.Spec.Subject.HumanID, AgentID: g.Spec.Subject.AgentID},
+		Subject:            sentinelaccess.SubjectRef{HumanID: g.Spec.Subject.HumanID, AgentID: g.Spec.Subject.AgentID, TeamID: g.Spec.Subject.TeamID},
 		MaxTrust:           trust,
 		AllowedSideEffects: allowedSideEffects,
 		PolicyVersion:      g.Spec.PolicyVersion,
@@ -448,7 +448,7 @@ func sessionFromV1(s *mcpv1alpha1.MCPAgentSession) sessionAPIBody {
 		Name:           s.Name,
 		Namespace:      ns,
 		ServerRef:      sentinelaccess.ServerReference{Name: s.Spec.ServerRef.Name, Namespace: s.Spec.ServerRef.Namespace},
-		Subject:        sentinelaccess.SubjectRef{HumanID: s.Spec.Subject.HumanID, AgentID: s.Spec.Subject.AgentID},
+		Subject:        sentinelaccess.SubjectRef{HumanID: s.Spec.Subject.HumanID, AgentID: s.Spec.Subject.AgentID, TeamID: s.Spec.Subject.TeamID},
 		ConsentedTrust: sentinelaccess.TrustLevel(s.Spec.ConsentedTrust),
 		PolicyVersion:  s.Spec.PolicyVersion,
 		Revoked:        &rev,
@@ -511,12 +511,37 @@ type Team struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+type TeamMembership struct {
+	TeamID        string    `json:"team_id"`
+	TeamSlug      string    `json:"team_slug"`
+	TeamName      string    `json:"team_name"`
+	TeamNamespace string    `json:"team_namespace"`
+	UserID        string    `json:"user_id"`
+	Email         string    `json:"email,omitempty"`
+	Role          string    `json:"role"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
 type teamsResponse struct {
 	Teams []Team `json:"teams"`
 }
 
 type teamResponse struct {
 	Team Team `json:"team"`
+}
+
+type teamMembersResponse struct {
+	Members []TeamMembership `json:"members"`
+}
+
+type teamUserResponse struct {
+	User struct {
+		ID        string `json:"id"`
+		Email     string `json:"email"`
+		Role      string `json:"role"`
+		Namespace string `json:"namespace"`
+	} `json:"user"`
+	Membership TeamMembership `json:"membership"`
 }
 
 type namespaceListItem struct {
@@ -709,6 +734,60 @@ func (c *PlatformClient) CreateTeam(ctx context.Context, slug, name string) (Tea
 		return Team{}, err
 	}
 	return out.Team, nil
+}
+
+func (c *PlatformClient) ListTeamMembers(ctx context.Context, slug string) ([]TeamMembership, error) {
+	rel := "/runtime/teams/" + url.PathEscape(strings.TrimSpace(slug)) + "/members"
+	resp, err := c.do(ctx, http.MethodGet, rel, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, httpAPIError(resp.StatusCode, b)
+	}
+	var out teamMembersResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out.Members, nil
+}
+
+func (c *PlatformClient) CreateTeamUser(ctx context.Context, slug, email, password, role string) (TeamMembership, error) {
+	payload := map[string]string{
+		"email":    strings.TrimSpace(email),
+		"password": password,
+		"role":     strings.TrimSpace(role),
+	}
+	js, err := json.Marshal(payload)
+	if err != nil {
+		return TeamMembership{}, err
+	}
+	rel := "/runtime/teams/" + url.PathEscape(strings.TrimSpace(slug)) + "/users"
+	resp, err := c.do(ctx, http.MethodPost, rel, "", bytes.NewReader(js))
+	if err != nil {
+		return TeamMembership{}, err
+	}
+	defer resp.Body.Close()
+	b, err := readBody(resp.Body)
+	if err != nil {
+		return TeamMembership{}, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return TeamMembership{}, httpAPIError(resp.StatusCode, b)
+	}
+	var out teamUserResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		return TeamMembership{}, err
+	}
+	if out.Membership.Email == "" {
+		out.Membership.Email = out.User.Email
+	}
+	return out.Membership, nil
 }
 
 func (c *PlatformClient) ListNamespaces(ctx context.Context) ([]namespaceListItem, error) {

--- a/internal/cli/platformapi/client.go
+++ b/internal/cli/platformapi/client.go
@@ -22,6 +22,7 @@ import (
 	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
 	sentinelaccess "mcp-runtime/pkg/access"
 	"mcp-runtime/pkg/authfile"
+	"mcp-runtime/pkg/platform"
 )
 
 const maxAPIBodyRead = 4 << 20
@@ -511,16 +512,7 @@ type Team struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-type TeamMembership struct {
-	TeamID        string    `json:"team_id"`
-	TeamSlug      string    `json:"team_slug"`
-	TeamName      string    `json:"team_name"`
-	TeamNamespace string    `json:"team_namespace"`
-	UserID        string    `json:"user_id"`
-	Email         string    `json:"email,omitempty"`
-	Role          string    `json:"role"`
-	CreatedAt     time.Time `json:"created_at"`
-}
+type TeamMembership = platform.TeamMembership
 
 type teamsResponse struct {
 	Teams []Team `json:"teams"`
@@ -783,9 +775,6 @@ func (c *PlatformClient) CreateTeamUser(ctx context.Context, slug, email, passwo
 	var out teamUserResponse
 	if err := json.Unmarshal(b, &out); err != nil {
 		return TeamMembership{}, err
-	}
-	if out.Membership.Email == "" {
-		out.Membership.Email = out.User.Email
 	}
 	return out.Membership, nil
 }

--- a/internal/cli/platformapi/client_test.go
+++ b/internal/cli/platformapi/client_test.go
@@ -198,7 +198,7 @@ func TestPlatformClientTeamAndServerRoutes(t *testing.T) {
 				}
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       io.NopCloser(strings.NewReader(`{"user":{"id":"user-1","email":"member@example.com","role":"user"},"membership":{"team_slug":"core","team_namespace":"mcp-team-core","user_id":"user-1","role":"member"}}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"user":{"id":"user-1","email":"member@example.com","role":"user"},"membership":{"team_slug":"core","team_namespace":"mcp-team-core","user_id":"user-1","email":"member@example.com","role":"member"}}`)),
 				}, nil
 			case r.Method == http.MethodGet && r.URL.Path == "/api/runtime/servers":
 				if got := r.URL.Query().Get("namespace"); got != "" {

--- a/internal/cli/platformapi/client_test.go
+++ b/internal/cli/platformapi/client_test.go
@@ -27,8 +27,24 @@ func TestApplyAccessFromYAMLFile_MultiDocument(t *testing.T) {
 			switch r.URL.Path {
 			case "/api/runtime/grants":
 				grantCalls++
+				body, _ := io.ReadAll(r.Body)
+				var payload grantAPIBody
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("decode grant body: %v", err)
+				}
+				if payload.Subject.TeamID != "team-acme" {
+					t.Fatalf("grant subject teamID = %q, want team-acme", payload.Subject.TeamID)
+				}
 			case "/api/runtime/sessions":
 				sessionCalls++
+				body, _ := io.ReadAll(r.Body)
+				var payload sessionAPIBody
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatalf("decode session body: %v", err)
+				}
+				if payload.Subject.TeamID != "team-acme" {
+					t.Fatalf("session subject teamID = %q, want team-acme", payload.Subject.TeamID)
+				}
 			default:
 				t.Fatalf("unexpected path %q", r.URL.Path)
 			}
@@ -51,6 +67,7 @@ spec:
     name: demo
   subject:
     humanID: user-1
+    teamID: team-acme
   maxTrust: low
   allowedSideEffects:
     - read
@@ -68,6 +85,7 @@ spec:
     name: demo
   subject:
     humanID: user-1
+    teamID: team-acme
   consentedTrust: low
 `), 0o600); err != nil {
 		t.Fatal(err)
@@ -155,6 +173,11 @@ func TestPlatformClientTeamAndServerRoutes(t *testing.T) {
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(`{"team":{"slug":"core","name":"Core","namespace":"mcp-team-core"}}`)),
 				}, nil
+			case r.Method == http.MethodGet && r.URL.Path == "/api/runtime/teams/core/members":
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"members":[{"team_slug":"core","team_namespace":"mcp-team-core","user_id":"user-1","email":"member@example.com","role":"member"}]}`)),
+				}, nil
 			case r.Method == http.MethodPost && r.URL.Path == "/api/runtime/teams":
 				body, _ := io.ReadAll(r.Body)
 				var payload map[string]string
@@ -165,6 +188,17 @@ func TestPlatformClientTeamAndServerRoutes(t *testing.T) {
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Body:       io.NopCloser(strings.NewReader(`{"team":{"slug":"core","name":"Core Team","namespace":"mcp-team-core"}}`)),
+				}, nil
+			case r.Method == http.MethodPost && r.URL.Path == "/api/runtime/teams/core/users":
+				body, _ := io.ReadAll(r.Body)
+				var payload map[string]string
+				_ = json.Unmarshal(body, &payload)
+				if payload["email"] != "member@example.com" || payload["password"] != "password123" || payload["role"] != "member" {
+					t.Fatalf("create team user payload = %#v", payload)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(`{"user":{"id":"user-1","email":"member@example.com","role":"user"},"membership":{"team_slug":"core","team_namespace":"mcp-team-core","user_id":"user-1","role":"member"}}`)),
 				}, nil
 			case r.Method == http.MethodGet && r.URL.Path == "/api/runtime/servers":
 				if got := r.URL.Query().Get("namespace"); got != "" {
@@ -218,6 +252,20 @@ func TestPlatformClientTeamAndServerRoutes(t *testing.T) {
 	}
 	if _, err := client.CreateTeam(context.Background(), "core", "Core Team"); err != nil {
 		t.Fatalf("CreateTeam() error = %v", err)
+	}
+	members, err := client.ListTeamMembers(context.Background(), "core")
+	if err != nil {
+		t.Fatalf("ListTeamMembers() error = %v", err)
+	}
+	if len(members) != 1 || members[0].Email != "member@example.com" {
+		t.Fatalf("members = %#v", members)
+	}
+	created, err := client.CreateTeamUser(context.Background(), "core", "member@example.com", "password123", "member")
+	if err != nil {
+		t.Fatalf("CreateTeamUser() error = %v", err)
+	}
+	if created.Email != "member@example.com" || created.TeamSlug != "core" {
+		t.Fatalf("created membership = %#v", created)
 	}
 	if _, err := client.ListRuntimeServers(context.Background(), ""); err != nil {
 		t.Fatalf("ListRuntimeServers() error = %v", err)

--- a/internal/cli/team/manager.go
+++ b/internal/cli/team/manager.go
@@ -87,6 +87,50 @@ func (m *Manager) CreateTeam(slug, name string) error {
 	return nil
 }
 
+func (m *Manager) ListTeamUsers(slug string) error {
+	client, err := platformapi.NewPlatformClient()
+	if err != nil {
+		return err
+	}
+	members, err := client.ListTeamMembers(context.Background(), strings.TrimSpace(slug))
+	if err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "EMAIL\tUSER ID\tROLE\tTEAM\tNAMESPACE")
+	for _, member := range members {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", member.Email, member.UserID, member.Role, member.TeamSlug, member.TeamNamespace)
+	}
+	_ = tw.Flush()
+	return nil
+}
+
+func (m *Manager) CreateTeamUser(slug, email, password, role string) error {
+	client, err := platformapi.NewPlatformClient()
+	if err != nil {
+		return err
+	}
+	slug = strings.TrimSpace(slug)
+	email = strings.TrimSpace(email)
+	role = strings.TrimSpace(role)
+	if email == "" {
+		return errors.New("email is required (use --email or --username)")
+	}
+	if strings.TrimSpace(password) == "" {
+		return errors.New("password is required")
+	}
+	if role == "" {
+		role = "member"
+	}
+	member, err := client.CreateTeamUser(context.Background(), slug, email, password, role)
+	if err != nil {
+		return err
+	}
+	core.Success(fmt.Sprintf("Ensured user %s in team %s as %s", member.Email, member.TeamSlug, member.Role))
+	return nil
+}
+
 func (m *Manager) InitTeam(opts InitOptions) error {
 	normalized, err := normalizeInitOptions(opts)
 	if err != nil {

--- a/internal/cli/team/manager_test.go
+++ b/internal/cli/team/manager_test.go
@@ -109,3 +109,23 @@ func TestInitTeamRejectsReservedNamespace(t *testing.T) {
 		t.Fatalf("expected reserved namespace error, got %v", err)
 	}
 }
+
+func TestResolveTeamUserEmailAcceptsUsernameAlias(t *testing.T) {
+	got, err := resolveTeamUserEmail("", "globex@example.com")
+	if err != nil {
+		t.Fatalf("resolveTeamUserEmail() error = %v", err)
+	}
+	if got != "globex@example.com" {
+		t.Fatalf("resolveTeamUserEmail() = %q, want username alias", got)
+	}
+}
+
+func TestResolveTeamUserEmailRejectsMismatchedAlias(t *testing.T) {
+	_, err := resolveTeamUserEmail("globex@example.com", "other@example.com")
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	if !strings.Contains(err.Error(), "must match") {
+		t.Fatalf("expected mismatch error, got %v", err)
+	}
+}

--- a/internal/cli/team/manager_test.go
+++ b/internal/cli/team/manager_test.go
@@ -109,23 +109,3 @@ func TestInitTeamRejectsReservedNamespace(t *testing.T) {
 		t.Fatalf("expected reserved namespace error, got %v", err)
 	}
 }
-
-func TestResolveTeamUserEmailAcceptsUsernameAlias(t *testing.T) {
-	got, err := resolveTeamUserEmail("", "globex@example.com")
-	if err != nil {
-		t.Fatalf("resolveTeamUserEmail() error = %v", err)
-	}
-	if got != "globex@example.com" {
-		t.Fatalf("resolveTeamUserEmail() = %q, want username alias", got)
-	}
-}
-
-func TestResolveTeamUserEmailRejectsMismatchedAlias(t *testing.T) {
-	_, err := resolveTeamUserEmail("globex@example.com", "other@example.com")
-	if err == nil {
-		t.Fatal("expected mismatch error")
-	}
-	if !strings.Contains(err.Error(), "must match") {
-		t.Fatalf("expected mismatch error, got %v", err)
-	}
-}

--- a/internal/cli/team/team.go
+++ b/internal/cli/team/team.go
@@ -1,9 +1,6 @@
 package team
 
 import (
-	"errors"
-	"strings"
-
 	"github.com/spf13/cobra"
 
 	"mcp-runtime/internal/cli/core"
@@ -52,7 +49,7 @@ func NewWithManager(mgr *Manager) *cobra.Command {
 		Short: "Create or update a password-login user and add them to a team",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			email, err := resolveTeamUserEmail(userEmail, userUsername)
+			email, err := core.ResolveEmailAlias(userEmail, userUsername)
 			if err != nil {
 				return err
 			}
@@ -99,16 +96,4 @@ func NewWithManager(mgr *Manager) *cobra.Command {
 
 	cmd.AddCommand(listCmd, createCmd, userCmd, initCmd)
 	return cmd
-}
-
-func resolveTeamUserEmail(email, username string) (string, error) {
-	email = strings.TrimSpace(email)
-	username = strings.TrimSpace(username)
-	if email != "" && username != "" && !strings.EqualFold(email, username) {
-		return "", errors.New("--email and --username must match when both are set")
-	}
-	if email != "" {
-		return email, nil
-	}
-	return username, nil
 }

--- a/internal/cli/team/team.go
+++ b/internal/cli/team/team.go
@@ -1,6 +1,9 @@
 package team
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"mcp-runtime/internal/cli/core"
@@ -36,6 +39,41 @@ func NewWithManager(mgr *Manager) *cobra.Command {
 	}
 	createCmd.Flags().StringVar(&name, "name", "", "Display name for the team (defaults to slug)")
 
+	var userEmail string
+	var userUsername string
+	var userPassword string
+	var userRole string
+	userCmd := &cobra.Command{
+		Use:   "user",
+		Short: "Manage password-login users for a team",
+	}
+	userCreateCmd := &cobra.Command{
+		Use:   "create [team-slug]",
+		Short: "Create or update a password-login user and add them to a team",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			email, err := resolveTeamUserEmail(userEmail, userUsername)
+			if err != nil {
+				return err
+			}
+			return mgr.CreateTeamUser(args[0], email, userPassword, userRole)
+		},
+	}
+	userCreateCmd.Flags().StringVar(&userEmail, "email", "", "Platform account email")
+	userCreateCmd.Flags().StringVar(&userUsername, "username", "", "Alias for --email")
+	userCreateCmd.Flags().StringVar(&userPassword, "password", "", "Platform account password (prefer a private shell or environment-managed invocation)")
+	userCreateCmd.Flags().StringVar(&userRole, "role", "member", "Team role for the user: member or owner")
+
+	userListCmd := &cobra.Command{
+		Use:   "list [team-slug]",
+		Short: "List users in a team",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return mgr.ListTeamUsers(args[0])
+		},
+	}
+	userCmd.AddCommand(userCreateCmd, userListCmd)
+
 	initOpts := InitOptions{}
 	initCmd := &cobra.Command{
 		Use:   "init [slug]",
@@ -59,6 +97,18 @@ func NewWithManager(mgr *Manager) *cobra.Command {
 	initCmd.Flags().StringVar(&initOpts.TraefikServiceAccount, "traefik-service-account", "traefik", "Bundled Traefik ServiceAccount to bind in the team namespace")
 	initCmd.Flags().BoolVar(&initOpts.DryRun, "dry-run", false, "Print the generated namespace/RBAC manifest without applying or patching Traefik")
 
-	cmd.AddCommand(listCmd, createCmd, initCmd)
+	cmd.AddCommand(listCmd, createCmd, userCmd, initCmd)
 	return cmd
+}
+
+func resolveTeamUserEmail(email, username string) (string, error) {
+	email = strings.TrimSpace(email)
+	username = strings.TrimSpace(username)
+	if email != "" && username != "" && !strings.EqualFold(email, username) {
+		return "", errors.New("--email and --username must match when both are set")
+	}
+	if email != "" {
+		return email, nil
+	}
+	return username, nil
 }

--- a/pkg/platform/types.go
+++ b/pkg/platform/types.go
@@ -1,0 +1,15 @@
+package platform
+
+import "time"
+
+// TeamMembership is the shared API contract for platform team membership data.
+type TeamMembership struct {
+	TeamID        string    `json:"team_id"`
+	TeamSlug      string    `json:"team_slug"`
+	TeamName      string    `json:"team_name"`
+	TeamNamespace string    `json:"team_namespace"`
+	UserID        string    `json:"user_id"`
+	Email         string    `json:"email,omitempty"`
+	Role          string    `json:"role"`
+	CreatedAt     time.Time `json:"created_at"`
+}

--- a/services/api/internal/platformstore/auth.go
+++ b/services/api/internal/platformstore/auth.go
@@ -142,11 +142,12 @@ DO UPDATE SET user_id = EXCLUDED.user_id, password_hash = EXCLUDED.password_hash
 // not accidentally demoted when they are added to a team.
 func (s *Store) EnsureTeamPasswordUser(ctx context.Context, email, password string) (User, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
+	password = strings.TrimSpace(password)
 	if !validEmail(email) {
 		return User{}, errors.New("valid email required")
 	}
-	if len(password) < 8 {
-		return User{}, errors.New("password must be at least 8 characters")
+	if len(password) < 12 {
+		return User{}, errors.New("password must be at least 12 characters")
 	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), 12)
 	if err != nil {

--- a/services/api/internal/platformstore/auth.go
+++ b/services/api/internal/platformstore/auth.go
@@ -137,6 +137,60 @@ DO UPDATE SET user_id = EXCLUDED.user_id, password_hash = EXCLUDED.password_hash
 	return u, nil
 }
 
+// EnsureTeamPasswordUser ensures a regular password-login account exists for
+// team membership flows. Existing platform roles are preserved so an admin is
+// not accidentally demoted when they are added to a team.
+func (s *Store) EnsureTeamPasswordUser(ctx context.Context, email, password string) (User, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if !validEmail(email) {
+		return User{}, errors.New("valid email required")
+	}
+	if len(password) < 8 {
+		return User{}, errors.New("password must be at least 8 characters")
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+	if err != nil {
+		return User{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return User{}, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var u User
+	err = tx.QueryRowContext(ctx, `
+SELECT u.id, u.email, u.role, ''
+FROM users u
+WHERE u.email = $1 AND u.deleted_at IS NULL`, email).
+		Scan(&u.ID, &u.Email, &u.Role, &u.Namespace)
+	if errors.Is(err, sql.ErrNoRows) {
+		u = User{ID: uuid.NewString(), Email: email, Role: RoleUser}
+		if _, err = tx.ExecContext(ctx, `INSERT INTO users (id,email,role) VALUES ($1,$2,$3)`, u.ID, u.Email, u.Role); err != nil {
+			return User{}, err
+		}
+	} else if err != nil {
+		return User{}, err
+	}
+
+	if _, err = tx.ExecContext(ctx, `
+INSERT INTO auth_identities (user_id, provider, subject, password_hash)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (provider, subject)
+DO UPDATE SET user_id = EXCLUDED.user_id, password_hash = EXCLUDED.password_hash`, u.ID, passwordProvider, email, string(hash)); err != nil {
+		return User{}, err
+	}
+	if err = tx.Commit(); err != nil {
+		return User{}, err
+	}
+	return u, nil
+}
+
 func (s *Store) AuthenticatePassword(ctx context.Context, email, password string) (User, bool, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
 	var u User

--- a/services/api/internal/platformstore/auth_test.go
+++ b/services/api/internal/platformstore/auth_test.go
@@ -1,0 +1,18 @@
+package platformstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestEnsureTeamPasswordUserTrimsBeforeLengthCheck(t *testing.T) {
+	store := NewForTest(nil)
+	_, err := store.EnsureTeamPasswordUser(context.Background(), "member@example.com", " 12345678901 ")
+	if err == nil {
+		t.Fatal("expected short password error")
+	}
+	if !strings.Contains(err.Error(), "at least 12 characters") {
+		t.Fatalf("expected password length error, got %v", err)
+	}
+}

--- a/services/api/internal/platformstore/teams.go
+++ b/services/api/internal/platformstore/teams.go
@@ -188,6 +188,32 @@ ORDER BY t.slug ASC`, userID)
 	return out, rows.Err()
 }
 
+func (s *Store) ListTeamMemberships(ctx context.Context, teamSlug string) ([]TeamMembership, error) {
+	teamSlug = NormalizeTeamSlug(teamSlug)
+	rows, err := s.db.QueryContext(ctx, `
+SELECT t.id, t.slug, t.display_name, COALESCE(n.namespace, ''), tm.user_id::text, u.email, tm.role, tm.created_at
+FROM team_memberships tm
+JOIN teams t ON t.id = tm.team_id AND t.deleted_at IS NULL
+JOIN users u ON u.id = tm.user_id AND u.deleted_at IS NULL
+LEFT JOIN namespaces n ON n.team_id = t.id AND n.deleted_at IS NULL AND COALESCE(n.scope, 'team') = 'team'
+WHERE t.slug = $1 AND tm.deleted_at IS NULL
+ORDER BY u.email ASC`, teamSlug)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]TeamMembership, 0)
+	for rows.Next() {
+		var membership TeamMembership
+		if err := rows.Scan(&membership.TeamID, &membership.TeamSlug, &membership.TeamName, &membership.TeamNamespace, &membership.UserID, &membership.Email, &membership.Role, &membership.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, membership)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) GetTeamBySlug(ctx context.Context, slug string) (Team, bool, error) {
 	slug = NormalizeTeamSlug(slug)
 	var team Team

--- a/services/api/internal/platformstore/types.go
+++ b/services/api/internal/platformstore/types.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"strings"
 	"time"
+
+	"mcp-runtime/pkg/platform"
 )
 
 const (
@@ -110,16 +112,7 @@ type Team struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-type TeamMembership struct {
-	TeamID        string    `json:"team_id"`
-	TeamSlug      string    `json:"team_slug"`
-	TeamName      string    `json:"team_name"`
-	TeamNamespace string    `json:"team_namespace"`
-	UserID        string    `json:"user_id"`
-	Email         string    `json:"email,omitempty"`
-	Role          string    `json:"role"`
-	CreatedAt     time.Time `json:"created_at"`
-}
+type TeamMembership = platform.TeamMembership
 
 type APIKeySummary struct {
 	ID        string     `json:"id"`

--- a/services/api/internal/platformstore/types.go
+++ b/services/api/internal/platformstore/types.go
@@ -116,6 +116,7 @@ type TeamMembership struct {
 	TeamName      string    `json:"team_name"`
 	TeamNamespace string    `json:"team_namespace"`
 	UserID        string    `json:"user_id"`
+	Email         string    `json:"email,omitempty"`
 	Role          string    `json:"role"`
 	CreatedAt     time.Time `json:"created_at"`
 }

--- a/services/api/internal/runtimeapi/teams.go
+++ b/services/api/internal/runtimeapi/teams.go
@@ -374,6 +374,13 @@ func (s *RuntimeServer) handleRuntimeTeamUserCreate(w http.ResponseWriter, r *ht
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
+	if _, ok, err := s.platform.GetTeamBySlug(ctx, teamSlug); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch team"})
+		return
+	} else if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "team not found"})
+		return
+	}
 	u, err := s.platform.EnsureTeamPasswordUser(ctx, req.Email, req.Password)
 	if err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})

--- a/services/api/internal/runtimeapi/teams.go
+++ b/services/api/internal/runtimeapi/teams.go
@@ -58,11 +58,17 @@ func (s *RuntimeServer) HandleRuntimeTeamItemPath(w http.ResponseWriter, r *http
 	case len(parts) == 1 && r.Method == http.MethodGet:
 		s.handleRuntimeTeamGet(w, r, p, teamSlug)
 		return
+	case len(parts) == 2 && parts[1] == "members" && r.Method == http.MethodGet:
+		s.handleRuntimeTeamMemberList(w, r, p, teamSlug)
+		return
 	case len(parts) == 2 && parts[1] == "members" && r.Method == http.MethodPost:
 		s.handleRuntimeTeamMemberUpsert(w, r, p, teamSlug)
 		return
 	case len(parts) == 3 && parts[1] == "members" && r.Method == http.MethodDelete:
 		s.handleRuntimeTeamMemberDelete(w, r, p, teamSlug, strings.TrimSpace(parts[2]))
+		return
+	case len(parts) == 2 && parts[1] == "users" && r.Method == http.MethodPost:
+		s.handleRuntimeTeamUserCreate(w, r, p, teamSlug)
 		return
 	default:
 		w.Header().Set("allow", "GET, POST, DELETE")
@@ -300,6 +306,21 @@ func (s *RuntimeServer) handleRuntimeTeamCreate(w http.ResponseWriter, r *http.R
 	writeJSON(w, http.StatusOK, map[string]any{"team": team})
 }
 
+func (s *RuntimeServer) handleRuntimeTeamMemberList(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
+	if p.Role != roleAdmin && p.TeamRole(teamSlug) == "" {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	memberships, err := s.platform.ListTeamMemberships(ctx, teamSlug)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list team members"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"members": memberships})
+}
+
 func (s *RuntimeServer) handleRuntimeTeamMemberUpsert(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
 	if p.Role != roleAdmin && p.TeamRole(teamSlug) != teamRoleOwner {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
@@ -326,6 +347,60 @@ func (s *RuntimeServer) handleRuntimeTeamMemberUpsert(w http.ResponseWriter, r *
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"membership": membership})
+}
+
+func (s *RuntimeServer) handleRuntimeTeamUserCreate(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
+	if p.Role != roleAdmin {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin role required"})
+		return
+	}
+	var req struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+		Role     string `json:"role"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, teamApplyMaxBytes)
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeBodyDecodeError(w, err)
+		return
+	}
+	membershipRole := strings.ToLower(strings.TrimSpace(req.Role))
+	if membershipRole == "" {
+		membershipRole = teamRoleMember
+	}
+	if membershipRole != teamRoleMember && membershipRole != teamRoleOwner {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role must be member or owner"})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	u, err := s.platform.EnsureTeamPasswordUser(ctx, req.Email, req.Password)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	membership, err := s.platform.UpsertTeamMembership(ctx, teamSlug, u.ID, membershipRole)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "team or user not found"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	membership.Email = u.Email
+	s.writeAudit(r.Context(), auditEvent{
+		UserID:       p.UserID(),
+		Action:       "team_user_create",
+		Resource:     u.Email,
+		Namespace:    membership.TeamNamespace,
+		Status:       "success",
+		Message:      "team=" + membership.TeamSlug + " role=" + membership.Role,
+		ActorIP:      requestIP(r),
+		Source:       auditSource(r, p),
+		AuthIdentity: auditIdentityLabel(p),
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"user": u, "membership": membership})
 }
 
 func (s *RuntimeServer) handleRuntimeTeamMemberDelete(w http.ResponseWriter, r *http.Request, p principal, teamSlug, userID string) {

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -164,6 +164,43 @@ func TestStaticAppDefaultsAdminsToAllNamespaceGovernance(t *testing.T) {
 	}
 }
 
+func TestStaticAppIncludesAdminTeamsView(t *testing.T) {
+	index, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("read static index: %v", err)
+	}
+	html := string(index)
+	for _, want := range []string{
+		`id="tab-button-teams"`,
+		`id="tab-teams"`,
+		`id="team-create-form"`,
+		`id="team-user-form"`,
+		`id="team-user-password"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("teams view missing %q", want)
+		}
+	}
+
+	body, err := os.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read static app: %v", err)
+	}
+	source := string(body)
+	for _, want := range []string{
+		`loadTeams()`,
+		`fetchJSON("/runtime/teams")`,
+		"`/runtime/teams/${encodePathSegment(selectedTeamSlug)}/members`",
+		"`/runtime/teams/${encodePathSegment(team)}/users`",
+		`document.getElementById("team-user-password")?.value || ""`,
+		`function initTeams()`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("teams app missing %q", want)
+		}
+	}
+}
+
 func TestStaticAppHidesUserAPIKeysWithoutUserIdentity(t *testing.T) {
 	index, err := os.ReadFile("static/index.html")
 	if err != nil {

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -10,6 +10,8 @@ let authPrincipal = null;
 let grantsCache = [];
 let sessionsCache = [];
 let userAPIKeysCache = [];
+let teamsCache = [];
+let teamMembersCache = [];
 let serversCache = [];
 let publishPolicyCache = null;
 let selectedServerKey = "";
@@ -27,6 +29,7 @@ let serverSearchQuery = "";
 let serverStatusFilter = "all";
 let selectedOperationsServerKey = "";
 let selectedUserAnalyticsServerKey = "";
+let selectedTeamSlug = "";
 let namespaceScopes = [];
 let selectedNamespace = defaults.namespace || "";
 
@@ -322,6 +325,8 @@ function initTabs() {
       } else if (target === "governance") {
         loadGrants();
         loadSessions();
+      } else if (target === "teams") {
+        loadTeams();
       } else if (target === "operations") {
         loadMCPOperations();
       } else if (target === "platform") {
@@ -939,6 +944,7 @@ async function logout() {
   resetDashboard();
   resetUserDashboard();
   resetGovernance();
+  resetTeams();
   resetUserAPIKeys();
   activateTab("servers");
   if (publicCatalogEnabled) {
@@ -996,6 +1002,8 @@ function loadActiveTab() {
   } else if (active === "governance") {
     loadGrants();
     loadSessions();
+  } else if (active === "teams") {
+    loadTeams();
   } else if (active === "operations") {
     loadMCPOperations();
   } else if (active === "platform") {
@@ -2556,6 +2564,232 @@ function initGovernance() {
   document.getElementById("session-filter")?.addEventListener("input", debouncedRenderSessions);
 }
 
+// Teams
+async function loadTeams() {
+  setInlineError("team-create-error");
+  setInlineError("team-user-error");
+  try {
+    const data = await fetchJSON("/runtime/teams");
+    teamsCache = Array.isArray(data.teams) ? data.teams : [];
+    if (!teamsCache.some((team) => team.slug === selectedTeamSlug)) {
+      selectedTeamSlug = teamsCache[0]?.slug || "";
+    }
+    renderTeams();
+    renderTeamSelect();
+    await loadTeamMembers();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    const message = `Failed to load teams: ${readErrorMessage(err, "request failed")}`;
+    teamsCache = [];
+    teamMembersCache = [];
+    renderTeams();
+    renderTeamSelect();
+    renderTeamMembers();
+    setInlineError("team-create-error", message);
+    showToast(message, "error");
+  }
+}
+
+async function loadTeamMembers() {
+  if (!selectedTeamSlug) {
+    teamMembersCache = [];
+    renderTeamMembers();
+    return;
+  }
+  try {
+    const data = await fetchJSON(`/runtime/teams/${encodePathSegment(selectedTeamSlug)}/members`);
+    teamMembersCache = Array.isArray(data.members) ? data.members : [];
+    renderTeamMembers();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    const message = `Failed to load team users: ${readErrorMessage(err, "request failed")}`;
+    teamMembersCache = [];
+    renderTeamMembers();
+    setInlineError("team-user-error", message);
+    showToast(message, "error");
+  }
+}
+
+function renderTeams() {
+  setText("teams-total", formatNumber(teamsCache.length));
+  setText("team-members-total", formatNumber(teamMembersCache.length));
+  setText("team-selected-count", selectedTeamSlug || "-");
+
+  const tbody = document.getElementById("teams-body");
+  if (!tbody) return;
+  if (!teamsCache.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No teams found.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  teamsCache.forEach((team) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(team.name || team.slug || "-", team.slug || ""));
+    row.appendChild(createTextCell(team.namespace || "-"));
+    row.appendChild(createCodeCell(team.id || "-"));
+    row.appendChild(createTextCell(formatDateTime(team.created_at)));
+    row.addEventListener("click", () => {
+      selectedTeamSlug = team.slug || "";
+      renderTeamSelect();
+      loadTeamMembers();
+    });
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+function renderTeamSelect() {
+  const select = document.getElementById("team-user-team");
+  if (!select) return;
+  select.innerHTML = "";
+  if (!teamsCache.length) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "No teams";
+    select.appendChild(option);
+    select.disabled = true;
+    return;
+  }
+  teamsCache.forEach((team) => {
+    const option = document.createElement("option");
+    option.value = team.slug || "";
+    option.textContent = `${team.slug || "-"} / ${team.namespace || "-"}`;
+    select.appendChild(option);
+  });
+  select.disabled = false;
+  select.value = selectedTeamSlug;
+}
+
+function renderTeamMembers() {
+  setText("team-members-total", formatNumber(teamMembersCache.length));
+  setText("team-selected-count", selectedTeamSlug || "-");
+
+  const tbody = document.getElementById("team-members-body");
+  if (!tbody) return;
+  if (!selectedTeamSlug) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">Select a team.</td></tr>';
+    return;
+  }
+  if (!teamMembersCache.length) {
+    tbody.innerHTML = '<tr><td colspan="4" class="empty">No users in this team.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  teamMembersCache.forEach((member) => {
+    const row = document.createElement("tr");
+    row.appendChild(createIdentityCell(member.email || member.user_id || "-", member.team_slug || selectedTeamSlug));
+    row.appendChild(createBadgeCell(member.role || "member", member.role === "owner" ? "badge-warning" : "badge-muted"));
+    row.appendChild(createCodeCell(member.user_id || "-"));
+    row.appendChild(createTextCell(formatDateTime(member.created_at)));
+    fragment.appendChild(row);
+  });
+  tbody.appendChild(fragment);
+}
+
+async function createTeam(event) {
+  event.preventDefault();
+  const submit = event.submitter;
+  if (submit?.disabled) return;
+  const slug = fieldValue("team-create-slug");
+  const name = fieldValue("team-create-name");
+  setInlineError("team-create-error");
+  if (!slug) {
+    const message = "Team slug is required.";
+    setInlineError("team-create-error", message);
+    showToast(message, "warning");
+    return;
+  }
+  if (submit) submit.disabled = true;
+  try {
+    await fetchJSON("/runtime/teams", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug, name }),
+    });
+    showToast(`Team "${slug}" created`);
+    selectedTeamSlug = slug;
+    document.getElementById("team-create-form")?.reset();
+    await loadNamespaceScopes();
+    await loadTeams();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    const message = `Failed to create team: ${readErrorMessage(err, "request failed")}`;
+    setInlineError("team-create-error", message);
+    showToast(message, "error");
+  } finally {
+    if (submit) submit.disabled = false;
+  }
+}
+
+async function createTeamUser(event) {
+  event.preventDefault();
+  const submit = event.submitter;
+  if (submit?.disabled) return;
+  const team = fieldValue("team-user-team") || selectedTeamSlug;
+  const email = fieldValue("team-user-email");
+  const password = document.getElementById("team-user-password")?.value || "";
+  const role = fieldValue("team-user-role") || "member";
+  setInlineError("team-user-error");
+  if (!team || !email || !password.trim()) {
+    const message = "Team, email, and password are required.";
+    setInlineError("team-user-error", message);
+    showToast(message, "warning");
+    return;
+  }
+  if (submit) submit.disabled = true;
+  try {
+    await fetchJSON(`/runtime/teams/${encodePathSegment(team)}/users`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, role }),
+    });
+    showToast(`User "${email}" added to ${team}`);
+    selectedTeamSlug = team;
+    const passwordInput = document.getElementById("team-user-password");
+    if (passwordInput) passwordInput.value = "";
+    await loadTeamMembers();
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    const message = `Failed to create team user: ${readErrorMessage(err, "request failed")}`;
+    setInlineError("team-user-error", message);
+    showToast(message, "error");
+  } finally {
+    if (submit) submit.disabled = false;
+  }
+}
+
+function resetTeams() {
+  teamsCache = [];
+  teamMembersCache = [];
+  selectedTeamSlug = "";
+  setText("teams-total", "-");
+  setText("team-members-total", "-");
+  setText("team-selected-count", "-");
+  setInlineError("team-create-error");
+  setInlineError("team-user-error");
+  const teamsBody = document.getElementById("teams-body");
+  if (teamsBody) {
+    teamsBody.innerHTML = '<tr><td colspan="4" class="empty">No teams found.</td></tr>';
+  }
+  const membersBody = document.getElementById("team-members-body");
+  if (membersBody) {
+    membersBody.innerHTML = '<tr><td colspan="4" class="empty">Select a team.</td></tr>';
+  }
+  renderTeamSelect();
+}
+
+function initTeams() {
+  document.getElementById("refresh-teams")?.addEventListener("click", loadTeams);
+  document.getElementById("team-create-form")?.addEventListener("submit", createTeam);
+  document.getElementById("team-user-form")?.addEventListener("submit", createTeamUser);
+  document.getElementById("team-user-team")?.addEventListener("change", (event) => {
+    selectedTeamSlug = event.target.value || "";
+    loadTeamMembers();
+  });
+}
+
 // User API Keys
 async function loadUserAPIKeys(options = {}) {
   if (!options.preserveOneTime) {
@@ -3362,6 +3596,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initTabs();
   initDashboard();
   initGovernance();
+  initTeams();
   initUserAPIKeys();
   initOperations();
   initPlatform();

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -76,6 +76,18 @@
           Dashboard
         </button>
         <button
+          id="tab-button-teams"
+          class="tab"
+          data-tab="teams"
+          data-admin-only="true"
+          role="tab"
+          type="button"
+          aria-controls="tab-teams"
+          aria-selected="false"
+        >
+          Teams
+        </button>
+        <button
           id="tab-button-governance"
           class="tab"
           data-tab="governance"
@@ -340,6 +352,130 @@
                 </tr>
               </tbody>
             </table>
+          </div>
+        </div>
+      </section>
+
+      <!-- Teams Tab -->
+      <section
+        id="tab-teams"
+        class="tab-content"
+        data-admin-only="true"
+        role="tabpanel"
+        aria-labelledby="tab-button-teams"
+        hidden
+      >
+        <div class="metrics-grid">
+          <div class="metric-card">
+            <span class="metric-label">Teams</span>
+            <strong class="metric-value" id="teams-total">-</strong>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Members</span>
+            <strong class="metric-value" id="team-members-total">-</strong>
+          </div>
+          <div class="metric-card">
+            <span class="metric-label">Selected</span>
+            <strong class="metric-value" id="team-selected-count">-</strong>
+          </div>
+        </div>
+
+        <div class="ops-two-column">
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>Teams</h2>
+                <p class="panel-kicker">Tenant namespaces and team identities.</p>
+              </div>
+              <div class="panel-actions">
+                <button class="ghost" id="refresh-teams" type="button">Refresh</button>
+              </div>
+            </div>
+            <form class="governance-form" id="team-create-form">
+              <div class="form-grid">
+                <label>
+                  Slug
+                  <input type="text" id="team-create-slug" autocomplete="off" required />
+                </label>
+                <label>
+                  Name
+                  <input type="text" id="team-create-name" autocomplete="off" />
+                </label>
+              </div>
+              <p id="team-create-error" class="form-error hidden" role="alert"></p>
+              <div class="form-actions">
+                <button class="primary" type="submit">Create Team</button>
+              </div>
+            </form>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Team</th>
+                    <th>Namespace</th>
+                    <th>ID</th>
+                    <th>Created</th>
+                  </tr>
+                </thead>
+                <tbody id="teams-body">
+                  <tr>
+                    <td colspan="4" class="empty">Loading teams...</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>Team Users</h2>
+                <p class="panel-kicker">Password-login users and team membership.</p>
+              </div>
+              <div class="panel-actions">
+                <select id="team-user-team" aria-label="Select team"></select>
+              </div>
+            </div>
+            <form class="governance-form" id="team-user-form">
+              <div class="form-grid">
+                <label>
+                  Email
+                  <input type="email" id="team-user-email" autocomplete="username" required />
+                </label>
+                <label>
+                  Password
+                  <input type="password" id="team-user-password" autocomplete="new-password" required />
+                </label>
+                <label>
+                  Team Role
+                  <select id="team-user-role">
+                    <option value="member" selected>member</option>
+                    <option value="owner">owner</option>
+                  </select>
+                </label>
+              </div>
+              <p id="team-user-error" class="form-error hidden" role="alert"></p>
+              <div class="form-actions">
+                <button class="primary" type="submit">Create User</button>
+              </div>
+            </form>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>User</th>
+                    <th>Role</th>
+                    <th>User ID</th>
+                    <th>Added</th>
+                  </tr>
+                </thead>
+                <tbody id="team-members-body">
+                  <tr>
+                    <td colspan="4" class="empty">Select a team.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </section>

--- a/test/golden/cli/testdata/mcp-runtime_auth_login_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_auth_login_help.golden
@@ -12,6 +12,7 @@ Flags:
       --skip-verify            Store credentials without calling the API to validate the token
       --token string           API token (or use --token-stdin, or the interactive prompt)
       --token-stdin            Read the token from stdin (non-interactive)
+      --username string        Alias for --email
 
 Global Flags:
       --debug   Enable debug mode with structured error logging


### PR DESCRIPTION
Summary:
- add admin team user create/list platform APIs and CLI commands
- add an admin Teams dashboard view for team creation and password-login users
- document username/password login, team user commands, API routes, and generated API references

Tests:
- go test ./internal/cli/auth ./internal/cli/platformapi ./internal/cli/team -count=1
- go test ./test/golden/... -count=1
- go test ./... -count=1 (services/api)
- go test ./... -count=1 (services/ui)
- go build -o bin/mcp-runtime ./cmd/mcp-runtime
- pre-commit hooks during commit