### PR TITLE
doc: document registry TLS node trust gotcha

### DIFF
--- a/ai-assist/gotchas.md
+++ b/ai-assist/gotchas.md
@@ -60,10 +60,10 @@ Added: 2026-05-12
 ### Bundled registry TLS does not configure node trust
 
 `setup --registry-mode bundled-https` makes the registry pod serve HTTPS
-and renders platform image refs with a stable internal registry host, but
-kubelet still pulls through the node's container runtime. Nodes must be
-able to resolve or mirror that image host and trust the issuing CA; the
-cluster-side Certificate and Service changes alone do not update
+and creates `cert-manager/mcp-runtime-ca` when the built-in issuer is used,
+but kubelet still pulls through the node's container runtime. Nodes must
+be able to resolve or mirror that image host and trust the issuing CA; the
+cluster-side Secret, Certificate, and Service changes alone do not update
 containerd, k3s, Docker, or host DNS.
 
 References:

--- a/ai-assist/gotchas.md
+++ b/ai-assist/gotchas.md
@@ -60,9 +60,9 @@ Added: 2026-05-12
 ### Bundled registry TLS does not configure node trust
 
 `setup --registry-mode bundled-https` makes the registry pod serve HTTPS
-and creates `cert-manager/mcp-runtime-ca` when the built-in issuer is used,
+and creates the `cert-manager/mcp-runtime-ca` Secret when the built-in issuer is used,
 but kubelet still pulls through the node's container runtime. Nodes must
-be able to resolve or mirror that image host and trust the issuing CA; the
+be able to resolve or mirror the registry host and trust the issuing CA; the
 cluster-side Secret, Certificate, and Service changes alone do not update
 containerd, k3s, Docker, or host DNS.
 


### PR DESCRIPTION
## Summary
- clarify that bundled HTTPS registry setup can create the built-in issuer/CA but does not update node container runtime trust or DNS
- keep the gotcha focused on k3s/containerd/Docker node configuration requirements

Refs #216

## Verification
- pre-commit hooks during commit: gitleaks, go vet, staticcheck, generated file drift