### PR TITLE
feat(ui): improve dashboard navigation and catalog density

### DIFF
--- a/services/ui/main.go
+++ b/services/ui/main.go
@@ -1214,7 +1214,7 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 		h.Set("Content-Security-Policy",
 			"default-src 'self'; "+
 				"script-src 'self' https://accounts.google.com https://apis.google.com; "+
-				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "+
+				"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com; "+
 				"img-src 'self' data: https:; "+
 				"font-src 'self' data: https://fonts.gstatic.com; "+
 				"connect-src 'self' https://accounts.google.com; "+

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -520,8 +520,72 @@ func TestSecurityHeadersAllowConfiguredExternalAssets(t *testing.T) {
 	if !strings.Contains(csp, "https://fonts.googleapis.com") {
 		t.Fatalf("CSP should allow stylesheet font origin, got %q", csp)
 	}
+	if !strings.Contains(csp, "https://accounts.google.com") {
+		t.Fatalf("CSP should allow Google sign-in stylesheet origin, got %q", csp)
+	}
 	if !strings.Contains(csp, "https://fonts.gstatic.com") {
 		t.Fatalf("CSP should allow font file origin, got %q", csp)
+	}
+}
+
+func TestStaticAppUsesCompactCatalogInventorySections(t *testing.T) {
+	body, err := os.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read static app: %v", err)
+	}
+	source := string(body)
+	for _, want := range []string{
+		`function serverVisibleInventorySections(inventory)`,
+		`].filter((section) => section.items.length > 0);`,
+		`const visibleInventory = serverVisibleInventorySections(displayInventory)`,
+		`if (inventory.prompts.length)`,
+		`if (inventory.resources.length)`,
+		`if (inventory.tasks.length)`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("app missing compact catalog behavior %q", want)
+		}
+	}
+}
+
+func TestStaticMarkupBoundsLongActivityTables(t *testing.T) {
+	index, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("read static index: %v", err)
+	}
+	html := string(index)
+	if got := strings.Count(html, `class="table-wrap scroll-table"`); got < 4 {
+		t.Fatalf("expected long dashboard tables to use scroll-table, got %d", got)
+	}
+	for _, want := range []string{
+		`class="section-nav" aria-label="Dashboard sections"`,
+		`class="section-nav" aria-label="Operations sections"`,
+		`href="#ops-inspector-panel"`,
+		`placeholder="Search servers"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("index missing navigation affordance %q", want)
+		}
+	}
+
+	styles, err := os.ReadFile("static/styles.css")
+	if err != nil {
+		t.Fatalf("read static styles: %v", err)
+	}
+	css := string(styles)
+	for _, want := range []string{
+		`.table-wrap.scroll-table`,
+		`max-height: min(62vh, 680px);`,
+		`.scroll-table thead th`,
+		`position: sticky;`,
+		`.section-nav`,
+		`.tabs`,
+		`position: sticky;`,
+		`.server-card:hover`,
+	} {
+		if !strings.Contains(css, want) {
+			t.Fatalf("styles missing UX affordance %q", want)
+		}
 	}
 }
 

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -1402,13 +1402,15 @@ function renderServers() {
     card.appendChild(renderServerEndpoint(server));
 
     const displayInventory = serverDisplayInventory(server);
-    const inventory = document.createElement("div");
-    inventory.className = "server-inventory-grid";
-    inventory.appendChild(renderInventoryBlock("Tools", displayInventory.tools, renderToolItem));
-    inventory.appendChild(renderInventoryBlock("Prompts", displayInventory.prompts, renderInventoryItem));
-    inventory.appendChild(renderInventoryBlock("Resources", displayInventory.resources, renderInventoryItem));
-    inventory.appendChild(renderInventoryBlock("Tasks", displayInventory.tasks, renderInventoryItem));
-    card.appendChild(inventory);
+    const visibleInventory = serverVisibleInventorySections(displayInventory);
+    if (visibleInventory.length) {
+      const inventory = document.createElement("div");
+      inventory.className = "server-inventory-grid";
+      visibleInventory.forEach((section) => {
+        inventory.appendChild(renderInventoryBlock(section.label, section.items, section.renderer));
+      });
+      card.appendChild(inventory);
+    }
 
     if (server.access_json && Object.keys(server.access_json).length) {
       card.appendChild(renderServerConnectConfig(server));
@@ -1470,6 +1472,15 @@ function serverDisplayInventory(server) {
     resources: mergeNamedInventory(live.resources || [], declaredResources, resourceInventoryKey),
     tasks: declaredTasks,
   };
+}
+
+function serverVisibleInventorySections(inventory) {
+  return [
+    { label: "Tools", items: inventory.tools || [], renderer: renderToolItem },
+    { label: "Prompts", items: inventory.prompts || [], renderer: renderInventoryItem },
+    { label: "Resources", items: inventory.resources || [], renderer: renderInventoryItem },
+    { label: "Tasks", items: inventory.tasks || [], renderer: renderInventoryItem },
+  ].filter((section) => section.items.length > 0);
 }
 
 function mergeToolInventory(liveItems, declaredItems) {
@@ -1774,8 +1785,15 @@ function renderServerMeta(server) {
   meta.className = "server-meta-row";
   meta.appendChild(serverMetaPill("HTTP MCP"));
   meta.appendChild(serverMetaPill(`${inventory.tools.length} tools`));
-  meta.appendChild(serverMetaPill(`${inventory.prompts.length} prompts`));
-  meta.appendChild(serverMetaPill(`${inventory.resources.length} resources`));
+  if (inventory.prompts.length) {
+    meta.appendChild(serverMetaPill(`${inventory.prompts.length} prompts`));
+  }
+  if (inventory.resources.length) {
+    meta.appendChild(serverMetaPill(`${inventory.resources.length} resources`));
+  }
+  if (inventory.tasks.length) {
+    meta.appendChild(serverMetaPill(`${inventory.tasks.length} tasks`));
+  }
   meta.appendChild(serverMetaPill(`Created ${formatServerAge(server.age)}`));
   wrap.appendChild(meta);
 

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -159,7 +159,7 @@
               <input
                 type="search"
                 id="server-search"
-                placeholder="Search servers, namespaces, routes, tools"
+                placeholder="Search servers"
                 aria-label="Search MCP servers"
               />
             </div>
@@ -508,7 +508,12 @@
           </div>
         </div>
 
-        <div class="panel">
+        <nav class="section-nav" aria-label="Dashboard sections">
+          <a href="#dashboard-analytics">Usage analytics</a>
+          <a href="#dashboard-audit">Decision audit</a>
+        </nav>
+
+        <div class="panel" id="dashboard-analytics">
           <div class="panel-head">
             <h2>Usage Analytics</h2>
             <div class="panel-actions">
@@ -650,7 +655,7 @@
           </div>
         </div>
 
-        <div class="panel">
+        <div class="panel" id="dashboard-audit">
           <div class="panel-head">
             <h2>Decision Audit</h2>
             <div class="panel-actions">
@@ -661,7 +666,7 @@
               </label>
             </div>
           </div>
-          <div class="table-wrap">
+          <div class="table-wrap scroll-table">
             <table class="audit-table">
               <thead>
                 <tr>
@@ -964,9 +969,16 @@
               <button type="submit">Apply</button>
             </div>
           </form>
+          <nav class="section-nav" aria-label="Operations sections">
+            <a href="#ops-users-panel">Users</a>
+            <a href="#ops-server-health-panel">Server health</a>
+            <a href="#ops-activity-panels">Activity</a>
+            <a href="#ops-images-panel">Images</a>
+            <a href="#ops-inspector-panel">Inspector</a>
+          </nav>
         </div>
 
-        <div class="panel">
+        <div class="panel" id="ops-users-panel">
           <div class="panel-head">
             <div>
               <h2>Logged-in Users</h2>
@@ -994,7 +1006,7 @@
           </div>
         </div>
 
-        <div class="panel">
+        <div class="panel" id="ops-server-health-panel">
           <div class="panel-head">
             <div>
               <h2>MCP Server Health</h2>
@@ -1022,7 +1034,7 @@
           </div>
         </div>
 
-        <div class="ops-two-column">
+        <div class="ops-two-column" id="ops-activity-panels">
           <div class="panel">
             <div class="panel-head">
               <div>
@@ -1030,7 +1042,7 @@
                 <p class="panel-kicker">Recent login, deploy, image, credential, and denied platform actions.</p>
               </div>
             </div>
-            <div class="table-wrap">
+            <div class="table-wrap scroll-table">
               <table>
                 <thead>
                   <tr>
@@ -1057,7 +1069,7 @@
                 <p class="panel-kicker">Recent allow and deny decisions from the MCP gateway path.</p>
               </div>
             </div>
-            <div class="table-wrap">
+            <div class="table-wrap scroll-table">
               <table class="audit-table compact-audit-table">
                 <thead>
                   <tr>
@@ -1077,14 +1089,14 @@
           </div>
         </div>
 
-        <div class="panel">
+        <div class="panel" id="ops-images-panel">
           <div class="panel-head">
             <div>
               <h2>Images and Deployments</h2>
               <p class="panel-kicker">Image publish records and currently deployed image references by user or namespace.</p>
             </div>
           </div>
-          <div class="table-wrap">
+          <div class="table-wrap scroll-table">
             <table>
               <thead>
                 <tr>
@@ -1105,7 +1117,7 @@
           </div>
         </div>
 
-        <div class="panel">
+        <div class="panel" id="ops-inspector-panel">
           <div class="panel-head">
             <div>
               <h2>MCP Server Inspector</h2>

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -1,17 +1,22 @@
 @import "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600;700&family=DM+Serif+Display&display=swap";
 
 :root {
-  --bg: #0f1f1b;
-  --bg-secondary: #132b26;
-  --panel: #1b3b34;
+  --bg: #0b1412;
+  --bg-secondary: #10201d;
+  --surface: #0d1c19;
+  --panel: #17352f;
+  --panel-strong: #1d443c;
   --accent: #f2b84b;
   --accent-strong: #f26a4b;
+  --info: #8bd3ff;
   --text: #f7f5ef;
   --muted: #9cb6ab;
+  --line: rgba(247, 245, 239, 0.1);
   --shadow: rgba(0, 0, 0, 0.35);
   --success: #4ade80;
   --warning: #fbbf24;
   --error: #f87171;
+  --focus-ring: rgba(139, 211, 255, 0.56);
 }
 
 * {
@@ -20,23 +25,27 @@
 
 html {
   min-height: 100%;
-  background: radial-gradient(circle at top left, #2b4f46, var(--bg));
+  background:
+    radial-gradient(circle at top left, rgba(45, 82, 73, 0.72), transparent 34rem),
+    linear-gradient(145deg, #0c1513 0%, var(--bg) 56%, #08100e 100%);
 }
 
 body {
   margin: 0;
   font-family: "Space Grotesk", "Helvetica Neue", sans-serif;
   color: var(--text);
-  background: radial-gradient(circle at top left, #2b4f46, var(--bg));
+  background:
+    radial-gradient(circle at top left, rgba(45, 82, 73, 0.72), transparent 34rem),
+    linear-gradient(145deg, #0c1513 0%, var(--bg) 56%, #08100e 100%);
   min-height: 100vh;
   overflow-x: hidden;
 }
 
 .canvas {
-  max-width: 1400px;
+  max-width: 1360px;
   margin: 0 auto;
   min-height: 100vh;
-  padding: 40px 24px 64px;
+  padding: 30px 24px 56px;
 }
 
 /* Header */
@@ -45,7 +54,7 @@ body {
   grid-template-columns: 1fr auto;
   gap: 24px;
   align-items: center;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .eyebrow {
@@ -58,27 +67,30 @@ body {
 
 h1 {
   font-family: "DM Serif Display", serif;
-  font-size: clamp(32px, 4vw, 48px);
+  font-size: clamp(32px, 3.6vw, 44px);
   line-height: 1.05;
-  margin: 0 0 12px;
+  margin: 0 0 10px;
   overflow-wrap: break-word;
 }
 
 .lede {
-  font-size: 16px;
+  font-size: 15px;
   color: var(--muted);
   margin: 0;
 }
 
 .hero-links {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
+  justify-content: flex-end;
 }
 
 .link-badge {
   display: inline-flex;
   align-items: center;
-  padding: 8px 16px;
+  min-height: 34px;
+  padding: 8px 14px;
   border-radius: 999px;
   border: 0;
   background: var(--panel);
@@ -92,20 +104,28 @@ h1 {
 .link-badge:hover {
   background: linear-gradient(120deg, var(--accent), var(--accent-strong));
   color: #2b1e12;
-  transform: translateY(-2px);
+  transform: translateY(-1px);
 }
 
 /* Tabs */
 .tabs {
   display: flex;
   gap: 8px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid rgba(247, 245, 239, 0.1);
-  padding-bottom: 8px;
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+  padding: 0 0 8px;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: linear-gradient(180deg, rgba(11, 20, 18, 0.96), rgba(11, 20, 18, 0.86));
+  backdrop-filter: blur(14px);
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .tab {
-  padding: 12px 24px;
+  min-height: 42px;
+  padding: 10px 20px;
   border-radius: 999px;
   border: none;
   background: transparent;
@@ -117,12 +137,23 @@ h1 {
 
 .tab:hover {
   color: var(--text);
-  background: rgba(247, 245, 239, 0.05);
+  background: rgba(247, 245, 239, 0.08);
 }
 
 .tab.active {
   background: linear-gradient(120deg, var(--accent), var(--accent-strong));
   color: #2b1e12;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+.server-card:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 /* Tab Content */
@@ -135,6 +166,39 @@ h1 {
   display: block;
 }
 
+.panel,
+.ops-two-column {
+  scroll-margin-top: 76px;
+}
+
+.section-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: -4px 0 18px;
+}
+
+.section-nav a {
+  align-items: center;
+  background: rgba(247, 245, 239, 0.06);
+  border: 1px solid rgba(247, 245, 239, 0.1);
+  border-radius: 999px;
+  color: var(--muted);
+  display: inline-flex;
+  font-size: 13px;
+  font-weight: 700;
+  min-height: 34px;
+  padding: 7px 12px;
+  text-decoration: none;
+}
+
+.section-nav a:hover {
+  background: rgba(139, 211, 255, 0.12);
+  border-color: rgba(139, 211, 255, 0.34);
+  color: var(--text);
+}
+
 /* Metrics Grid */
 .metrics-grid {
   display: grid;
@@ -144,10 +208,11 @@ h1 {
 }
 
 .metric-card {
-  background: linear-gradient(160deg, var(--panel), var(--bg-secondary));
-  border-radius: 16px;
-  padding: 20px;
-  box-shadow: 0 12px 32px var(--shadow);
+  background: linear-gradient(160deg, rgba(23, 53, 47, 0.98), rgba(13, 28, 25, 0.92));
+  border: 1px solid rgba(247, 245, 239, 0.06);
+  border-radius: 8px;
+  padding: 18px;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
 }
 
 .metric-label {
@@ -166,7 +231,7 @@ h1 {
 }
 
 .metric-card.compact {
-  padding: 14px 16px;
+  padding: 13px 15px;
 }
 
 .metric-card.compact .metric-value {
@@ -191,7 +256,7 @@ h1 {
     linear-gradient(160deg, rgba(242, 184, 75, 0.12), transparent 55%),
     var(--bg-secondary);
   border: 1px solid rgba(247, 245, 239, 0.08);
-  border-radius: 16px;
+  border-radius: 8px;
   min-width: 0;
   padding: 16px;
 }
@@ -281,12 +346,13 @@ h1 {
 
 /* Panels */
 .panel {
-  background: rgba(27, 59, 52, 0.75);
-  border-radius: 20px;
+  background: rgba(23, 53, 47, 0.78);
+  border: 1px solid rgba(247, 245, 239, 0.06);
+  border-radius: 8px;
   min-width: 0;
-  padding: 24px;
+  padding: 22px;
   backdrop-filter: blur(8px);
-  box-shadow: 0 20px 40px var(--shadow);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.24);
   margin-bottom: 24px;
 }
 
@@ -298,14 +364,14 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 16px;
   margin-bottom: 16px;
 }
 
 .panel h2 {
   margin: 0;
-  font-size: 20px;
+  font-size: 19px;
 }
 
 .panel-kicker {
@@ -319,23 +385,25 @@ h1 {
 .panel-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
+  justify-content: flex-end;
 }
 
 /* Buttons */
 button {
   border: none;
   padding: 10px 16px;
-  border-radius: 999px;
+  border-radius: 8px;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
   font-family: inherit;
 }
 
 button:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px var(--shadow);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.24);
 }
 
 button:disabled {
@@ -354,9 +422,15 @@ button:disabled {
   border: 1px solid var(--muted);
 }
 
+.ghost:hover:not(:disabled) {
+  border-color: var(--text);
+  background: rgba(247, 245, 239, 0.08);
+}
+
 .danger {
   background: var(--error);
   color: white;
+  border-color: transparent;
 }
 
 /* Toggle */
@@ -383,12 +457,13 @@ input[type="datetime-local"],
 textarea,
 select {
   padding: 10px 14px;
-  border-radius: 10px;
-  border: 1px solid var(--muted);
+  border-radius: 8px;
+  border: 1px solid rgba(247, 245, 239, 0.46);
   background: var(--bg-secondary);
   color: var(--text);
   font-family: inherit;
   font-size: 14px;
+  min-height: 40px;
 }
 
 input[type="text"]::placeholder,
@@ -428,7 +503,8 @@ select:disabled {
 
 .governance-form {
   background: var(--bg-secondary);
-  border-radius: 14px;
+  border: 1px solid rgba(247, 245, 239, 0.06);
+  border-radius: 8px;
   margin-bottom: 20px;
   padding: 18px;
 }
@@ -509,7 +585,7 @@ select:disabled {
     linear-gradient(150deg, rgba(156, 182, 171, 0.12), transparent 55%),
     var(--bg-secondary);
   border: 1px solid rgba(247, 245, 239, 0.08);
-  border-radius: 16px;
+  border-radius: 8px;
   min-width: 0;
   padding: 18px;
 }
@@ -620,6 +696,25 @@ select:disabled {
   overflow-x: auto;
 }
 
+.table-wrap.scroll-table {
+  max-height: min(62vh, 680px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  border: 1px solid rgba(247, 245, 239, 0.06);
+  border-radius: 8px;
+}
+
+.scroll-table table {
+  min-width: 760px;
+}
+
+.scroll-table thead th {
+  background: rgba(23, 53, 47, 0.98);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -629,7 +724,7 @@ table {
 th,
 td {
   text-align: left;
-  padding: 12px;
+  padding: 11px 12px;
   border-bottom: 1px solid rgba(247, 245, 239, 0.08);
 }
 
@@ -704,7 +799,7 @@ tr:hover td {
 
 .component-card {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 16px;
   border-left: 4px solid var(--muted);
 }
@@ -797,6 +892,10 @@ tr:hover td {
   gap: 24px;
 }
 
+.ops-two-column .scroll-table table {
+  min-width: 560px;
+}
+
 .ops-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
@@ -805,7 +904,7 @@ tr:hover td {
 
 .ops-section {
   background: var(--bg-secondary);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 20px;
 }
 
@@ -964,7 +1063,7 @@ tr:hover td {
 
 .modal-content {
   background: var(--panel);
-  border-radius: 20px;
+  border-radius: 8px;
   padding: 32px;
   max-width: 420px;
   width: 90%;
@@ -1009,7 +1108,7 @@ tr:hover td {
 
 .toast {
   background: var(--panel);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 16px 20px;
   box-shadow: 0 12px 32px var(--shadow);
   display: flex;
@@ -1033,21 +1132,21 @@ tr:hover td {
 
 .server-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 460px), 1fr));
-  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 430px), 1fr));
+  gap: 16px;
   align-items: start;
   min-width: 0;
 }
 
 .server-catalog-toolbar {
   display: grid;
-  grid-template-columns: auto auto minmax(240px, 1fr);
+  grid-template-columns: minmax(190px, auto) minmax(160px, auto) minmax(320px, 1fr);
   gap: 12px;
   align-items: center;
   background: rgba(11, 24, 21, 0.42);
-  border: 1px solid rgba(247, 245, 239, 0.1);
+  border: 1px solid rgba(247, 245, 239, 0.12);
   border-radius: 8px;
-  padding: 14px;
+  padding: 12px;
   margin-bottom: 18px;
   min-width: 0;
 }
@@ -1128,16 +1227,23 @@ tr:hover td {
   background: linear-gradient(160deg, rgba(12, 31, 27, 0.96), rgba(26, 56, 49, 0.84));
   border: 1px solid rgba(247, 245, 239, 0.14);
   border-radius: 8px;
-  padding: 20px;
+  padding: 18px;
   display: grid;
-  gap: 16px;
+  gap: 13px;
   min-width: 0;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.22);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .server-card.selected {
   border-color: rgba(242, 184, 75, 0.72);
-  box-shadow: 0 0 0 1px rgba(242, 184, 75, 0.24), 0 18px 36px rgba(0, 0, 0, 0.24);
+  box-shadow: 0 0 0 1px rgba(242, 184, 75, 0.24), 0 14px 28px rgba(0, 0, 0, 0.22);
+}
+
+.server-card:hover {
+  border-color: rgba(139, 211, 255, 0.38);
+  box-shadow: 0 0 0 1px rgba(139, 211, 255, 0.12), 0 18px 32px rgba(0, 0, 0, 0.28);
+  transform: translateY(-1px);
 }
 
 .server-card::before {
@@ -1151,7 +1257,7 @@ tr:hover td {
 .server-card-hero {
   display: flex;
   justify-content: space-between;
-  gap: 18px;
+  gap: 14px;
   align-items: flex-start;
 }
 
@@ -1168,11 +1274,11 @@ tr:hover td {
   border-radius: 8px;
   color: var(--accent);
   display: inline-flex;
-  flex: 0 0 44px;
+  flex: 0 0 40px;
   font-weight: 700;
-  height: 44px;
+  height: 40px;
   justify-content: center;
-  width: 44px;
+  width: 40px;
 }
 
 .server-title-stack {
@@ -1195,7 +1301,7 @@ tr:hover td {
 }
 
 .server-card h3 {
-  font-size: 18px;
+  font-size: 17px;
   overflow-wrap: anywhere;
 }
 
@@ -1245,8 +1351,8 @@ tr:hover td {
   border: 1px solid rgba(247, 245, 239, 0.08);
   border-radius: 999px;
   color: var(--muted);
-  font-size: 12px;
-  padding: 6px 10px;
+  font-size: 11px;
+  padding: 5px 9px;
 }
 
 .server-card-actions {
@@ -1272,16 +1378,17 @@ tr:hover td {
   background: rgba(0, 0, 0, 0.28);
   border: 1px solid rgba(247, 245, 239, 0.08);
   border-radius: 6px;
-  min-height: 40px;
-  padding: 10px 12px;
+  min-height: 38px;
+  padding: 9px 11px;
   font-size: 12px;
+  line-height: 1.35;
 }
 
 .server-action {
   border-color: rgba(247, 245, 239, 0.35);
   border-radius: 8px;
-  min-height: 34px;
-  padding: 7px 11px;
+  min-height: 32px;
+  padding: 7px 10px;
   white-space: nowrap;
 }
 
@@ -1293,8 +1400,8 @@ tr:hover td {
 .server-inventory-grid {
   align-items: start;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
 }
 
 .inventory-block {
@@ -1315,8 +1422,8 @@ tr:hover td {
   gap: 10px;
   justify-content: space-between;
   list-style: none;
-  min-height: 42px;
-  padding: 10px 12px;
+  min-height: 38px;
+  padding: 9px 11px;
   text-transform: uppercase;
 }
 
@@ -1359,6 +1466,8 @@ tr:hover td {
 
 .inventory-section-body {
   border-top: 1px solid rgba(247, 245, 239, 0.08);
+  max-height: 260px;
+  overflow: auto;
   padding: 10px;
 }
 
@@ -1374,7 +1483,7 @@ tr:hover td {
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(247, 245, 239, 0.06);
   border-radius: 6px;
-  min-height: 40px;
+  min-height: 38px;
   min-width: 0;
   overflow: hidden;
 }
@@ -1483,7 +1592,7 @@ tr:hover td {
 
 .server-connect {
   border-top: 1px solid rgba(247, 245, 239, 0.1);
-  padding-top: 4px;
+  padding-top: 2px;
 }
 
 .server-connect summary {
@@ -1556,34 +1665,52 @@ tr:hover td {
 
 /* Responsive */
 @media (max-width: 720px) {
+  .canvas {
+    padding-top: 24px;
+  }
+
   .hero {
     grid-template-columns: 1fr;
-    text-align: center;
+    gap: 16px;
+    margin-bottom: 18px;
+    text-align: left;
   }
 
   .hero-links {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    justify-content: stretch;
+  }
+
+  .link-badge {
     justify-content: center;
+    padding-left: 10px;
+    padding-right: 10px;
   }
 
   h1 {
-    max-width: 12ch;
-    margin-left: auto;
-    margin-right: auto;
+    max-width: 16ch;
   }
 
   .lede {
     max-width: 30ch;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   .tabs {
-    overflow-x: auto;
     flex-wrap: nowrap;
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    top: 0;
     -webkit-overflow-scrolling: touch;
   }
 
   .tab {
+    min-height: 40px;
+    padding: 9px 18px;
+    scroll-snap-align: start;
     white-space: nowrap;
   }
 
@@ -1608,11 +1735,24 @@ tr:hover td {
 
   .panel-actions {
     flex-wrap: wrap;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .panel-actions > * {
+    min-width: 0;
   }
 
   .panel {
-    border-radius: 14px;
     padding: 18px;
+  }
+
+  .panel-head {
+    gap: 12px;
+  }
+
+  .panel h2 {
+    font-size: 18px;
   }
 
   .server-catalog-toolbar,
@@ -1621,7 +1761,10 @@ tr:hover td {
   }
 
   .server-catalog-controls {
-    justify-content: flex-start;
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 1fr;
+    justify-content: stretch;
   }
 
   .server-catalog-controls input,
@@ -1644,6 +1787,7 @@ tr:hover td {
   .server-card-hero {
     align-items: stretch;
     flex-direction: column;
+    gap: 10px;
   }
 
   .server-meta-wrap {
@@ -1651,7 +1795,14 @@ tr:hover td {
   }
 
   .server-card-actions {
-    justify-content: flex-start;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(82px, 1fr));
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .server-action {
+    width: 100%;
   }
 
   .server-status-stack {
@@ -1666,6 +1817,10 @@ tr:hover td {
 
   .table-code {
     max-width: 72vw;
+  }
+
+  .table-wrap.scroll-table {
+    max-height: 520px;
   }
 
   .ops-form {
@@ -1699,14 +1854,36 @@ tr:hover td {
 
 @media (max-width: 480px) {
   .canvas {
-    padding: 36px 16px 48px;
+    padding: 24px 16px 48px;
   }
 
   h1 {
-    font-size: 28px;
+    font-size: 30px;
   }
 
   .metrics-grid {
     grid-template-columns: 1fr;
+  }
+
+  .hero-links {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .server-catalog-stats {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .server-catalog-stats span {
+    justify-content: flex-start;
+  }
+
+  .server-card {
+    padding: 16px;
+  }
+
+  .server-meta-row {
+    gap: 7px;
   }
 }

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -709,7 +709,7 @@ select:disabled {
 }
 
 .scroll-table thead th {
-  background: rgba(23, 53, 47, 0.98);
+  background: var(--panel);
   position: sticky;
   top: 0;
   z-index: 1;

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -2462,7 +2462,17 @@ fi
 connect_local_registry_to_kind_network
 
 refresh_kind_kubeconfig() {
-  kind get kubeconfig --name "${CLUSTER_NAME}" > "${KUBECONFIG_FILE}"
+  local refreshed_kubeconfig
+  refreshed_kubeconfig="$(mktemp)"
+  if kind get kubeconfig --name "${CLUSTER_NAME}" > "${refreshed_kubeconfig}"; then
+    mv "${refreshed_kubeconfig}" "${KUBECONFIG_FILE}"
+  elif [[ -s "${KUBECONFIG_FILE}" ]]; then
+    rm -f "${refreshed_kubeconfig}"
+    echo "[kind][warn] could not refresh kubeconfig for ${CLUSTER_NAME}; reusing existing ${KUBECONFIG_FILE}" >&2
+  else
+    rm -f "${refreshed_kubeconfig}"
+    return 1
+  fi
   export KUBECONFIG="${KUBECONFIG_FILE}"
   kubectl config use-context "kind-${CLUSTER_NAME}"
   mkdir -p "${HOME}/.kube"


### PR DESCRIPTION
## Summary
- tighten Sentinel dashboard layout, sticky navigation, focus/hover states, and mobile catalog readability
- add Dashboard and Operations section jump links plus bounded scroll areas for long activity tables
- compact empty catalog inventory sections and allow the Google sign-in stylesheet through CSP

## Validation
- `node --check static/app.js`
- `go test ./... -count=1` in `services/ui`
- `git diff --check -- services/ui/main.go services/ui/main_test.go services/ui/static/app.js services/ui/static/index.html services/ui/static/styles.css`
- browser validation against local patched UI proxied to the live API: admin login, 0 console errors, 0 failed requests
- pre-commit hook with `MCP_RUNTIME_CONFIG_DIR=/tmp/mcp-runtime-empty-config`: gitleaks, go fmt, staticcheck, go vet, go unit tests, generated file drift

## Notes
- The first pre-commit attempt inherited a saved local MCP Runtime auth file and caused unrelated root CLI tests to hit live platform auth paths with 401/403. Rerunning with an empty `MCP_RUNTIME_CONFIG_DIR` isolated that machine-local state and passed.
