### PR TITLE
fix(cli,ui): validate public setup and simplify admin views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,10 @@ kubectl get secret mcp-sentinel-secrets -n mcp-sentinel \
   `admin@mcpruntime.org` / `admin@123`. Disable or override them through the
   `PLATFORM_DEV_*` keys in `mcp-sentinel-secrets`, then roll the API deployment.
 - **Google / OIDC sign-in:** set `GOOGLE_CLIENT_ID` before `setup` when the
-  dashboard should render Google sign-in. For Google, setup defaults
+  dashboard should render Google sign-in. Non-test public TLS installs
+  (`--platform-mode public --with-tls`) fail fast unless `GOOGLE_CLIENT_ID`
+  / `MCP_GOOGLE_CLIENT_ID` is set, or `OIDC_ISSUER`, `OIDC_AUDIENCE`, and
+  `OIDC_JWKS_URL` are all set for another provider. For Google, setup defaults
   `OIDC_AUDIENCE` to that client ID and fills `OIDC_ISSUER=https://accounts.google.com`
   plus `OIDC_JWKS_URL=https://www.googleapis.com/oauth2/v3/certs` when they are
   otherwise empty. For other OIDC providers, set `OIDC_ISSUER`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ If instructions conflict, prefer **this repo** (`README`, CRDs, `v1alpha1` types
 | Default cluster install YAML | `k8s/`, `config/` | Overlays, CRDs, cert-manager examples |
 | Traefik plugins (dev) | `services/traefik-plugins/` | e.g. PII redactor source for local overlays |
 | Team / tenant isolation docs | `docs/multi-team.md` | Team identity contract, per-team namespaces, RBAC, ingress watch scope, and platform API enforcement |
+| Deployment target guide | `docs/deployment-targets.md` | High-level install shape guidance for k3s, self-managed clusters, and managed Kubernetes before using the distribution-specific readiness guide |
 | Site / public docs (if editing) | `website/` | Not required for control-plane work |
 | E2E | `test/e2e/`, `test/integration/` | Kind script and envtest-based integration tests |
 | Agent tool config | `.claude/`, `.codex/skills/` | `.claude/skills` should symlink to `../.codex/skills` so Claude Desktop and the Codex CLI use the same local skills |

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Host tools:
 
 Cluster prerequisites:
 
-- A running Kubernetes cluster: kind, k3s, minikube, Docker Desktop Kubernetes, EKS, or equivalent
+- A running Kubernetes cluster: kind, k3s, minikube, Docker Desktop Kubernetes, EKS, GKE, AKS, or equivalent
 - Working DNS, default storage class, ingress, and load-balancing path for your distribution
-- See [`docs/cluster-readiness.md`](docs/cluster-readiness.md) before running production-like installs
+- See [`docs/deployment-targets.md`](docs/deployment-targets.md) to choose the install shape, then [`docs/cluster-readiness.md`](docs/cluster-readiness.md) before running production-like installs
 
 `mcp-runtime setup` installs the platform stack, including Sentinel services such as ClickHouse and Kafka. You do not install those separately for the default flow.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ human workflows.
 
   <div class="docs-actions">
     <a class="docs-button docs-button-primary" href="getting-started/">Get started</a>
+    <a class="docs-button" href="deployment-targets/">Deploy</a>
     <a class="docs-button" href="contributor/">Contribute</a>
     <a class="docs-button" href="architecture/">Architecture</a>
     <a class="docs-button" href="api/">API reference</a>
@@ -93,7 +94,9 @@ resources for the selected environment.
 
 For provider-specific prerequisites such as container runtime registry trust,
 DNS, ingress, TLS, and k3s configuration, start with
-[Cluster readiness](cluster-readiness.md).
+[Deployment Targets](deployment-targets.md) to choose the right install shape,
+then [Cluster readiness](cluster-readiness.md) for distribution-specific
+preparation.
 
 ## Choose a path
 
@@ -113,7 +116,13 @@ DNS, ingress, TLS, and k3s configuration, start with
 <a class="docs-card" href="cluster-readiness/">
   <span class="docs-card-kicker">Prepare</span>
   <strong>Check your cluster</strong>
-  <span>Review prerequisites for k3s, kind, minikube, Docker Desktop Kubernetes, kubeadm, and EKS.</span>
+  <span>Review registry, DNS, ingress, storage, TLS, and node-runtime prerequisites before setup.</span>
+</a>
+
+<a class="docs-card" href="deployment-targets/">
+  <span class="docs-card-kicker">Deploy</span>
+  <strong>Choose a Kubernetes target</strong>
+  <span>Pick the right install shape for k3s, self-managed clusters, EKS, GKE, AKS, and other Kubernetes distributions.</span>
 </a>
 
 <a class="docs-card" href="contributor/">
@@ -180,7 +189,7 @@ DNS, ingress, TLS, and k3s configuration, start with
 | Workflow | Start here |
 |---|---|
 | Evaluate MCP Runtime for a private MCP platform | [Getting started](getting-started.md), then [Architecture](architecture.md) |
-| Run MCP Runtime on a real cluster | [Cluster readiness](cluster-readiness.md), then [Runtime](runtime.md) |
+| Run MCP Runtime on a real cluster | [Deployment Targets](deployment-targets.md), then [Cluster readiness](cluster-readiness.md) |
 | Host multiple teams on one cluster | [Multi-team isolation](multi-team.md), then [CLI](cli.md) |
 | Govern tools and sessions | [Sentinel](sentinel.md), then [API reference](api.md) |
 | Integrate from automation | [CLI](cli.md), then [API reference](api.md) |

--- a/docs/api.md
+++ b/docs/api.md
@@ -230,7 +230,8 @@ GET  /api/auth/me
 set `GOOGLE_CLIENT_ID` before setup; when the issuer, audience, and JWKS URL are
 empty, setup derives the standard Google OIDC values from that client ID. For
 other OIDC providers, set `OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL`
-explicitly.
+explicitly. Non-test public TLS setup fails fast unless one of those browser
+login configurations is present.
 
 ## Gateway flow and headers
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,7 +114,9 @@ scopes signed-in users to team namespaces for teams they belong to; `org` uses
 namespace access; `public` uses `mcp-servers-public`, exposes anonymous catalog
 reads, and lets signed-in users publish public preview MCP servers while
 preserving team namespace access. `MCP_PLATFORM_MODE` provides the same
-value when the flag is not set.
+value when the flag is not set. Non-test public TLS setup also requires
+`GOOGLE_CLIENT_ID` / `MCP_GOOGLE_CLIENT_ID` or the complete custom OIDC trio:
+`OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL`.
 
 `--test-mode` relaxes production guardrails, but it still builds and pushes the
 operator, gateway proxy, and Sentinel images with `latest` tags to the

--- a/docs/cluster-readiness.md
+++ b/docs/cluster-readiness.md
@@ -8,7 +8,10 @@ If you skip this, you'll typically see:
 - The operator pod goes to `ImagePullBackOff` with `10.43.x.x:5000: connection refused` or `no such host`.
 - MCPServer pods get stuck in `ImagePullBackOff` pulling `registry.local/<server-name>`.
 
-This document lists what each distribution needs before you run `setup`.
+This document lists what each distribution needs before you run `setup`. If you
+are still choosing where to deploy the platform, start with
+[Deployment Targets](deployment-targets.md), then return here for the exact
+registry, DNS, TLS, and node-runtime preparation.
 
 ---
 

--- a/docs/deployment-targets.md
+++ b/docs/deployment-targets.md
@@ -1,0 +1,318 @@
+# Deployment Targets
+
+Use this guide when you know you want to deploy MCP Runtime, but still need to
+choose the right Kubernetes target and install shape. It sits between
+[Getting Started](getting-started.md) and
+[Cluster Readiness](cluster-readiness.md):
+
+- [Getting Started](getting-started.md) is the step-by-step install flow.
+- This page explains which path to use for common self-managed and managed
+  Kubernetes distributions.
+- [Cluster Readiness](cluster-readiness.md) has the detailed registry,
+  container runtime, DNS, ingress, TLS, and failure-mode checks.
+
+`mcp-runtime setup` installs into an existing Kubernetes cluster. It does not
+create EKS, GKE, AKS, k3s, or kubeadm clusters for you, and it does not modify
+node container runtime trust unless a documented provider path says so.
+
+## Common Deployment Model
+
+Every distribution needs the same high-level shape:
+
+1. Create or choose a Kubernetes cluster.
+2. Configure `kubectl` for that cluster.
+3. Make sure nodes can pull the registry host that MCP Runtime will use.
+4. Decide ingress, DNS, TLS, storage, and image credential ownership.
+5. Run `./bin/mcp-runtime bootstrap`.
+6. Run `./bin/mcp-runtime setup` with the registry and TLS mode that matches
+   the cluster.
+7. Run `./bin/mcp-runtime cluster doctor`.
+8. Deploy the first MCP server and verify the dashboard/API.
+
+For production-like installs, prefer:
+
+```bash
+./bin/mcp-runtime setup --with-tls --strict-prod
+```
+
+Then make registry mode explicit:
+
+```bash
+# Existing managed or enterprise registry.
+./bin/mcp-runtime setup \
+  --registry-mode external \
+  --external-registry-url registry.example.com \
+  --with-tls \
+  --strict-prod
+
+# Bundled registry with internal HTTPS. Every node must trust the internal CA.
+./bin/mcp-runtime setup \
+  --registry-mode bundled-https \
+  --with-tls \
+  --strict-prod
+```
+
+## Choose a Target
+
+| Target | Best use | Registry recommendation | Notes |
+|---|---|---|---|
+| kind | Contributor development, CI-like smoke tests, disposable clusters | Bundled HTTP registry with the documented kind mirror | Use [Contributor Local Kind](contributor/local-kind.md) and `setup --test-mode`. |
+| Docker Desktop Kubernetes | Laptop demos and local evaluation | Bundled HTTP registry or Docker Desktop image loading | Good for local UI/API exploration, not production. |
+| minikube | Laptop or VM evaluation | Insecure registry flag at cluster start, or `minikube image load` | Recreate minikube when changing insecure registry settings. |
+| k3s | Single-node lab, edge, small self-managed clusters | Bundled registry for labs; external or bundled HTTPS for production | See the k3s example below and [Cluster Readiness - k3s](cluster-readiness.md#k3s). |
+| kubeadm / vanilla Kubernetes | Self-managed production or staging | External registry, or bundled HTTPS with node CA trust | Configure containerd, DNS, ingress, storage, and TLS on every node. |
+| RKE2 | Self-managed production or staging | External registry, or bundled HTTPS with node CA trust | Treat it like a hardened self-managed cluster; use provider tooling for runtime config. |
+| EKS | AWS managed Kubernetes | ECR | Use AWS-managed node registry auth, a real ingress/load balancer, Route 53 or equivalent DNS, and cert-manager or enterprise TLS. |
+| GKE | Google managed Kubernetes | Artifact Registry | Use node/workload identity registry access, Cloud DNS or equivalent DNS, and a Kubernetes ingress controller compatible with this platform. |
+| AKS | Azure managed Kubernetes | ACR | Use AKS/ACR integration or pull secrets, Azure DNS or equivalent DNS, and a supported ingress/TLS path. |
+
+OpenShift and other Kubernetes distributions are not a first-class documented
+target yet. They can work only if the cluster can satisfy the same Kubernetes
+contracts: CRDs, Deployments, Services, Ingress, storage, image pulls, TLS
+secrets, and pod security requirements. Review the generated manifests and
+platform security policy before using those clusters.
+
+## Self-Managed Clusters
+
+Self-managed clusters give you direct control over node runtime configuration.
+That is useful for labs and edge clusters, but it also means you own every node
+pull path.
+
+### k3s Lab Example
+
+Use this for a single-node k3s lab or internal evaluation with the bundled
+plain HTTP registry. Do not copy the insecure registry settings into
+production.
+
+1. Install k3s and point your shell at its kubeconfig:
+
+   ```bash
+   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+   kubectl get nodes
+   ```
+
+2. Preconfigure k3s containerd for the bundled registry NodePort:
+
+   ```bash
+   sudo tee /etc/rancher/k3s/registries.yaml >/dev/null <<'EOF'
+   mirrors:
+     registry.local:
+       endpoint:
+         - "http://127.0.0.1:32000"
+   configs:
+     "127.0.0.1:32000":
+       tls:
+         insecure_skip_verify: true
+   EOF
+
+   echo "127.0.0.1 registry.local" | sudo tee -a /etc/hosts
+   sudo systemctl restart k3s
+   ```
+
+   Multi-node k3s needs equivalent registry mirror and host resolution on every
+   node that can schedule MCP Runtime pods.
+
+3. Build the CLI and run the k3s bootstrap apply path:
+
+   ```bash
+   make deps
+   make build
+
+   ./bin/mcp-runtime bootstrap --apply --provider k3s
+   ```
+
+   `bootstrap --apply --provider k3s` is the only automated prerequisite apply
+   path today. It installs the bundled CoreDNS and local-path manifests when
+   they are missing.
+
+4. Install the platform:
+
+   ```bash
+   MCP_SETUP_WAIT_TIMEOUT=900 \
+     MCP_REGISTRY_ENDPOINT=registry.local:32000 \
+     ./bin/mcp-runtime setup
+   ```
+
+5. Validate the rollout:
+
+   ```bash
+   ./bin/mcp-runtime status
+   ./bin/mcp-runtime cluster doctor
+   kubectl get pods -n mcp-sentinel
+   ```
+
+If setup prints a different registry internal URL, copy that exact `host:port`
+into `/etc/rancher/k3s/registries.yaml`, restart k3s, and rerun setup. k3s
+containerd registry matching is exact.
+
+### k3s Production-Style Shape
+
+For a public or persistent k3s cluster, make it production-like:
+
+```bash
+export MCP_PLATFORM_DOMAIN=example.com
+export MCP_PLATFORM_ADMIN_EMAIL=admin@example.com
+export GOOGLE_CLIENT_ID=<google-oauth-client-id>
+
+./bin/mcp-runtime bootstrap --provider k3s
+./bin/mcp-runtime setup \
+  --registry-mode external \
+  --external-registry-url registry.example.com \
+  --with-tls \
+  --acme-email ops@example.com \
+  --strict-prod
+```
+
+Use `--tls-cluster-issuer <issuer-name>` instead of `--acme-email` when your
+cluster already has an enterprise `ClusterIssuer`.
+
+### kubeadm, RKE2, and Other Self-Managed Clusters
+
+For self-managed production clusters:
+
+- Use a stable registry endpoint that every node can resolve and trust.
+- Configure containerd or your node runtime on every node pool.
+- Use an ingress controller that creates Kubernetes `Ingress` routes, or run
+  `setup --ingress none` only when equivalent ingress and registry auth are
+  managed outside this repo.
+- Install or verify a default `StorageClass`.
+- Decide whether cert-manager, an enterprise issuer, or pre-created TLS secrets
+  own platform certificates.
+
+Then use the same production-style setup command:
+
+```bash
+./bin/mcp-runtime bootstrap
+./bin/mcp-runtime setup --with-tls --strict-prod
+./bin/mcp-runtime cluster doctor
+```
+
+## Managed Kubernetes
+
+Managed clusters reduce node lifecycle work, but they do not remove registry,
+DNS, TLS, or ingress decisions. In most managed environments, use an external
+registry instead of the bundled registry.
+
+### EKS
+
+Recommended shape:
+
+- Registry: ECR.
+- Node pull auth: EKS node role, IRSA, or explicit image pull secrets.
+- DNS: Route 53 or your enterprise DNS.
+- Ingress: existing platform ingress controller, AWS Load Balancer Controller,
+  ingress-nginx, or Traefik, as long as it supports the required Kubernetes
+  `Ingress` routes and registry auth guard.
+- TLS: cert-manager with Let's Encrypt or an enterprise issuer.
+
+Setup shape:
+
+```bash
+export MCP_PLATFORM_DOMAIN=example.com
+export MCP_PLATFORM_ADMIN_EMAIL=admin@example.com
+export GOOGLE_CLIENT_ID=<google-oauth-client-id>
+
+./bin/mcp-runtime bootstrap
+./bin/mcp-runtime setup \
+  --registry-mode external \
+  --external-registry-url <account>.dkr.ecr.<region>.amazonaws.com/mcp-runtime \
+  --with-tls \
+  --strict-prod
+```
+
+### GKE
+
+Recommended shape:
+
+- Registry: Artifact Registry.
+- Node pull auth: Google-managed node identity or workload identity where
+  appropriate.
+- DNS: Cloud DNS or enterprise DNS.
+- Ingress: GKE ingress, ingress-nginx, or Traefik, with equivalent registry
+  auth if you do not use the repo-managed Traefik dynamic config.
+- TLS: cert-manager with Let's Encrypt or an enterprise issuer.
+
+Setup shape:
+
+```bash
+export MCP_PLATFORM_DOMAIN=example.com
+export MCP_PLATFORM_ADMIN_EMAIL=admin@example.com
+export GOOGLE_CLIENT_ID=<google-oauth-client-id>
+
+./bin/mcp-runtime bootstrap
+./bin/mcp-runtime setup \
+  --registry-mode external \
+  --external-registry-url <region>-docker.pkg.dev/<project>/<repo> \
+  --with-tls \
+  --strict-prod
+```
+
+### AKS
+
+Recommended shape:
+
+- Registry: ACR.
+- Node pull auth: AKS to ACR attachment, managed identity, or pull secrets.
+- DNS: Azure DNS or enterprise DNS.
+- Ingress: Application Gateway Ingress Controller, ingress-nginx, or Traefik,
+  with equivalent registry auth if you replace repo-managed Traefik.
+- TLS: cert-manager with Let's Encrypt or an enterprise issuer.
+
+Setup shape:
+
+```bash
+export MCP_PLATFORM_DOMAIN=example.com
+export MCP_PLATFORM_ADMIN_EMAIL=admin@example.com
+export GOOGLE_CLIENT_ID=<google-oauth-client-id>
+
+./bin/mcp-runtime bootstrap
+./bin/mcp-runtime setup \
+  --registry-mode external \
+  --external-registry-url <registry>.azurecr.io/mcp-runtime \
+  --with-tls \
+  --strict-prod
+```
+
+## Ingress and Registry Ownership
+
+MCP Runtime can install repo-managed Traefik, or it can reuse an existing
+ingress controller. Avoid running two ingress stacks for the same public
+surface.
+
+If you bring your own ingress controller:
+
+- Make sure it watches the namespaces MCP Runtime uses.
+- Make sure it can serve `platform.<domain>`, `mcp.<domain>`, and
+  `registry.<domain>` when `MCP_PLATFORM_DOMAIN` is set.
+- Provide an equivalent registry auth guard before exposing
+  `registry.<domain>` publicly. The repo-managed Traefik stack uses
+  `registry-admin-auth@file` backed by `/api/registry/authz`.
+- Use `./bin/mcp-runtime setup --ingress none ...` only when that external
+  ingress path is already prepared.
+
+## After Setup
+
+Run the same checks on every distribution:
+
+```bash
+./bin/mcp-runtime status
+./bin/mcp-runtime cluster doctor
+
+kubectl get pods -n mcp-runtime
+kubectl get pods -n mcp-sentinel
+kubectl get ingress -A
+```
+
+For host-based public installs, also verify:
+
+```bash
+getent hosts registry.<domain>
+getent hosts mcp.<domain>
+getent hosts platform.<domain>
+
+curl -k -I https://platform.<domain>/
+curl -k -I -H "x-api-key: $ADMIN_API_KEY" https://registry.<domain>/v2/
+```
+
+Then continue with [Getting Started - Connect your first MCP
+server](getting-started.md#8-connect-your-first-mcp-server).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ The shortest path from an empty Kubernetes cluster to a governed MCP endpoint: i
 - Docker or a Docker-compatible client, with the daemon running and reachable
 - `kubectl` on `PATH`, configured for the target cluster
 - `curl`, `jq`, and `python3` for documented dev and traffic-generation flows
-- A Kubernetes cluster (k3s, kind, minikube, Docker Desktop Kubernetes, EKS — see [cluster-readiness.md](cluster-readiness.md) for distribution-specific prep)
+- A Kubernetes cluster (k3s, kind, minikube, Docker Desktop Kubernetes, EKS, GKE, AKS, or equivalent). If you are choosing a target, start with [Deployment Targets](deployment-targets.md), then use [Cluster Readiness](cluster-readiness.md) for distribution-specific prep.
 
 Host bootstrap:
 
@@ -37,6 +37,8 @@ This produces `./bin/mcp-runtime`.
 
 Before setup, confirm the target Kubernetes cluster is ready for registry
 pushes, image pulls, ingress, storage, and TLS. See
+[Deployment Targets](deployment-targets.md) to choose the right install shape
+for self-managed or managed Kubernetes, then
 [cluster-readiness.md](cluster-readiness.md) for distribution-specific
 preparation.
 
@@ -62,12 +64,14 @@ This page now branches on purpose:
 | Path | Use it when | Start here |
 |---|---|---|
 | Local development | You are working on the repo, using Kind, or validating changes with disposable infra | [Contributor test-mode cluster](#4-contributor-test-mode-cluster) |
+| Target selection | You are deciding between k3s, kubeadm, EKS, GKE, AKS, or another distribution | [Deployment Targets](deployment-targets.md) |
 | Production-style install | You are evaluating or deploying MCP Runtime on a shared, persistent, or externally reachable cluster | [Production-style install](#5-production-style-install) |
 
 The rest of this page keeps both flows in one place, but the detailed
 contributor runbooks still live under [docs/contributor/](contributor/README.md)
-and the distribution-specific production prerequisites still live in
-[cluster-readiness.md](cluster-readiness.md).
+the deployment target guide lives in
+[deployment-targets.md](deployment-targets.md), and the distribution-specific
+production prerequisites still live in [cluster-readiness.md](cluster-readiness.md).
 
 ## 4. Contributor test-mode cluster
 
@@ -346,6 +350,7 @@ Before `setup`, make these decisions explicitly:
 
 Read these first:
 
+- [Deployment Targets](deployment-targets.md)
 - [Cluster readiness](cluster-readiness.md)
 - [Sentinel Kubernetes awareness and hardening](sentinel.md#kubernetes-awareness-and-hardening)
 - [Multi-team isolation](multi-team.md) if multiple teams will publish or govern servers on one cluster

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -438,7 +438,10 @@ analytics, audit, and observability.
 | `org` | `mcp-servers-org` | Signed-in users publish and browse the org-wide catalog and can still work in team namespaces. |
 | `public` | `mcp-servers-public` | Anonymous users can browse the public preview catalog; signed-in users publish public preview MCP servers and can still work in team namespaces. |
 
-For browser Google sign-in, provide the OAuth client ID before setup. For
+For browser Google sign-in, provide the OAuth client ID before setup. Non-test
+public TLS installs (`--platform-mode public --with-tls`) fail fast unless
+`GOOGLE_CLIENT_ID` / `MCP_GOOGLE_CLIENT_ID` is set, or `OIDC_ISSUER`,
+`OIDC_AUDIENCE`, and `OIDC_JWKS_URL` are all set for another provider. For
 Google, setup uses the client ID as the OIDC audience and fills the standard
 Google issuer and JWKS URL when those values are not set explicitly:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ extra_css:
 nav:
   - Home: README.md
   - Getting Started: getting-started.md
+  - Deployment Targets: deployment-targets.md
   - Contributor Guide:
       - Overview: contributor/README.md
       - Local Kind and Test Mode: contributor/local-kind.md

--- a/internal/cli/setup/flow.go
+++ b/internal/cli/setup/flow.go
@@ -86,10 +86,14 @@ func externalRegistryFlagConfig(plan setupplan.Plan) *config.ExternalRegistryCon
 }
 
 func validateNonTestSetup(plan setupplan.Plan, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry bool) error {
+	return validateNonTestSetupWithAuthConfig(plan, extRegistry, usingExternalRegistry, nil)
+}
+
+func validateNonTestSetupWithAuthConfig(plan setupplan.Plan, extRegistry *config.ExternalRegistryConfig, usingExternalRegistry bool, existingAuthConfig map[string]string) error {
 	if plan.TestMode {
 		return nil
 	}
-	if err := validateRequiredPlatformEnv(plan, usingExternalRegistry); err != nil {
+	if err := validateRequiredPlatformEnv(plan, usingExternalRegistry, existingAuthConfig); err != nil {
 		return err
 	}
 	if !plan.StrictProd {
@@ -134,7 +138,7 @@ func validateNonTestSetup(plan setupplan.Plan, extRegistry *config.ExternalRegis
 	return nil
 }
 
-func validateRequiredPlatformEnv(plan setupplan.Plan, usingExternalRegistry bool) error {
+func validateRequiredPlatformEnv(plan setupplan.Plan, usingExternalRegistry bool, existingAuthConfig map[string]string) error {
 	if !platformEnvValidationRequired(plan) {
 		return nil
 	}
@@ -153,7 +157,7 @@ func validateRequiredPlatformEnv(plan setupplan.Plan, usingExternalRegistry bool
 			"platform admin configuration is incomplete; set MCP_PLATFORM_ADMIN_EMAIL (or ADMIN_USERS) before running production setup",
 		)
 	}
-	if err := ValidatePublicPlatformAuthEnv(plan.PlatformMode, plan.TLSEnabled, plan.TestMode); err != nil {
+	if err := ValidatePublicPlatformAuthConfig(plan.PlatformMode, plan.TLSEnabled, plan.TestMode, existingAuthConfig); err != nil {
 		return err
 	}
 	if !usingExternalRegistry && !registryEndpointEnvExplicitlyConfigured() {
@@ -163,6 +167,16 @@ func validateRequiredPlatformEnv(plan setupplan.Plan, usingExternalRegistry bool
 		)
 	}
 	return nil
+}
+
+func existingPublicAuthConfigForSetup(plan setupplan.Plan) (map[string]string, error) {
+	if !publicPlatformAuthConfigRequired(plan.PlatformMode, plan.TLSEnabled, plan.TestMode) {
+		return nil, nil
+	}
+	if publicBrowserLoginConfigConfigured(nil) {
+		return nil, nil
+	}
+	return existingConfigMapData(core.DefaultKubectlClient(), core.DefaultAnalyticsNamespace, "mcp-sentinel-config")
 }
 
 func platformAdminEnvConfigured() bool {

--- a/internal/cli/setup/flow.go
+++ b/internal/cli/setup/flow.go
@@ -153,6 +153,9 @@ func validateRequiredPlatformEnv(plan setupplan.Plan, usingExternalRegistry bool
 			"platform admin configuration is incomplete; set MCP_PLATFORM_ADMIN_EMAIL (or ADMIN_USERS) before running production setup",
 		)
 	}
+	if err := ValidatePublicPlatformAuthEnv(plan.PlatformMode, plan.TLSEnabled, plan.TestMode); err != nil {
+		return err
+	}
 	if !usingExternalRegistry && !registryEndpointEnvExplicitlyConfigured() {
 		return core.NewWithSentinel(
 			core.ErrSetupStepFailed,

--- a/internal/cli/setup/plan_flow_test.go
+++ b/internal/cli/setup/plan_flow_test.go
@@ -334,8 +334,23 @@ func TestValidateNonTestSetupRejectsMissingPlatformAdminEnv(t *testing.T) {
 	}
 }
 
+func TestValidateNonTestSetupRejectsPublicTLSWithoutBrowserLoginEnv(t *testing.T) {
+	setPublicDomainEnv(t)
+	t.Setenv("MCP_REGISTRY_ENDPOINT", "registry.prod.example.com")
+
+	err := validateNonTestSetup(
+		setupplan.Plan{PlatformMode: setupplan.PlatformModePublic, TLSEnabled: true, TestMode: false, RegistryMode: setupplan.RegistryModeBundledHTTPS},
+		nil,
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "GOOGLE_CLIENT_ID") {
+		t.Fatalf("expected public browser login env validation error, got %v", err)
+	}
+}
+
 func TestValidateNonTestSetupRejectsBundledPublicSetupWithoutRegistryEndpoint(t *testing.T) {
 	setPublicDomainEnv(t)
+	t.Setenv("GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")
 
 	err := validateNonTestSetup(
 		setupplan.Plan{TLSEnabled: false, TestMode: false, RegistryMode: setupplan.RegistryModeBundledHTTP},
@@ -350,6 +365,7 @@ func TestValidateNonTestSetupRejectsBundledPublicSetupWithoutRegistryEndpoint(t 
 func TestValidateNonTestSetupAllowsPublicDomainAndRegistryEndpointWithoutStrictProd(t *testing.T) {
 	setPublicDomainEnv(t)
 	t.Setenv("MCP_REGISTRY_ENDPOINT", "registry.local:32000")
+	t.Setenv("GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")
 
 	err := validateNonTestSetup(
 		setupplan.Plan{TLSEnabled: false, TestMode: false, RegistryMode: setupplan.RegistryModeBundledHTTP},
@@ -364,6 +380,7 @@ func TestValidateNonTestSetupAllowsPublicDomainAndRegistryEndpointWithoutStrictP
 func TestValidateNonTestSetupRejectsBundledHTTPInStrictProd(t *testing.T) {
 	setPublicDomainEnv(t)
 	t.Setenv("MCP_REGISTRY_ENDPOINT", "registry.local:32000")
+	t.Setenv("GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")
 
 	err := validateNonTestSetup(
 		setupplan.Plan{TLSEnabled: true, TestMode: false, StrictProd: true, RegistryMode: setupplan.RegistryModeBundledHTTP},
@@ -378,6 +395,7 @@ func TestValidateNonTestSetupRejectsBundledHTTPInStrictProd(t *testing.T) {
 func TestValidateNonTestSetupAllowsBundledHTTPSInStrictProd(t *testing.T) {
 	setPublicDomainEnv(t)
 	t.Setenv("MCP_REGISTRY_ENDPOINT", "registry.prod.example.com")
+	t.Setenv("GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")
 
 	err := validateNonTestSetup(
 		setupplan.Plan{TLSEnabled: true, TestMode: false, StrictProd: true, RegistryMode: setupplan.RegistryModeBundledHTTPS},
@@ -392,6 +410,7 @@ func TestValidateNonTestSetupAllowsBundledHTTPSInStrictProd(t *testing.T) {
 func TestValidateNonTestSetupRejectsAutoBundledRegistryInStrictProd(t *testing.T) {
 	setPublicDomainEnv(t)
 	t.Setenv("MCP_REGISTRY_ENDPOINT", "registry.prod.example.com")
+	t.Setenv("GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")
 
 	err := validateNonTestSetup(
 		setupplan.Plan{TLSEnabled: true, TestMode: false, StrictProd: true, RegistryMode: setupplan.RegistryModeAuto},

--- a/internal/cli/setup/plan_flow_test.go
+++ b/internal/cli/setup/plan_flow_test.go
@@ -348,6 +348,21 @@ func TestValidateNonTestSetupRejectsPublicTLSWithoutBrowserLoginEnv(t *testing.T
 	}
 }
 
+func TestValidateNonTestSetupAllowsExistingPublicBrowserLoginConfig(t *testing.T) {
+	setPublicDomainEnv(t)
+	t.Setenv("MCP_REGISTRY_ENDPOINT", "registry.prod.example.com")
+
+	err := validateNonTestSetupWithAuthConfig(
+		setupplan.Plan{PlatformMode: setupplan.PlatformModePublic, TLSEnabled: true, TestMode: false, RegistryMode: setupplan.RegistryModeBundledHTTPS},
+		nil,
+		false,
+		map[string]string{"GOOGLE_CLIENT_ID": "client.apps.googleusercontent.com"},
+	)
+	if err != nil {
+		t.Fatalf("expected existing browser login config to be allowed, got %v", err)
+	}
+}
+
 func TestValidateNonTestSetupRejectsBundledPublicSetupWithoutRegistryEndpoint(t *testing.T) {
 	setPublicDomainEnv(t)
 	t.Setenv("GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -344,6 +344,26 @@ func ValidatePlatformMode(mode string) error {
 	return core.WrapWithSentinel(core.ErrFieldRequired, fmt.Errorf("invalid platform mode %q", mode), "invalid --platform-mode; expected tenant, org, or public")
 }
 
+func ValidatePublicPlatformAuthEnv(platformMode string, tlsEnabled, testMode bool) error {
+	mode, ok := setupplan.NormalizePlatformMode(platformMode)
+	if !ok || mode != setupplan.PlatformModePublic || !tlsEnabled || testMode {
+		return nil
+	}
+	if setupAnalyticsConfigEnvValue("GOOGLE_CLIENT_ID") != "" {
+		return nil
+	}
+	oidcIssuer := setupAnalyticsConfigEnvValue("OIDC_ISSUER")
+	oidcAudience := setupAnalyticsConfigEnvValue("OIDC_AUDIENCE")
+	oidcJWKSURL := setupAnalyticsConfigEnvValue("OIDC_JWKS_URL")
+	if oidcIssuer != "" && oidcAudience != "" && oidcJWKSURL != "" {
+		return nil
+	}
+	return core.NewWithSentinel(
+		core.ErrFieldRequired,
+		"--platform-mode public with --with-tls requires browser login configuration: set GOOGLE_CLIENT_ID or MCP_GOOGLE_CLIENT_ID for Google sign-in, or set OIDC_ISSUER, OIDC_AUDIENCE, and OIDC_JWKS_URL for another provider before running setup",
+	)
+}
+
 func SetupPlatform(logger *zap.Logger, plan setupplan.Plan, clusterMgr ClusterManagerAPI) error {
 	return setupPlatformWithDeps(logger, plan, SetupDeps{ClusterManager: clusterMgr}.withDefaults(logger))
 }

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -345,23 +345,42 @@ func ValidatePlatformMode(mode string) error {
 }
 
 func ValidatePublicPlatformAuthEnv(platformMode string, tlsEnabled, testMode bool) error {
-	mode, ok := setupplan.NormalizePlatformMode(platformMode)
-	if !ok || mode != setupplan.PlatformModePublic || !tlsEnabled || testMode {
+	return ValidatePublicPlatformAuthConfig(platformMode, tlsEnabled, testMode, nil)
+}
+
+func ValidatePublicPlatformAuthConfig(platformMode string, tlsEnabled, testMode bool, existingData map[string]string) error {
+	if !publicPlatformAuthConfigRequired(platformMode, tlsEnabled, testMode) {
 		return nil
 	}
-	if setupAnalyticsConfigEnvValue("GOOGLE_CLIENT_ID") != "" {
-		return nil
-	}
-	oidcIssuer := setupAnalyticsConfigEnvValue("OIDC_ISSUER")
-	oidcAudience := setupAnalyticsConfigEnvValue("OIDC_AUDIENCE")
-	oidcJWKSURL := setupAnalyticsConfigEnvValue("OIDC_JWKS_URL")
-	if oidcIssuer != "" && oidcAudience != "" && oidcJWKSURL != "" {
+	if publicBrowserLoginConfigConfigured(existingData) {
 		return nil
 	}
 	return core.NewWithSentinel(
 		core.ErrFieldRequired,
-		"--platform-mode public with --with-tls requires browser login configuration: set GOOGLE_CLIENT_ID or MCP_GOOGLE_CLIENT_ID for Google sign-in, or set OIDC_ISSUER, OIDC_AUDIENCE, and OIDC_JWKS_URL for another provider before running setup",
+		"--platform-mode public with --with-tls requires browser login configuration: set GOOGLE_CLIENT_ID or MCP_GOOGLE_CLIENT_ID for Google sign-in, set OIDC_ISSUER, OIDC_AUDIENCE, and OIDC_JWKS_URL for another provider, or rerun against a cluster whose mcp-sentinel-config already contains those values",
 	)
+}
+
+func publicPlatformAuthConfigRequired(platformMode string, tlsEnabled, testMode bool) bool {
+	mode, ok := setupplan.NormalizePlatformMode(platformMode)
+	return ok && mode == setupplan.PlatformModePublic && tlsEnabled && !testMode
+}
+
+func publicBrowserLoginConfigConfigured(existingData map[string]string) bool {
+	if publicAuthConfigValue(existingData, "GOOGLE_CLIENT_ID") != "" {
+		return true
+	}
+	oidcIssuer := publicAuthConfigValue(existingData, "OIDC_ISSUER")
+	oidcAudience := publicAuthConfigValue(existingData, "OIDC_AUDIENCE")
+	oidcJWKSURL := publicAuthConfigValue(existingData, "OIDC_JWKS_URL")
+	return oidcIssuer != "" && oidcAudience != "" && oidcJWKSURL != ""
+}
+
+func publicAuthConfigValue(existingData map[string]string, key string) string {
+	if envValue := setupAnalyticsConfigEnvValue(key); envValue != "" {
+		return envValue
+	}
+	return strings.TrimSpace(existingData[key])
 }
 
 func SetupPlatform(logger *zap.Logger, plan setupplan.Plan, clusterMgr ClusterManagerAPI) error {
@@ -389,7 +408,12 @@ func setupPlatformWithDeps(logger *zap.Logger, plan setupplan.Plan, deps SetupDe
 		core.LogStructuredError(logger, err, "Invalid registry setup configuration")
 		return err
 	}
-	if err := validateNonTestSetup(plan, extRegistry, usingExternalRegistry); err != nil {
+	existingPublicAuthConfig, err := existingPublicAuthConfigForSetup(plan)
+	if err != nil {
+		core.LogStructuredError(logger, err, "Invalid public platform auth configuration")
+		return err
+	}
+	if err := validateNonTestSetupWithAuthConfig(plan, extRegistry, usingExternalRegistry, existingPublicAuthConfig); err != nil {
 		core.LogStructuredError(logger, err, "Invalid non-test setup configuration")
 		return err
 	}

--- a/internal/cli/setup/public_auth_env_test.go
+++ b/internal/cli/setup/public_auth_env_test.go
@@ -1,0 +1,78 @@
+package setup
+
+import (
+	"strings"
+	"testing"
+
+	setupplan "mcp-runtime/internal/cli/setup/plan"
+)
+
+func clearPublicAuthEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"GOOGLE_CLIENT_ID",
+		"MCP_GOOGLE_CLIENT_ID",
+		"OIDC_ISSUER",
+		"MCP_OIDC_ISSUER",
+		"OIDC_AUDIENCE",
+		"MCP_OIDC_AUDIENCE",
+		"OIDC_JWKS_URL",
+		"MCP_OIDC_JWKS_URL",
+	} {
+		t.Setenv(key, "")
+	}
+}
+
+func TestValidatePublicPlatformAuthEnvRequiresLoginConfigForPublicTLS(t *testing.T) {
+	clearPublicAuthEnv(t)
+
+	err := ValidatePublicPlatformAuthEnv(setupplan.PlatformModePublic, true, false)
+	if err == nil {
+		t.Fatal("expected missing public auth env to fail")
+	}
+	if !strings.Contains(err.Error(), "GOOGLE_CLIENT_ID") || !strings.Contains(err.Error(), "OIDC_ISSUER") {
+		t.Fatalf("expected actionable env message, got %v", err)
+	}
+}
+
+func TestValidatePublicPlatformAuthEnvAllowsGoogleClientID(t *testing.T) {
+	clearPublicAuthEnv(t)
+	t.Setenv("MCP_GOOGLE_CLIENT_ID", "client.apps.googleusercontent.com")
+
+	if err := ValidatePublicPlatformAuthEnv(setupplan.PlatformModePublic, true, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatePublicPlatformAuthEnvAllowsCompleteOIDCConfig(t *testing.T) {
+	clearPublicAuthEnv(t)
+	t.Setenv("OIDC_ISSUER", "https://issuer.example.com")
+	t.Setenv("OIDC_AUDIENCE", "mcp-runtime")
+	t.Setenv("OIDC_JWKS_URL", "https://issuer.example.com/.well-known/jwks.json")
+
+	if err := ValidatePublicPlatformAuthEnv(setupplan.PlatformModePublic, true, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatePublicPlatformAuthEnvSkipsNonPublicTLSModes(t *testing.T) {
+	clearPublicAuthEnv(t)
+
+	cases := []struct {
+		name         string
+		platformMode string
+		tlsEnabled   bool
+		testMode     bool
+	}{
+		{name: "tenant tls", platformMode: setupplan.PlatformModeTenant, tlsEnabled: true},
+		{name: "public without tls", platformMode: setupplan.PlatformModePublic, tlsEnabled: false},
+		{name: "public tls test mode", platformMode: setupplan.PlatformModePublic, tlsEnabled: true, testMode: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidatePublicPlatformAuthEnv(tc.platformMode, tc.tlsEnabled, tc.testMode); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/cli/setup/public_auth_env_test.go
+++ b/internal/cli/setup/public_auth_env_test.go
@@ -44,6 +44,17 @@ func TestValidatePublicPlatformAuthEnvAllowsGoogleClientID(t *testing.T) {
 	}
 }
 
+func TestValidatePublicPlatformAuthConfigAllowsExistingGoogleClientID(t *testing.T) {
+	clearPublicAuthEnv(t)
+
+	err := ValidatePublicPlatformAuthConfig(setupplan.PlatformModePublic, true, false, map[string]string{
+		"GOOGLE_CLIENT_ID": "client.apps.googleusercontent.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestValidatePublicPlatformAuthEnvAllowsCompleteOIDCConfig(t *testing.T) {
 	clearPublicAuthEnv(t)
 	t.Setenv("OIDC_ISSUER", "https://issuer.example.com")
@@ -51,6 +62,19 @@ func TestValidatePublicPlatformAuthEnvAllowsCompleteOIDCConfig(t *testing.T) {
 	t.Setenv("OIDC_JWKS_URL", "https://issuer.example.com/.well-known/jwks.json")
 
 	if err := ValidatePublicPlatformAuthEnv(setupplan.PlatformModePublic, true, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatePublicPlatformAuthConfigAllowsMergedOIDCConfig(t *testing.T) {
+	clearPublicAuthEnv(t)
+	t.Setenv("OIDC_AUDIENCE", "mcp-runtime")
+
+	err := ValidatePublicPlatformAuthConfig(setupplan.PlatformModePublic, true, false, map[string]string{
+		"OIDC_ISSUER":   "https://issuer.example.com",
+		"OIDC_JWKS_URL": "https://issuer.example.com/.well-known/jwks.json",
+	})
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -558,13 +558,23 @@ func TestStaticMarkupBoundsLongActivityTables(t *testing.T) {
 		t.Fatalf("expected long dashboard tables to use scroll-table, got %d", got)
 	}
 	for _, want := range []string{
-		`class="section-nav" aria-label="Dashboard sections"`,
 		`class="section-nav" aria-label="Operations sections"`,
 		`href="#ops-inspector-panel"`,
 		`placeholder="Search servers"`,
+		`class="analytics-tabset" data-analytics-tabset`,
+		`id="governance-decisions" data-admin-only="true"`,
+		`data-analytics-tab-target="governance-decision-audit"`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("index missing navigation affordance %q", want)
+		}
+	}
+	for _, unwanted := range []string{
+		`href="#dashboard-audit"`,
+		`id="dashboard-audit"`,
+	} {
+		if strings.Contains(html, unwanted) {
+			t.Fatalf("dashboard should not own decision audit markup %q", unwanted)
 		}
 	}
 
@@ -579,6 +589,8 @@ func TestStaticMarkupBoundsLongActivityTables(t *testing.T) {
 		`.scroll-table thead th`,
 		`position: sticky;`,
 		`.section-nav`,
+		`.analytics-tabs`,
+		`.analytics-tab-panel[hidden]`,
 		`.tabs`,
 		`position: sticky;`,
 		`.server-card:hover`,
@@ -586,6 +598,27 @@ func TestStaticMarkupBoundsLongActivityTables(t *testing.T) {
 		if !strings.Contains(css, want) {
 			t.Fatalf("styles missing UX affordance %q", want)
 		}
+	}
+}
+
+func TestStaticAppRoutesDecisionAuditThroughGovernance(t *testing.T) {
+	body, err := os.ReadFile("static/app.js")
+	if err != nil {
+		t.Fatalf("read static app: %v", err)
+	}
+	source := string(body)
+	for _, want := range []string{
+		`function initAnalyticsTabsets()`,
+		`function loadGovernanceDecisionAnalytics()`,
+		`if (isAdminUser()) {` + "\n" + `          loadGovernanceDecisionAnalytics();` + "\n" + `          loadEvents();`,
+		`if (usageTab) activateAnalyticsTab(usageTab);`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("app missing governance decision behavior %q", want)
+		}
+	}
+	if strings.Contains(source, `loadDashboardAnalytics();`+"\n"+`        loadEvents();`) {
+		t.Fatal("dashboard tab should not load decision audit events")
 	}
 }
 

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -558,23 +558,26 @@ func TestStaticMarkupBoundsLongActivityTables(t *testing.T) {
 		t.Fatalf("expected long dashboard tables to use scroll-table, got %d", got)
 	}
 	for _, want := range []string{
-		`class="section-nav" aria-label="Operations sections"`,
-		`href="#ops-inspector-panel"`,
 		`placeholder="Search servers"`,
 		`class="analytics-tabset" data-analytics-tabset`,
 		`id="governance-decisions" data-admin-only="true"`,
 		`data-analytics-tab-target="governance-decision-audit"`,
+		`id="ops-workspace-panel"`,
+		`data-analytics-tab-target="ops-inspector-panel"`,
+		`id="ops-tab-platform-activity"`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("index missing navigation affordance %q", want)
 		}
 	}
 	for _, unwanted := range []string{
+		`class="section-nav" aria-label="Operations sections"`,
+		`href="#ops-inspector-panel"`,
 		`href="#dashboard-audit"`,
 		`id="dashboard-audit"`,
 	} {
 		if strings.Contains(html, unwanted) {
-			t.Fatalf("dashboard should not own decision audit markup %q", unwanted)
+			t.Fatalf("stacked section navigation should not own dense workspace markup %q", unwanted)
 		}
 	}
 
@@ -591,6 +594,7 @@ func TestStaticMarkupBoundsLongActivityTables(t *testing.T) {
 		`.section-nav`,
 		`.analytics-tabs`,
 		`.analytics-tab-panel[hidden]`,
+		`.ops-tab-head`,
 		`.tabs`,
 		`position: sticky;`,
 		`.server-card:hover`,

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -319,12 +319,15 @@ function initTabs() {
       if (target === "dashboard") {
         loadDashboardSummary();
         loadDashboardAnalytics();
-        loadEvents();
       } else if (target === "userdashboard") {
         loadUserDashboard();
       } else if (target === "governance") {
         loadGrants();
         loadSessions();
+        if (isAdminUser()) {
+          loadGovernanceDecisionAnalytics();
+          loadEvents();
+        }
       } else if (target === "teams") {
         loadTeams();
       } else if (target === "operations") {
@@ -374,6 +377,18 @@ async function loadDashboardAnalytics() {
   }
 }
 
+async function loadGovernanceDecisionAnalytics() {
+  try {
+    const limit = document.getElementById("analytics-limit")?.value || "10";
+    const data = await fetchJSON(`/analytics/usage?limit=${encodeURIComponent(limit)}`);
+    renderGovernanceDecisionAnalytics(data);
+  } catch (err) {
+    if (isUnauthorizedError(err)) return;
+    console.error("Failed to load governance decision analytics:", err);
+    renderGovernanceDecisionAnalyticsError();
+  }
+}
+
 function renderDashboardAnalytics(data) {
   const totals = data?.totals || {};
   const events = Number(totals.events || 0);
@@ -384,11 +399,18 @@ function renderDashboardAnalytics(data) {
   setText("analytics-denied", formatNumber(denied));
   setText("analytics-humans", formatNumber(totals.unique_humans || 0));
   setText("analytics-agents", formatNumber(totals.unique_agents || 0));
-  renderDecisionMeter(events, allowed, denied);
 
   renderAnalyticsServers(data?.servers || []);
   renderAnalyticsActors(data?.actors || []);
   renderAnalyticsTools(data?.tools || []);
+}
+
+function renderGovernanceDecisionAnalytics(data) {
+  const totals = data?.totals || {};
+  const events = Number(totals.events || 0);
+  const allowed = Number(totals.allowed || 0);
+  const denied = Number(totals.denied || 0);
+  renderDecisionMeter(events, allowed, denied);
   renderAnalyticsDecisions(data?.decisions || []);
 }
 
@@ -499,13 +521,16 @@ function renderAnalyticsError() {
   setText("analytics-denied", "-");
   setText("analytics-humans", "-");
   setText("analytics-agents", "-");
-  renderDecisionMeter(0, 0, 0);
   document.getElementById("analytics-servers-body").innerHTML =
     '<tr><td colspan="7" class="empty">Error loading usage.</td></tr>';
   document.getElementById("analytics-actors-body").innerHTML =
     '<tr><td colspan="6" class="empty">Error loading actors.</td></tr>';
   document.getElementById("analytics-tools-body").innerHTML =
     '<tr><td colspan="4" class="empty">Error loading tools.</td></tr>';
+}
+
+function renderGovernanceDecisionAnalyticsError() {
+  renderDecisionMeter(0, 0, 0);
   document.getElementById("analytics-decisions-body").innerHTML =
     '<tr><td colspan="2" class="empty">Error loading decisions.</td></tr>';
 }
@@ -994,7 +1019,6 @@ function loadActiveTab() {
   if (active === "dashboard") {
     loadDashboardSummary();
     loadDashboardAnalytics();
-    loadEvents();
   } else if (active === "userdashboard") {
     loadUserDashboard();
   } else if (active === "servers") {
@@ -1002,6 +1026,10 @@ function loadActiveTab() {
   } else if (active === "governance") {
     loadGrants();
     loadSessions();
+    if (isAdminUser()) {
+      loadGovernanceDecisionAnalytics();
+      loadEvents();
+    }
   } else if (active === "teams") {
     loadTeams();
   } else if (active === "operations") {
@@ -1208,6 +1236,8 @@ function createUserServerActionsCell(server) {
     selectedUserAnalyticsServerKey = operationServerKey(server);
     const select = document.getElementById("user-analytics-server");
     if (select) select.value = selectedUserAnalyticsServerKey;
+    const usageTab = document.getElementById("user-analytics-tab-usage");
+    if (usageTab) activateAnalyticsTab(usageTab);
     loadUserDashboardAnalytics();
   });
   actions.appendChild(analyticsButton);
@@ -1989,7 +2019,31 @@ function renderInventoryLabels(labels) {
     .join("");
 }
 
+function activateAnalyticsTab(button) {
+  const tabset = button.closest("[data-analytics-tabset]");
+  if (!tabset) return;
+  const targetID = button.dataset.analyticsTabTarget;
+  tabset.querySelectorAll("[data-analytics-tab-target]").forEach((tab) => {
+    const selected = tab === button;
+    tab.classList.toggle("active", selected);
+    tab.setAttribute("aria-selected", selected ? "true" : "false");
+  });
+  tabset.querySelectorAll(".analytics-tab-panel").forEach((panel) => {
+    const selected = panel.id === targetID;
+    panel.classList.toggle("active", selected);
+    panel.hidden = !selected;
+  });
+}
+
+function initAnalyticsTabsets() {
+  document.querySelectorAll("[data-analytics-tab-target]").forEach((button) => {
+    button.addEventListener("click", () => activateAnalyticsTab(button));
+  });
+}
+
 function initDashboard() {
+  initAnalyticsTabsets();
+
   // Auto refresh
   const autoRefreshCheckbox = document.getElementById("auto-refresh");
   if (autoRefreshCheckbox) {
@@ -2003,6 +2057,8 @@ function initDashboard() {
   }
 
   document.getElementById("refresh-events")?.addEventListener("click", () => {
+    if (!isAdminUser()) return;
+    loadGovernanceDecisionAnalytics();
     loadEvents();
   });
   document.getElementById("refresh-analytics")?.addEventListener("click", () => {
@@ -2053,6 +2109,7 @@ function startAutoRefresh() {
   autoRefreshInterval = setInterval(() => {
     loadDashboardSummary();
     loadDashboardAnalytics();
+    loadGovernanceDecisionAnalytics();
     loadEvents();
     loadServers();
   }, 5000);

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -1135,168 +1135,237 @@
               <button type="submit">Apply</button>
             </div>
           </form>
-          <nav class="section-nav" aria-label="Operations sections">
-            <a href="#ops-users-panel">Users</a>
-            <a href="#ops-server-health-panel">Server health</a>
-            <a href="#ops-activity-panels">Activity</a>
-            <a href="#ops-images-panel">Images</a>
-            <a href="#ops-inspector-panel">Inspector</a>
-          </nav>
         </div>
 
-        <div class="panel" id="ops-users-panel">
-          <div class="panel-head">
-            <div>
-              <h2>Logged-in Users</h2>
-              <p class="panel-kicker">Platform users with last login, last activity, and owned namespace.</p>
+        <div class="panel" id="ops-workspace-panel">
+          <div class="analytics-tabset" data-analytics-tabset>
+            <div class="analytics-tabs" role="tablist" aria-label="Operations views">
+              <button
+                class="analytics-tab active"
+                type="button"
+                id="ops-tab-users"
+                role="tab"
+                aria-controls="ops-users-panel"
+                aria-selected="true"
+                data-analytics-tab-target="ops-users-panel"
+              >
+                Users
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="ops-tab-server-health"
+                role="tab"
+                aria-controls="ops-server-health-panel"
+                aria-selected="false"
+                data-analytics-tab-target="ops-server-health-panel"
+              >
+                Server Health
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="ops-tab-platform-activity"
+                role="tab"
+                aria-controls="ops-platform-activity-panel"
+                aria-selected="false"
+                data-analytics-tab-target="ops-platform-activity-panel"
+              >
+                Platform Activity
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="ops-tab-mcp-activity"
+                role="tab"
+                aria-controls="ops-mcp-activity-panel"
+                aria-selected="false"
+                data-analytics-tab-target="ops-mcp-activity-panel"
+              >
+                MCP Activity
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="ops-tab-images"
+                role="tab"
+                aria-controls="ops-images-panel"
+                aria-selected="false"
+                data-analytics-tab-target="ops-images-panel"
+              >
+                Images
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="ops-tab-inspector"
+                role="tab"
+                aria-controls="ops-inspector-panel"
+                aria-selected="false"
+                data-analytics-tab-target="ops-inspector-panel"
+              >
+                Inspector
+              </button>
             </div>
-          </div>
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr>
-                  <th>User</th>
-                  <th>Role</th>
-                  <th>Namespace</th>
-                  <th>Last Login</th>
-                  <th>Last Activity</th>
-                  <th>Failures</th>
-                </tr>
-              </thead>
-              <tbody id="ops-users-body">
-                <tr>
-                  <td colspan="6" class="empty">Loading users...</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
 
-        <div class="panel" id="ops-server-health-panel">
-          <div class="panel-head">
-            <div>
-              <h2>MCP Server Health</h2>
-              <p class="panel-kicker">See which MCP servers are deployed, their rollout state, and when they were created.</p>
-            </div>
-          </div>
-          <div class="table-wrap">
-            <table class="server-health-table">
-              <thead>
-                <tr>
-                  <th>Server</th>
-                  <th>Status</th>
-                  <th>Ready</th>
-                  <th>Inventory</th>
-                  <th>Deployed</th>
-                  <th>Endpoint</th>
-                </tr>
-              </thead>
-              <tbody id="ops-server-health-body">
-                <tr>
-                  <td colspan="6" class="empty">Loading MCP servers...</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <div class="ops-two-column" id="ops-activity-panels">
-          <div class="panel">
-            <div class="panel-head">
-              <div>
-                <h2>Activity Timeline</h2>
-                <p class="panel-kicker">Recent login, deploy, image, credential, and denied platform actions.</p>
+            <section
+              class="analytics-section analytics-tab-panel active"
+              id="ops-users-panel"
+              role="tabpanel"
+              aria-labelledby="ops-tab-users"
+            >
+              <h3>Logged-in Users</h3>
+              <div class="table-wrap scroll-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>User</th>
+                      <th>Role</th>
+                      <th>Namespace</th>
+                      <th>Last Login</th>
+                      <th>Last Activity</th>
+                      <th>Failures</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ops-users-body">
+                    <tr>
+                      <td colspan="6" class="empty">Loading users...</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
-            </div>
-            <div class="table-wrap scroll-table">
-              <table>
-                <thead>
-                  <tr>
-                    <th>Time</th>
-                    <th>User</th>
-                    <th>Action</th>
-                    <th>Source</th>
-                    <th>Status</th>
-                  </tr>
-                </thead>
-                <tbody id="ops-user-activity-body">
-                  <tr>
-                    <td colspan="5" class="empty">Loading user activity...</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
+            </section>
 
-          <div class="panel">
-            <div class="panel-head">
-              <div>
-                <h2>MCP Activity</h2>
-                <p class="panel-kicker">Recent allow and deny decisions from the MCP gateway path.</p>
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="ops-server-health-panel"
+              role="tabpanel"
+              aria-labelledby="ops-tab-server-health"
+              hidden
+            >
+              <h3>MCP Server Health</h3>
+              <div class="table-wrap scroll-table">
+                <table class="server-health-table">
+                  <thead>
+                    <tr>
+                      <th>Server</th>
+                      <th>Status</th>
+                      <th>Ready</th>
+                      <th>Inventory</th>
+                      <th>Deployed</th>
+                      <th>Endpoint</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ops-server-health-body">
+                    <tr>
+                      <td colspan="6" class="empty">Loading MCP servers...</td>
+                    </tr>
+                  </tbody>
+                </table>
               </div>
-            </div>
-            <div class="table-wrap scroll-table">
-              <table class="audit-table compact-audit-table">
-                <thead>
-                  <tr>
-                    <th>Time</th>
-                    <th>Subject</th>
-                    <th>MCP Action</th>
-                    <th>Decision</th>
-                  </tr>
-                </thead>
-                <tbody id="ops-activity-body">
-                  <tr>
-                    <td colspan="4" class="empty">Loading MCP activity...</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
+            </section>
 
-        <div class="panel" id="ops-images-panel">
-          <div class="panel-head">
-            <div>
-              <h2>Images and Deployments</h2>
-              <p class="panel-kicker">Image publish records and currently deployed image references by user or namespace.</p>
-            </div>
-          </div>
-          <div class="table-wrap scroll-table">
-            <table>
-              <thead>
-                <tr>
-                  <th>Time</th>
-                  <th>User</th>
-                  <th>Image</th>
-                  <th>Target</th>
-                  <th>Action</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody id="ops-image-body">
-                <tr>
-                  <td colspan="6" class="empty">Loading image activity...</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="ops-platform-activity-panel"
+              role="tabpanel"
+              aria-labelledby="ops-tab-platform-activity"
+              hidden
+            >
+              <h3>Platform Activity</h3>
+              <div class="table-wrap scroll-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>User</th>
+                      <th>Action</th>
+                      <th>Source</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ops-user-activity-body">
+                    <tr>
+                      <td colspan="5" class="empty">Loading user activity...</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
 
-        <div class="panel" id="ops-inspector-panel">
-          <div class="panel-head">
-            <div>
-              <h2>MCP Server Inspector</h2>
-              <p class="panel-kicker">Select a server to inspect deployment metadata and MCP inventory.</p>
-            </div>
-            <div class="panel-actions">
-              <select id="ops-server-select" aria-label="Select MCP server">
-                <option value="">Select server...</option>
-              </select>
-            </div>
-          </div>
-          <div class="server-inspector" id="ops-server-detail">
-            <div class="empty">Select a server to inspect deployment details.</div>
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="ops-mcp-activity-panel"
+              role="tabpanel"
+              aria-labelledby="ops-tab-mcp-activity"
+              hidden
+            >
+              <h3>MCP Activity</h3>
+              <div class="table-wrap scroll-table">
+                <table class="audit-table compact-audit-table">
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>Subject</th>
+                      <th>MCP Action</th>
+                      <th>Decision</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ops-activity-body">
+                    <tr>
+                      <td colspan="4" class="empty">Loading MCP activity...</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="ops-images-panel"
+              role="tabpanel"
+              aria-labelledby="ops-tab-images"
+              hidden
+            >
+              <h3>Images and Deployments</h3>
+              <div class="table-wrap scroll-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>User</th>
+                      <th>Image</th>
+                      <th>Target</th>
+                      <th>Action</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody id="ops-image-body">
+                    <tr>
+                      <td colspan="6" class="empty">Loading image activity...</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="ops-inspector-panel"
+              role="tabpanel"
+              aria-labelledby="ops-tab-inspector"
+              hidden
+            >
+              <div class="ops-tab-head">
+                <h3>MCP Server Inspector</h3>
+                <select id="ops-server-select" aria-label="Select MCP server">
+                  <option value="">Select server...</option>
+                </select>
+              </div>
+              <div class="server-inspector" id="ops-server-detail">
+                <div class="empty">Select a server to inspect deployment details.</div>
+              </div>
+            </section>
           </div>
         </div>
       </section>

--- a/services/ui/static/index.html
+++ b/services/ui/static/index.html
@@ -223,10 +223,62 @@
             </div>
           </div>
 
-          <div class="analytics-grid">
-            <section class="analytics-section">
+          <div class="analytics-tabset" data-analytics-tabset>
+            <div class="analytics-tabs" role="tablist" aria-label="My activity views">
+              <button
+                class="analytics-tab active"
+                type="button"
+                id="user-analytics-tab-servers"
+                role="tab"
+                aria-controls="user-analytics-servers-panel"
+                aria-selected="true"
+                data-analytics-tab-target="user-analytics-servers-panel"
+              >
+                Deployed Servers
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="user-analytics-tab-usage"
+                role="tab"
+                aria-controls="user-analytics-usage-panel"
+                aria-selected="false"
+                data-analytics-tab-target="user-analytics-usage-panel"
+              >
+                Usage
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="user-analytics-tab-tools"
+                role="tab"
+                aria-controls="user-analytics-tools-panel"
+                aria-selected="false"
+                data-analytics-tab-target="user-analytics-tools-panel"
+              >
+                Tools
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="user-analytics-tab-recent"
+                role="tab"
+                aria-controls="user-analytics-recent-panel"
+                aria-selected="false"
+                data-analytics-tab-target="user-analytics-recent-panel"
+              >
+                Recent
+              </button>
+            </div>
+
+            <section
+              class="analytics-section analytics-tab-panel active"
+              id="user-analytics-servers-panel"
+              role="tabpanel"
+              aria-labelledby="user-analytics-tab-servers"
+            >
               <h3>Deployed Servers</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -246,9 +298,15 @@
               </div>
             </section>
 
-            <section class="analytics-section">
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="user-analytics-usage-panel"
+              role="tabpanel"
+              aria-labelledby="user-analytics-tab-usage"
+              hidden
+            >
               <h3>Per-server Usage</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -269,9 +327,15 @@
               </div>
             </section>
 
-            <section class="analytics-section">
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="user-analytics-tools-panel"
+              role="tabpanel"
+              aria-labelledby="user-analytics-tab-tools"
+              hidden
+            >
               <h3>Top Tools</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -290,9 +354,15 @@
               </div>
             </section>
 
-            <section class="analytics-section">
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="user-analytics-recent-panel"
+              role="tabpanel"
+              aria-labelledby="user-analytics-tab-recent"
+              hidden
+            >
               <h3>Recent Activity</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -508,11 +578,6 @@
           </div>
         </div>
 
-        <nav class="section-nav" aria-label="Dashboard sections">
-          <a href="#dashboard-analytics">Usage analytics</a>
-          <a href="#dashboard-audit">Decision audit</a>
-        </nav>
-
         <div class="panel" id="dashboard-analytics">
           <div class="panel-head">
             <h2>Usage Analytics</h2>
@@ -549,26 +614,53 @@
                 <strong class="metric-value" id="analytics-agents">-</strong>
               </div>
             </div>
-            <div class="decision-health-card">
-              <div class="decision-health-head">
-                <span class="metric-label">Decision Health</span>
-                <strong id="analytics-allow-rate">-</strong>
-              </div>
-              <div class="decision-meter" aria-label="Allowed and denied event share">
-                <span class="decision-meter-allow" id="decision-meter-allow"></span>
-                <span class="decision-meter-deny" id="decision-meter-deny"></span>
-              </div>
-              <div class="decision-health-foot">
-                <span><i class="legend-dot allow"></i>Allow</span>
-                <span><i class="legend-dot deny"></i>Deny <strong id="analytics-deny-rate">-</strong></span>
-              </div>
-            </div>
           </div>
 
-          <div class="analytics-grid">
-            <section class="analytics-section">
+          <div class="analytics-tabset" data-analytics-tabset>
+            <div class="analytics-tabs" role="tablist" aria-label="Usage analytics views">
+              <button
+                class="analytics-tab active"
+                type="button"
+                id="analytics-tab-servers"
+                role="tab"
+                aria-controls="analytics-servers-panel"
+                aria-selected="true"
+                data-analytics-tab-target="analytics-servers-panel"
+              >
+                Servers
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="analytics-tab-actors"
+                role="tab"
+                aria-controls="analytics-actors-panel"
+                aria-selected="false"
+                data-analytics-tab-target="analytics-actors-panel"
+              >
+                Users & Agents
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="analytics-tab-tools"
+                role="tab"
+                aria-controls="analytics-tools-panel"
+                aria-selected="false"
+                data-analytics-tab-target="analytics-tools-panel"
+              >
+                Tools
+              </button>
+            </div>
+
+            <section
+              class="analytics-section analytics-tab-panel active"
+              id="analytics-servers-panel"
+              role="tabpanel"
+              aria-labelledby="analytics-tab-servers"
+            >
               <h3>MCP Servers</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -590,9 +682,15 @@
               </div>
             </section>
 
-            <section class="analytics-section">
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="analytics-actors-panel"
+              role="tabpanel"
+              aria-labelledby="analytics-tab-actors"
+              hidden
+            >
               <h3>Users & Agents</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -613,9 +711,15 @@
               </div>
             </section>
 
-            <section class="analytics-section">
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="analytics-tools-panel"
+              role="tabpanel"
+              aria-labelledby="analytics-tab-tools"
+              hidden
+            >
               <h3>Tools</h3>
-              <div class="table-wrap">
+              <div class="table-wrap scroll-table">
                 <table>
                   <thead>
                     <tr>
@@ -633,57 +737,6 @@
                 </table>
               </div>
             </section>
-
-            <section class="analytics-section">
-              <h3>Decisions</h3>
-              <div class="table-wrap">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Decision</th>
-                      <th>Events</th>
-                    </tr>
-                  </thead>
-                  <tbody id="analytics-decisions-body">
-                    <tr>
-                      <td colspan="2" class="empty">No decisions yet.</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          </div>
-        </div>
-
-        <div class="panel" id="dashboard-audit">
-          <div class="panel-head">
-            <h2>Decision Audit</h2>
-            <div class="panel-actions">
-              <button class="ghost" id="refresh-events">Refresh</button>
-              <label class="toggle">
-                <input type="checkbox" id="auto-refresh" checked />
-                Auto
-              </label>
-            </div>
-          </div>
-          <div class="table-wrap scroll-table">
-            <table class="audit-table">
-              <thead>
-                <tr>
-                  <th>Time</th>
-                  <th>Human</th>
-                  <th>Agent</th>
-                  <th>MCP Action</th>
-                  <th>Decision</th>
-                  <th>Policy</th>
-                </tr>
-              </thead>
-              <tbody id="events-body">
-                <tr>
-                  <td colspan="6" class="empty">No events yet.</td>
-                </tr>
-              </tbody>
-            </table>
           </div>
         </div>
       </section>
@@ -713,6 +766,119 @@
           <div class="governance-summary-card">
             <span class="metric-label">Revoked Sessions</span>
             <strong class="metric-value" id="gov-revoked-sessions">-</strong>
+          </div>
+        </div>
+
+        <div class="panel" id="governance-decisions" data-admin-only="true">
+          <div class="panel-head">
+            <div>
+              <h2>Policy Decisions</h2>
+              <p class="panel-kicker">Allow and deny outcomes from MCP gateway policy enforcement.</p>
+            </div>
+            <div class="panel-actions">
+              <button class="ghost" id="refresh-events" type="button">Refresh</button>
+              <label class="toggle">
+                <input type="checkbox" id="auto-refresh" checked />
+                Auto
+              </label>
+            </div>
+          </div>
+
+          <div class="governance-decision-overview">
+            <div class="decision-health-card">
+              <div class="decision-health-head">
+                <span class="metric-label">Decision Health</span>
+                <strong id="analytics-allow-rate">-</strong>
+              </div>
+              <div class="decision-meter" aria-label="Allowed and denied event share">
+                <span class="decision-meter-allow" id="decision-meter-allow"></span>
+                <span class="decision-meter-deny" id="decision-meter-deny"></span>
+              </div>
+              <div class="decision-health-foot">
+                <span><i class="legend-dot allow"></i>Allow</span>
+                <span><i class="legend-dot deny"></i>Deny <strong id="analytics-deny-rate">-</strong></span>
+              </div>
+            </div>
+          </div>
+
+          <div class="analytics-tabset" data-analytics-tabset>
+            <div class="analytics-tabs" role="tablist" aria-label="Governance decision views">
+              <button
+                class="analytics-tab active"
+                type="button"
+                id="governance-decisions-tab-summary"
+                role="tab"
+                aria-controls="governance-decisions-summary"
+                aria-selected="true"
+                data-analytics-tab-target="governance-decisions-summary"
+              >
+                Decisions
+              </button>
+              <button
+                class="analytics-tab"
+                type="button"
+                id="governance-decisions-tab-audit"
+                role="tab"
+                aria-controls="governance-decision-audit"
+                aria-selected="false"
+                data-analytics-tab-target="governance-decision-audit"
+              >
+                Audit
+              </button>
+            </div>
+
+            <section
+              class="analytics-section analytics-tab-panel active"
+              id="governance-decisions-summary"
+              role="tabpanel"
+              aria-labelledby="governance-decisions-tab-summary"
+            >
+              <h3>Decisions</h3>
+              <div class="table-wrap scroll-table">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Decision</th>
+                      <th>Events</th>
+                    </tr>
+                  </thead>
+                  <tbody id="analytics-decisions-body">
+                    <tr>
+                      <td colspan="2" class="empty">No decisions yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section
+              class="analytics-section analytics-tab-panel"
+              id="governance-decision-audit"
+              role="tabpanel"
+              aria-labelledby="governance-decisions-tab-audit"
+              hidden
+            >
+              <h3>Decision Audit</h3>
+              <div class="table-wrap scroll-table">
+                <table class="audit-table">
+                  <thead>
+                    <tr>
+                      <th>Time</th>
+                      <th>Human</th>
+                      <th>Agent</th>
+                      <th>MCP Action</th>
+                      <th>Decision</th>
+                      <th>Policy</th>
+                    </tr>
+                  </thead>
+                  <tbody id="events-body">
+                    <tr>
+                      <td colspan="6" class="empty">No events yet.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
           </div>
         </div>
 

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -246,7 +246,7 @@ summary:focus-visible,
 
 .analytics-overview {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
   margin-bottom: 20px;
 }
@@ -332,6 +332,46 @@ summary:focus-visible,
   gap: 24px;
 }
 
+.analytics-tabset {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.analytics-tabs {
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  padding-bottom: 8px;
+}
+
+.analytics-tab {
+  background: rgba(247, 245, 239, 0.05);
+  border: 1px solid rgba(247, 245, 239, 0.08);
+  color: var(--muted);
+  font-size: 13px;
+  min-height: 34px;
+  min-width: 0;
+  padding: 7px 12px;
+}
+
+.analytics-tab.active,
+.analytics-tab[aria-selected="true"] {
+  background: rgba(242, 184, 75, 0.18);
+  border-color: rgba(242, 184, 75, 0.38);
+  color: var(--text);
+}
+
+.analytics-tab-panel {
+  min-width: 0;
+}
+
+.analytics-tab-panel[hidden] {
+  display: none;
+}
+
 .analytics-section {
   min-width: 0;
 }
@@ -342,6 +382,12 @@ summary:focus-visible,
   letter-spacing: 0.12em;
   margin: 0 0 10px;
   text-transform: uppercase;
+}
+
+.governance-decision-overview {
+  display: grid;
+  grid-template-columns: minmax(260px, 380px);
+  margin-bottom: 16px;
 }
 
 /* Panels */
@@ -1720,6 +1766,19 @@ tr:hover td {
 
   .analytics-grid {
     grid-template-columns: 1fr;
+  }
+
+  .analytics-tabs {
+    flex-wrap: nowrap;
+    margin-left: -2px;
+    overflow-x: auto;
+    padding-bottom: 10px;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .analytics-tab {
+    flex: 0 0 auto;
+    white-space: nowrap;
   }
 
   .analytics-overview,

--- a/services/ui/static/styles.css
+++ b/services/ui/static/styles.css
@@ -942,6 +942,29 @@ tr:hover td {
   min-width: 560px;
 }
 
+#ops-workspace-panel .scroll-table table {
+  min-width: 720px;
+}
+
+.ops-tab-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  min-width: 0;
+}
+
+.ops-tab-head h3 {
+  margin-bottom: 0;
+}
+
+.ops-tab-head select {
+  max-width: 100%;
+  width: min(100%, 360px);
+}
+
 .ops-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));


### PR DESCRIPTION
## Summary
- Fail non-test public TLS setup when browser login config is missing: `GOOGLE_CLIENT_ID` / `MCP_GOOGLE_CLIENT_ID`, or a complete custom OIDC trio.
- Keep the setup check in the production preflight alongside public host, admin allowlist, and bundled registry endpoint validation, with docs updated for the required envs.
- Add a Deployment Targets guide for choosing install shapes across k3s, self-managed clusters, EKS, GKE, AKS, and other Kubernetes distributions, with a concrete k3s example and links from Getting Started, Cluster Readiness, the docs home, README, and AGENTS.
- Simplify Dashboard and My Activity analytics into one-at-a-time tabbed tables instead of stacked dense sections.
- Move policy Decisions and Decision Audit under Governance.
- Simplify Operations into a tabbed workspace for Users, Server Health, Platform Activity, MCP Activity, Images, and Inspector.

## Root Cause
The live public setup could complete with `GOOGLE_CLIENT_ID` empty, leaving the dashboard without the Google sign-in button even though public platform mode was enabled. The admin UI also grouped usage, governance decisions, audit, and operations data as stacked tables, making Dashboard and Operations too cramped to scan. Deployment docs had detailed cluster-readiness notes, but lacked a higher-level page that helps users choose the right self-managed or managed Kubernetes target before following the install flow.

## Validation
- `go test ./internal/cli/setup -count=1`
- `go test ./internal/cli/setup ./internal/cli/core ./pkg/metadata -count=1`
- `go test ./... -count=1` from `services/ui`
- `git diff --check`
- `mkdocs build -f docs/mkdocs.yml --strict` from a temporary venv with `docs/requirements.txt`
- Commit hooks: Gitleaks, gofmt, staticcheck, go vet, Go unit tests when applicable, generated-file drift
- Live devbox2 UI rolled to `registry.local:32000/mcp-sentinel-ui:59148b3` and rollout completed
- Live browser check on `https://platform.mcpruntime.org/`: Dashboard usage tabs, Governance Decisions/Audit tabs, Operations workspace tabs, and mobile no page-level horizontal overflow