### PR TITLE
fix(cli): harden public k3s setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,12 @@ gateway proxy, and Sentinel images with `latest` tags to the configured or
 bundled registry, then deploys pods that pull those images. In Kind test mode,
 implicit internal image refs use `registry.registry.svc.cluster.local:5000/...`
 so the documented containerd mirror matches the image host exactly.
+For remote Linux clusters, setup-built images must match the node CPU
+architecture, not the workstation CPU. Setup detects homogeneous node
+architectures and builds `linux/amd64` or `linux/arm64`; override with
+`MCP_IMAGE_PLATFORM=linux/amd64` or `MCP_IMAGE_PLATFORM=linux/arm64` when
+needed. Mixed-architecture clusters require prebuilt multi-arch images until
+setup publishes manifest lists.
 Before rerunning setup or e2e locally, check `kind get clusters` and prefer the
 existing `kind-mcp-runtime` context when it is healthy. Create a new Kind
 cluster only when you need a clean CI-equivalent run or the existing contributor

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ If instructions conflict, prefer **this repo** (`README`, CRDs, `v1alpha1` types
 | Default cluster install YAML | `k8s/`, `config/` | Overlays, CRDs, cert-manager examples |
 | Traefik plugins (dev) | `services/traefik-plugins/` | e.g. PII redactor source for local overlays |
 | Team / tenant isolation docs | `docs/multi-team.md` | Team identity contract, per-team namespaces, RBAC, ingress watch scope, and platform API enforcement |
-| Deployment target guide | `docs/deployment-targets.md` | High-level install shape guidance for k3s, self-managed clusters, and managed Kubernetes before using the distribution-specific readiness guide |
+| Deployment target guide | `docs/deployment-targets.md`, `docs/k3s-on-prem-cluster.md` | High-level install shape guidance for k3s, self-managed clusters, and managed Kubernetes before using the distribution-specific readiness guide; the k3s runbook covers a four/five-node public or on-prem topology |
 | Site / public docs (if editing) | `website/` | Not required for control-plane work |
 | E2E | `test/e2e/`, `test/integration/` | Kind script and envtest-based integration tests |
 | Agent tool config | `.claude/`, `.codex/skills/` | `.claude/skills` should symlink to `../.codex/skills` so Claude Desktop and the Codex CLI use the same local skills |

--- a/Makefile.operator
+++ b/Makefile.operator
@@ -69,12 +69,12 @@ run: manifests generate fmt vet ## Run operator against the configured Kubernete
 
 docker-build: test ## Build Docker image with the operator.
 	@echo "Building Docker image: ${IMG}"
-	DOCKER_BUILDKIT=0 docker build --platform=${DOCKER_PLATFORM} -t ${IMG} -f Dockerfile.operator .
+	docker build --platform=${DOCKER_PLATFORM} -t ${IMG} -f Dockerfile.operator .
 	@echo "Docker image built: ${IMG}"
 
 docker-build-operator-no-test: manifests generate fmt vet ## Build Docker image without running tests (used for test mode / airgapped CI).
 	@echo "Building Docker image (tests skipped): ${IMG}"
-	DOCKER_BUILDKIT=0 docker build --platform=${DOCKER_PLATFORM} -t ${IMG} -f Dockerfile.operator .
+	docker build --platform=${DOCKER_PLATFORM} -t ${IMG} -f Dockerfile.operator .
 	@echo "Docker image built: ${IMG}"
 
 docker-push: ## Push Docker image to registry.

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,6 +190,7 @@ preparation.
 |---|---|
 | Evaluate MCP Runtime for a private MCP platform | [Getting started](getting-started.md), then [Architecture](architecture.md) |
 | Run MCP Runtime on a real cluster | [Deployment Targets](deployment-targets.md), then [Cluster readiness](cluster-readiness.md) |
+| Build a four or five node k3s demo | [k3s On-Prem Cluster](k3s-on-prem-cluster.md), then [Publish an MCP Server](publish-mcp-server.md) |
 | Host multiple teams on one cluster | [Multi-team isolation](multi-team.md), then [CLI](cli.md) |
 | Govern tools and sessions | [Sentinel](sentinel.md), then [API reference](api.md) |
 | Integrate from automation | [CLI](cli.md), then [API reference](api.md) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,11 @@ HTTPS and requires `--with-tls` plus node trust for the issuing CA.
 `external` skips the bundled registry and uses `--external-registry-url`,
 `PROVISIONED_REGISTRY_URL`, or `mcp-runtime registry provision`.
 
+Setup-built images default to the Linux architecture reported by the cluster
+nodes. Override with `MCP_IMAGE_PLATFORM=linux/amd64` or
+`MCP_IMAGE_PLATFORM=linux/arm64` when the build host differs from the target
+cluster.
+
 For non-test public/TLS setup, configure the platform hostnames before running
 setup: set `MCP_PLATFORM_DOMAIN` to derive `platform.<domain>`,
 `registry.<domain>`, and `mcp.<domain>`, or set

--- a/docs/cluster-readiness.md
+++ b/docs/cluster-readiness.md
@@ -108,7 +108,7 @@ pull platform images through a specific internal registry endpoint.
 |------|-----------------|------------------|
 | `auto` | Keeps existing behavior: use a provisioned registry config when present, otherwise install the bundled registry. | Depends on the resolved path. |
 | `bundled-http` | Installs the bundled registry and keeps the registry pod on plain HTTP for internal platform pulls. Public ingress can still use TLS with `--with-tls`. | Configure every node/containerd runtime to allow the exact image host as an insecure registry. |
-| `bundled-https` | Installs the bundled registry with TLS served by the registry pod itself. Public ingress TLS can still use ACME; the registry pod uses a separate internal certificate from setup-generated `mcp-runtime-ca`, or from `--tls-cluster-issuer` when you provide one. | Configure every node to resolve or mirror the rendered registry host and trust the internal issuing CA. |
+| `bundled-https` | Installs the bundled registry with TLS served by the registry pod itself. Public ingress TLS can still use ACME; the registry pod uses a separate internal certificate from setup-generated `mcp-runtime-ca`, or from a non-ACME `--tls-cluster-issuer` when you provide one. | Configure every node to resolve or mirror the rendered registry host and trust the internal issuing CA. |
 | `external` | Skips the bundled registry and pushes setup images to a provisioned registry. | Registry DNS, TLS, auth, pull secrets, and node trust are owned by the external registry platform. |
 
 For bundled HTTPS without an explicit `MCP_REGISTRY_ENDPOINT`, setup renders
@@ -126,6 +126,19 @@ the `registry-internal-tls` Secret as the signal to probe the registry Service
 over HTTPS; a successful doctor registry probe confirms in-cluster push-helper
 reachability, while kubelet image pulls still depend on node/containerd trust
 for the exact rendered image host.
+
+### Setup image platform
+
+`setup` builds the operator, gateway proxy, and Sentinel images as Linux
+container images. By default it inspects `kubernetes.io/arch` on cluster nodes
+and builds a single-platform image for a homogeneous cluster, for example
+`linux/amd64` on standard VPS nodes or `linux/arm64` on ARM nodes. Mixed-arch
+clusters are rejected until multi-arch manifest publishing is supported, because
+the platform deployments do not pin pods to architecture-specific node pools.
+
+Set `MCP_IMAGE_PLATFORM=linux/amd64` or `MCP_IMAGE_PLATFORM=linux/arm64` when
+you need to override detection, such as building from an Apple Silicon laptop
+for an amd64 k3s VPS cluster.
 
 ---
 

--- a/docs/deployment-targets.md
+++ b/docs/deployment-targets.md
@@ -167,8 +167,8 @@ Use `--tls-cluster-issuer <issuer-name>` instead of `--acme-email` when your
 cluster already has an enterprise `ClusterIssuer`.
 
 For a complete four-node reference topology, worker join commands, ServiceLB
-pinning, public DNS, TLS, registry, validation, and a five-node extension, use
-[k3s On-Prem Cluster](k3s-on-prem-cluster.md).
+pinning, public DNS, Cloudflare or enterprise proxy front doors, TLS, registry,
+validation, and a five-node extension, use [k3s On-Prem Cluster](k3s-on-prem-cluster.md).
 
 ### kubeadm, RKE2, and Other Self-Managed Clusters
 

--- a/docs/deployment-targets.md
+++ b/docs/deployment-targets.md
@@ -59,7 +59,7 @@ Then make registry mode explicit:
 | kind | Contributor development, CI-like smoke tests, disposable clusters | Bundled HTTP registry with the documented kind mirror | Use [Contributor Local Kind](contributor/local-kind.md) and `setup --test-mode`. |
 | Docker Desktop Kubernetes | Laptop demos and local evaluation | Bundled HTTP registry or Docker Desktop image loading | Good for local UI/API exploration, not production. |
 | minikube | Laptop or VM evaluation | Insecure registry flag at cluster start, or `minikube image load` | Recreate minikube when changing insecure registry settings. |
-| k3s | Single-node lab, edge, small self-managed clusters | Bundled registry for labs; external or bundled HTTPS for production | See the k3s example below and [Cluster Readiness - k3s](cluster-readiness.md#k3s). |
+| k3s | Single-node lab, edge, small self-managed clusters | Bundled registry for labs; external or bundled HTTPS for production | See the k3s examples below, the [k3s On-Prem Cluster](k3s-on-prem-cluster.md) runbook, and [Cluster Readiness - k3s](cluster-readiness.md#k3s). |
 | kubeadm / vanilla Kubernetes | Self-managed production or staging | External registry, or bundled HTTPS with node CA trust | Configure containerd, DNS, ingress, storage, and TLS on every node. |
 | RKE2 | Self-managed production or staging | External registry, or bundled HTTPS with node CA trust | Treat it like a hardened self-managed cluster; use provider tooling for runtime config. |
 | EKS | AWS managed Kubernetes | ECR | Use AWS-managed node registry auth, a real ingress/load balancer, Route 53 or equivalent DNS, and cert-manager or enterprise TLS. |
@@ -165,6 +165,10 @@ export GOOGLE_CLIENT_ID=<google-oauth-client-id>
 
 Use `--tls-cluster-issuer <issuer-name>` instead of `--acme-email` when your
 cluster already has an enterprise `ClusterIssuer`.
+
+For a complete four-node reference topology, worker join commands, ServiceLB
+pinning, public DNS, TLS, registry, validation, and a five-node extension, use
+[k3s On-Prem Cluster](k3s-on-prem-cluster.md).
 
 ### kubeadm, RKE2, and Other Self-Managed Clusters
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -404,6 +404,10 @@ that Kubernetes nodes can pull. Set `MCP_PLATFORM_ADMIN_EMAIL` or
 `ADMIN_USERS` so the first OIDC login for that email is promoted to platform
 admin; `--acme-email` is only the certificate contact email.
 
+When building setup images from a machine with a different CPU architecture
+than the cluster, set `MCP_IMAGE_PLATFORM` to the target node platform, for
+example `MCP_IMAGE_PLATFORM=linux/amd64` for standard VPS/k3s nodes.
+
 You can also skip the saved provision step and pass
 `--external-registry-url registry.example.com` directly to `setup`.
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -3323,6 +3323,7 @@ type CLIConfig struct {
 	SkopeoImage               string
 	OperatorImage             string // Override for operator image
 	GatewayProxyImage         string // Optional default image for the MCP gateway sidecar
+	ImagePlatform             string // Optional Docker image platform for setup-built images, e.g. linux/amd64
 	GatewayOTLPEndpoint       string // Optional OTLP/HTTP endpoint for MCP gateway sidecar tracing
 	AnalyticsIngestURL        string // Optional analytics ingest URL override for the MCP gateway sidecar
 	IngressReadinessMode      string // Optional operator ingress readiness mode: strict or permissive

--- a/docs/k3s-on-prem-cluster.md
+++ b/docs/k3s-on-prem-cluster.md
@@ -59,6 +59,83 @@ Let's Encrypt HTTP-01 requires public DNS and public port 80. For private-only
 on-prem DNS, use an enterprise cert-manager `ClusterIssuer` or pre-created TLS
 secrets instead of `--acme-email`.
 
+## Choose the Front Door
+
+Pick the public or internal traffic path before installing MCP Runtime. The
+platform expects the same three hostnames either way:
+
+- `platform.example.com` for the dashboard, API, Grafana, and Prometheus.
+- `registry.example.com` for OCI registry push and pull flows.
+- `mcp.example.com` for MCP server routes such as `/<server-name>/mcp`.
+
+### Direct DNS to k3s Ingress
+
+This is the simplest public demo shape:
+
+```text
+client -> DNS A record -> mcp-ingress-1 public IP -> k3s ServiceLB -> Traefik
+```
+
+Use this when you can expose ports 80 and 443 directly on the ingress node or
+on a small external load balancer. `--acme-email` works in this shape because
+Let's Encrypt HTTP-01 can reach Traefik on port 80.
+
+### Cloudflare, WAF, or Public Reverse Proxy
+
+For internet-facing demos, it is usually better to put Cloudflare, an
+enterprise WAF, or another reverse proxy in front of the ingress node:
+
+```text
+client -> Cloudflare/WAF/proxy -> origin ingress IP -> k3s ServiceLB -> Traefik
+```
+
+In this shape:
+
+- Point the public DNS records at the proxy, not directly at the node, if the
+  proxy is meant to hide or shield the origin.
+- Configure the proxy origin to forward all three hosts to the ingress node or
+  external load balancer.
+- Preserve the original `Host` header and `X-Forwarded-Proto`.
+- Do not cache or rewrite `/api`, `/v2`, `/<server-name>/mcp`, or
+  `/.well-known/acme-challenge/*`.
+- Allow long-lived and streaming HTTP responses for MCP traffic.
+- Allow registry blob upload/download behavior, including large request bodies,
+  range requests, and Docker/OCI auth headers.
+- Restrict origin firewall access to the proxy source ranges when possible, and
+  keep those ranges updated from the proxy provider.
+
+`--acme-email` still uses HTTP-01. If the proxy is in front during issuance,
+`/.well-known/acme-challenge/*` must pass through to Traefik without auth,
+cache, forced HTTPS loops, or WAF blocks. A practical rollout is to start with
+DNS-only/direct records until cert-manager issues certificates, then enable the
+proxy after validation. For private or always-proxied environments, prefer an
+enterprise cert-manager `ClusterIssuer`, proxy-managed origin certificates, or
+pre-created TLS secrets instead of public HTTP-01.
+
+Test the registry path through the proxy before calling the install done:
+
+```bash
+curl -i https://registry.example.com/v2/
+```
+
+Unauthenticated `401` or `403` is healthy. A proxy-generated HTML error,
+timeout, body-size error, or cached response means Docker/OCI clients may fail
+even if the dashboard works.
+
+### Internal Enterprise Proxy or Load Balancer
+
+For private on-prem installs, put an internal reverse proxy, F5/HAProxy/NGINX,
+or a private load balancer in front of `mcp-ingress-1`:
+
+```text
+internal client -> internal DNS/proxy/LB -> k3s ServiceLB -> Traefik
+```
+
+Keep the same hostnames, but resolve them in internal DNS. Use
+`--tls-cluster-issuer <issuer-name>` or pre-created TLS secrets so certificates
+chain to your enterprise trust store. Public Let's Encrypt ACME is not the
+right fit unless the names and HTTP-01 challenge path are publicly reachable.
+
 ## Install k3s
 
 Install the first node as the single k3s server. Disable the packaged k3s

--- a/docs/k3s-on-prem-cluster.md
+++ b/docs/k3s-on-prem-cluster.md
@@ -1,0 +1,330 @@
+# k3s On-Prem Cluster
+
+This guide creates a small public or on-prem k3s cluster that can run MCP
+Runtime with real DNS, TLS, ingress, registry pulls, and multi-node scheduling.
+It is the production-style version of the lab path in
+[Deployment Targets](deployment-targets.md): still small enough for a demo or
+pilot, but close enough to a real customer environment to test the platform
+honestly.
+
+The reference layout is four nodes because that is the smallest shape that
+separates the control plane, public ingress, and general workloads. A fifth
+node is an easy extension and is covered below.
+
+This is a demo or pilot topology, not a high-availability control plane. For a
+production control plane, use the k3s HA topology with three server nodes and
+plan datastore backups separately.
+
+## Reference Topology
+
+| Node | k3s role | Recommended size | Purpose |
+|---|---|---|---|
+| `mcp-cp-1` | server | 4-8 vCPU, 8-16 GiB RAM | Kubernetes API, scheduler, controller manager, embedded datastore, light platform workloads |
+| `mcp-ingress-1` | agent | 2-4 vCPU, 4-8 GiB RAM | Public Traefik ServiceLB node for ports 80 and 443 |
+| `mcp-worker-1` | agent | 2-4 vCPU, 4-8 GiB RAM | Sentinel, operator, registry, and MCP server workloads |
+| `mcp-worker-2` | agent | 2-4 vCPU, 4-8 GiB RAM | Extra capacity and scheduling headroom |
+
+For a five-node demo, add `mcp-worker-3` as another general worker. If you need
+control-plane high availability, use the k3s HA server topology instead of just
+adding one more server node; that is a different operational shape.
+
+This guide assumes all nodes use the same CPU architecture. Standard VPS and
+most on-prem x86 servers are `amd64`, so setup builds `linux/amd64` images. Do
+not mix `amd64` and `arm64` nodes until MCP Runtime publishes multi-arch setup
+images.
+
+## Prerequisites
+
+- Ubuntu 24.04 or another k3s-supported Linux distribution on every node.
+- Root or passwordless sudo access on every node.
+- Node-to-node network connectivity for k3s and the pod network.
+- Public ports 80 and 443 open on the ingress node.
+- Kubernetes API port 6443 reachable from worker nodes and your admin
+  workstation. Restrict it to trusted IPs when the node has a public address.
+- A default storage path. k3s installs `local-path` by default; use a real CSI,
+  NFS, Longhorn, or another durable storage class for serious production.
+- DNS records for the platform hosts:
+
+  ```text
+  platform.example.com -> <ingress-public-ip>
+  registry.example.com -> <ingress-public-ip>
+  mcp.example.com      -> <ingress-public-ip>
+  ```
+
+Use your own apex domain in place of `example.com`. `MCP_PLATFORM_DOMAIN` takes
+the apex only, so `MCP_PLATFORM_DOMAIN=example.com` derives the three names
+above.
+
+Let's Encrypt HTTP-01 requires public DNS and public port 80. For private-only
+on-prem DNS, use an enterprise cert-manager `ClusterIssuer` or pre-created TLS
+secrets instead of `--acme-email`.
+
+## Install k3s
+
+Install the first node as the single k3s server. Disable the packaged k3s
+Traefik so MCP Runtime can install and own the repo-managed Traefik manifests.
+
+Run on `mcp-cp-1`:
+
+```bash
+curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server \
+  --node-name mcp-cp-1 \
+  --disable traefik \
+  --write-kubeconfig-mode 0644 \
+  --node-ip <cp-node-ip> \
+  --node-external-ip <cp-node-public-ip> \
+  --tls-san <cp-node-public-ip> \
+  --tls-san platform.example.com \
+  --tls-san registry.example.com \
+  --tls-san mcp.example.com" sh -
+```
+
+If nodes have more than one network interface, add `--flannel-iface <iface>` to
+the server and every agent install command so pod networking uses the intended
+interface.
+
+Get the node token:
+
+```bash
+sudo cat /var/lib/rancher/k3s/server/node-token
+```
+
+Treat the node token as a secret; it lets other machines join the cluster.
+
+Join each worker. Run this once per agent node, changing the node name and IPs:
+
+```bash
+curl -sfL https://get.k3s.io | K3S_URL=https://<cp-node-ip>:6443 \
+  K3S_TOKEN=<node-token> \
+  sh -s - agent \
+  --node-name mcp-ingress-1 \
+  --node-ip <worker-node-ip> \
+  --node-external-ip <worker-node-public-ip>
+```
+
+Repeat for `mcp-worker-1`, `mcp-worker-2`, and optionally `mcp-worker-3`.
+
+## Configure kubectl
+
+From your workstation, copy the kubeconfig from the server node, replace
+`127.0.0.1` with the reachable control-plane address, and keep the file
+private:
+
+```bash
+scp root@<cp-node-ip>:/etc/rancher/k3s/k3s.yaml ./mcp-k3s.yaml
+sed -i.bak 's/127.0.0.1/<cp-node-ip>/g' ./mcp-k3s.yaml
+chmod 0600 ./mcp-k3s.yaml
+export KUBECONFIG=$PWD/mcp-k3s.yaml
+kubectl get nodes -o wide
+```
+
+For macOS, the `sed -i.bak` form works with the default BSD `sed`.
+Treat the kubeconfig as a cluster-admin credential and do not commit it.
+
+## Pin ServiceLB to the Ingress Node
+
+k3s ServiceLB will schedule load-balancer pods on eligible nodes. For a public
+demo, keep ports 80 and 443 on one known public ingress node.
+
+Label the ingress node:
+
+```bash
+kubectl label node mcp-ingress-1 \
+  svccontroller.k3s.cattle.io/enablelb=true \
+  ingress.mcpruntime.org/public=true \
+  node-role.mcpruntime.org/public-ingress=true
+```
+
+If another node was labeled for ServiceLB during earlier testing, remove the
+ServiceLB label from it:
+
+```bash
+kubectl label node <node-name> svccontroller.k3s.cattle.io/enablelb- --overwrite
+```
+
+After setup installs Traefik, verify the `svclb-traefik` pods land only on the
+ingress node:
+
+```bash
+kubectl -n traefik get pods -o wide
+```
+
+If one node also serves non-Kubernetes docs or a website with Docker/nginx, keep
+that node out of Kubernetes scheduling:
+
+```bash
+kubectl cordon <docs-node-name>
+```
+
+Cordoning a node does not remove it from the cluster; it just prevents new pods
+from being scheduled there.
+
+## Preflight Checks
+
+Before installing MCP Runtime, verify the cluster shape:
+
+```bash
+kubectl get nodes -o wide
+kubectl get storageclass
+kubectl -n kube-system get pods
+kubectl get ingressclass
+```
+
+Check DNS from your workstation and from inside the cluster:
+
+```bash
+dig +short platform.example.com
+dig +short registry.example.com
+dig +short mcp.example.com
+
+kubectl run dns-check --rm -i --restart=Never --image=busybox:1.36 -- \
+  nslookup platform.example.com
+```
+
+All three public names must resolve to the ingress node before using
+Let's Encrypt HTTP-01. Port 80 must reach Traefik for certificate issuance.
+
+## Install MCP Runtime
+
+Build the CLI from the repo root:
+
+```bash
+make deps
+make build
+```
+
+For a public demo using the bundled HTTPS registry, set the public platform
+domain and make platform image pulls use the public registry host. The registry
+host must resolve from every node.
+
+```bash
+export MCP_PLATFORM_DOMAIN=example.com
+export MCP_REGISTRY_ENDPOINT=registry.example.com
+export MCP_PLATFORM_ADMIN_EMAIL=admin@example.com
+export GOOGLE_CLIENT_ID=<google-client-id>.apps.googleusercontent.com
+export MCP_IMAGE_PLATFORM=linux/amd64
+```
+
+`MCP_IMAGE_PLATFORM` is optional when all Kubernetes nodes report the same
+architecture, but setting it explicitly is useful when building from an ARM
+laptop for amd64 servers. Use `linux/arm64` only for a homogeneous ARM cluster.
+
+Run setup:
+
+```bash
+./bin/mcp-runtime bootstrap --provider k3s
+
+MCP_SETUP_WAIT_TIMEOUT=1200 ./bin/mcp-runtime setup \
+  --platform-mode public \
+  --registry-mode bundled-https \
+  --storage-mode dynamic \
+  --with-tls \
+  --acme-email ops@example.com \
+  --strict-prod \
+  --parallel-builds
+```
+
+Use `--platform-mode tenant` for private team-isolated installs, or
+`--platform-mode org` for a shared internal catalog. `public` exposes the
+catalog anonymously and requires browser login configuration for publishing.
+
+If your organization already owns cert-manager and a `ClusterIssuer`, replace
+`--acme-email` with:
+
+```bash
+MCP_SETUP_WAIT_TIMEOUT=1200 ./bin/mcp-runtime setup \
+  --platform-mode public \
+  --registry-mode bundled-https \
+  --storage-mode dynamic \
+  --with-tls \
+  --tls-cluster-issuer <issuer-name> \
+  --skip-cert-manager-install \
+  --strict-prod \
+  --parallel-builds
+```
+
+If your organization already owns a registry, prefer the external registry path:
+
+```bash
+MCP_SETUP_WAIT_TIMEOUT=1200 ./bin/mcp-runtime setup \
+  --platform-mode public \
+  --registry-mode external \
+  --external-registry-url registry.example.com/mcp-runtime \
+  --with-tls \
+  --acme-email ops@example.com \
+  --strict-prod \
+  --parallel-builds
+```
+
+Pass `--external-registry-username` and `PROVISIONED_REGISTRY_PASSWORD` when the
+registry needs credentials.
+
+## Validate
+
+Run the platform checks:
+
+```bash
+./bin/mcp-runtime status
+./bin/mcp-runtime cluster doctor
+kubectl get pods -A
+kubectl get ingress -A
+kubectl get certificate -A
+```
+
+Check the public routes:
+
+```bash
+curl -I https://platform.example.com/
+curl -i https://registry.example.com/v2/
+```
+
+The platform route should return `200`. The registry route should return
+`401` or `403` without credentials; that means the public registry route is up
+and guarded.
+
+Before deploying MCP servers, `https://mcp.example.com/<server>/mcp` can return
+404 because no server route exists yet. Follow
+[Publish an MCP Server](publish-mcp-server.md) to build, push, deploy, and
+verify a real server.
+
+## Five-Node Variant
+
+For a five-node demo, keep the same control-plane and ingress roles and add one
+more general worker:
+
+| Node | Role |
+|---|---|
+| `mcp-cp-1` | k3s server |
+| `mcp-ingress-1` | ServiceLB / Traefik public ingress |
+| `mcp-worker-1` | general workloads |
+| `mcp-worker-2` | general workloads |
+| `mcp-worker-3` | general workloads, observability, or larger MCP servers |
+
+Do not label the extra worker with
+`svccontroller.k3s.cattle.io/enablelb=true` unless you intentionally want ports
+80 and 443 spread across more than one public node. Keep DNS pointed at the
+node or load balancer that actually receives HTTP and HTTPS traffic.
+
+## Migration Notes
+
+Fresh installs do not need certificate backup or restore. Use fresh ACME,
+your enterprise issuer, or pre-created TLS secrets.
+
+Back up cert-manager `Certificate`, `Issuer` or `ClusterIssuer`, and TLS
+`Secret` objects only when migrating an existing public install that already
+owns valid certificates or issuer state. That is a migration concern, mainly to
+avoid losing working cert material or burning Let's Encrypt rate limits during a
+move. Keep those backups encrypted and out of git because TLS secrets contain
+private keys.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `exec format error` in a setup-built pod | The image architecture does not match the node. Use a homogeneous cluster and set `MCP_IMAGE_PLATFORM=linux/amd64` or `linux/arm64`. |
+| cert-manager reports NXDOMAIN or HTTP-01 failure | `platform`, `registry`, and `mcp` DNS records must point to the ingress IP, and port 80 must reach Traefik. |
+| Setup rejects public mode because login is missing | Set `GOOGLE_CLIENT_ID` / `MCP_GOOGLE_CLIENT_ID`, or set `OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL`. |
+| Setup rejects production admin config | Set `MCP_PLATFORM_ADMIN_EMAIL` or `MCP_ADMIN_USERS`. Do not confuse this with `--acme-email`, which is only the certificate contact. |
+| Registry image pulls fail | Confirm `MCP_REGISTRY_ENDPOINT` is the exact host nodes pull, DNS resolves from every node, and the certificate chain is trusted by the node runtime. |
+| Traefik 404 for the dashboard | Confirm `MCP_PLATFORM_DOMAIN=example.com`, `kubectl get ingress -A`, and DNS for `platform.example.com` points to the ingress node. |
+| ServiceLB lands on the wrong node | Check `kubectl get pods -A -o wide | grep svclb` and fix `svccontroller.k3s.cattle.io/enablelb` labels. |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Home: README.md
   - Getting Started: getting-started.md
   - Deployment Targets: deployment-targets.md
+  - k3s On-Prem Cluster: k3s-on-prem-cluster.md
   - Contributor Guide:
       - Overview: contributor/README.md
       - Local Kind and Test Mode: contributor/local-kind.md

--- a/internal/cli/core/config.go
+++ b/internal/cli/core/config.go
@@ -36,6 +36,7 @@ type CLIConfig struct {
 	SkopeoImage               string
 	OperatorImage             string // Override for operator image
 	GatewayProxyImage         string // Optional default image for the MCP gateway sidecar
+	ImagePlatform             string // Optional Docker image platform for setup-built images, e.g. linux/amd64
 	GatewayOTLPEndpoint       string // Optional OTLP/HTTP endpoint for MCP gateway sidecar tracing
 	AnalyticsIngestURL        string // Optional analytics ingest URL override for the MCP gateway sidecar
 	IngressReadinessMode      string // Optional operator ingress readiness mode: strict or permissive
@@ -87,6 +88,7 @@ func LoadCLIConfig() *CLIConfig {
 		SkopeoImage:                 getEnvOrDefault("MCP_SKOPEO_IMAGE", defaultSkopeoImage),
 		OperatorImage:               os.Getenv("MCP_OPERATOR_IMAGE"), // No default, empty means auto
 		GatewayProxyImage:           os.Getenv("MCP_GATEWAY_PROXY_IMAGE"),
+		ImagePlatform:               os.Getenv("MCP_IMAGE_PLATFORM"),
 		GatewayOTLPEndpoint:         os.Getenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT"),
 		AnalyticsIngestURL:          getEnvCompat("MCP_SENTINEL_INGEST_URL", "MCP_ANALYTICS_INGEST_URL"),
 		IngressReadinessMode:        os.Getenv("MCP_INGRESS_READINESS_MODE"),

--- a/internal/cli/core/config_test.go
+++ b/internal/cli/core/config_test.go
@@ -58,6 +58,7 @@ func TestLoadCLIConfigWithProvisionedRegistry(t *testing.T) {
 	t.Setenv("MCP_SKOPEO_IMAGE", "example/skopeo:latest")
 	t.Setenv("MCP_OPERATOR_IMAGE", "example/operator:latest")
 	t.Setenv("MCP_GATEWAY_PROXY_IMAGE", "example/mcp-gateway:latest")
+	t.Setenv("MCP_IMAGE_PLATFORM", "linux/amd64")
 	t.Setenv("MCP_GATEWAY_OTEL_EXPORTER_OTLP_ENDPOINT", "http://custom-otel:4318")
 	t.Setenv("MCP_SENTINEL_INGEST_URL", "http://mcp-sentinel-ingest.mcp-sentinel.svc.cluster.local:8081/events")
 	t.Setenv("MCP_INGRESS_READINESS_MODE", "permissive")
@@ -93,6 +94,9 @@ func TestLoadCLIConfigWithProvisionedRegistry(t *testing.T) {
 	}
 	if cfg.GatewayProxyImage != "example/mcp-gateway:latest" {
 		t.Fatalf("expected gateway proxy image override, got %q", cfg.GatewayProxyImage)
+	}
+	if cfg.ImagePlatform != "linux/amd64" {
+		t.Fatalf("expected image platform override, got %q", cfg.ImagePlatform)
 	}
 	if cfg.GatewayOTLPEndpoint != "http://custom-otel:4318" {
 		t.Fatalf("expected gateway OTLP endpoint override, got %q", cfg.GatewayOTLPEndpoint)

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -77,6 +77,67 @@ func csvHasValue(csv, value string) bool {
 	return false
 }
 
+func TestResolveSetupImagePlatformUsesNodeArchitecture(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	t.Cleanup(func() { core.DefaultCLIConfig = orig })
+	core.DefaultCLIConfig = &core.CLIConfig{}
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("amd64\namd64\n")})
+
+	got, err := resolveSetupImagePlatform(kubectl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "linux/amd64" {
+		t.Fatalf("expected linux/amd64, got %q", got)
+	}
+}
+
+func TestResolveSetupImagePlatformRejectsMixedNodeArchitectures(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	t.Cleanup(func() { core.DefaultCLIConfig = orig })
+	core.DefaultCLIConfig = &core.CLIConfig{}
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("amd64\narm64\n")})
+
+	_, err := resolveSetupImagePlatform(kubectl)
+	if err == nil || !strings.Contains(err.Error(), "mixed Kubernetes node architectures") {
+		t.Fatalf("expected mixed architecture error, got %v", err)
+	}
+}
+
+func TestResolveSetupImagePlatformRejectsExplicitMismatch(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	t.Cleanup(func() { core.DefaultCLIConfig = orig })
+	core.DefaultCLIConfig = &core.CLIConfig{ImagePlatform: "linux/arm64"}
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("amd64\n")})
+
+	_, err := resolveSetupImagePlatform(kubectl)
+	if err == nil || !strings.Contains(err.Error(), "does not match Kubernetes node architecture") {
+		t.Fatalf("expected explicit mismatch error, got %v", err)
+	}
+}
+
+func TestBuildOperatorImagePassesDockerPlatform(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	t.Cleanup(func() { core.DefaultCLIConfig = orig })
+	core.DefaultCLIConfig = &core.CLIConfig{ImagePlatform: "linux/amd64"}
+	restoreKubectl := core.SwapDefaultKubectlClient(core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("amd64\n")}))
+	t.Cleanup(restoreKubectl)
+	mockExec := &core.MockExecutor{}
+	restoreExec := core.SwapExecExecutor(mockExec)
+	t.Cleanup(restoreExec)
+
+	if err := buildOperatorImage("registry.example.com/mcp-runtime-operator:test"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mockExec.Commands) != 1 {
+		t.Fatalf("expected one command, got %#v", mockExec.Commands)
+	}
+	cmd := mockExec.Commands[0]
+	if cmd.Name != "make" || !contains(cmd.Args, "DOCKER_PLATFORM=linux/amd64") {
+		t.Fatalf("expected make command with DOCKER_PLATFORM, got %s %#v", cmd.Name, cmd.Args)
+	}
+}
+
 func TestGetOperatorImage(t *testing.T) {
 	origOverride := core.DefaultCLIConfig.OperatorImage
 	origTagResolver := setupImageTagResolver
@@ -880,6 +941,23 @@ func TestRenderAnalyticsSecretManifestUsesAdminEnv(t *testing.T) {
 		if !csvHasValue(data["ADMIN_USERS"], want) {
 			t.Fatalf("expected ADMIN_USERS to include %q, got %q", want, data["ADMIN_USERS"])
 		}
+	}
+}
+
+func TestRenderAnalyticsSecretManifestDoesNotSeedPartialAdminPasswordUser(t *testing.T) {
+	t.Setenv("MCP_PLATFORM_ADMIN_EMAIL", "PrinceKrRoshan01@gmail.com")
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{})
+
+	manifest, err := renderAnalyticsSecretManifest(kubectl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := secretStringDataFromManifest(t, manifest)
+	if data["PLATFORM_ADMIN_EMAIL"] != "" || data["PLATFORM_ADMIN_PASSWORD"] != "" {
+		t.Fatalf("expected partial admin bootstrap fields to be omitted, got email=%q password=%q", data["PLATFORM_ADMIN_EMAIL"], data["PLATFORM_ADMIN_PASSWORD"])
+	}
+	if !csvHasValue(data["ADMIN_USERS"], "PrinceKrRoshan01@gmail.com") {
+		t.Fatalf("expected admin email to remain in ADMIN_USERS, got %q", data["ADMIN_USERS"])
 	}
 }
 

--- a/internal/cli/setup/helpers_test.go
+++ b/internal/cli/setup/helpers_test.go
@@ -116,6 +116,21 @@ func TestResolveSetupImagePlatformRejectsExplicitMismatch(t *testing.T) {
 	}
 }
 
+func TestResolveSetupImagePlatformIncludesKubectlStderr(t *testing.T) {
+	orig := core.DefaultCLIConfig
+	t.Cleanup(func() { core.DefaultCLIConfig = orig })
+	core.DefaultCLIConfig = &core.CLIConfig{}
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{
+		DefaultOutput: []byte("Error from server (Forbidden): nodes is forbidden"),
+		DefaultErr:    errors.New("exit status 1"),
+	})
+
+	_, err := resolveSetupImagePlatform(kubectl)
+	if err == nil || !strings.Contains(err.Error(), "nodes is forbidden") {
+		t.Fatalf("expected kubectl stderr in error, got %v", err)
+	}
+}
+
 func TestBuildOperatorImagePassesDockerPlatform(t *testing.T) {
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() { core.DefaultCLIConfig = orig })
@@ -958,6 +973,35 @@ func TestRenderAnalyticsSecretManifestDoesNotSeedPartialAdminPasswordUser(t *tes
 	}
 	if !csvHasValue(data["ADMIN_USERS"], "PrinceKrRoshan01@gmail.com") {
 		t.Fatalf("expected admin email to remain in ADMIN_USERS, got %q", data["ADMIN_USERS"])
+	}
+}
+
+func TestRenderAnalyticsSecretManifestAllowsPartialAdminOverrideWithExistingPair(t *testing.T) {
+	t.Setenv("MCP_PLATFORM_ADMIN_EMAIL", "new-admin@mcpruntime.org")
+	existingPassword := base64.StdEncoding.EncodeToString([]byte("existing-password"))
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			if contains(spec.Args, "jsonpath={.data.PLATFORM_ADMIN_PASSWORD}") {
+				return &core.MockCommand{Args: spec.Args, OutputData: []byte(existingPassword)}
+			}
+			return &core.MockCommand{Args: spec.Args}
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	manifest, err := renderAnalyticsSecretManifest(kubectl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := secretStringDataFromManifest(t, manifest)
+	if data["PLATFORM_ADMIN_EMAIL"] != "new-admin@mcpruntime.org" {
+		t.Fatalf("expected admin email override, got %q", data["PLATFORM_ADMIN_EMAIL"])
+	}
+	if data["PLATFORM_ADMIN_PASSWORD"] != "existing-password" {
+		t.Fatalf("expected existing password to be retained, got %q", data["PLATFORM_ADMIN_PASSWORD"])
+	}
+	if !csvHasValue(data["ADMIN_USERS"], "new-admin@mcpruntime.org") {
+		t.Fatalf("expected ADMIN_USERS to include override email, got %q", data["ADMIN_USERS"])
 	}
 }
 

--- a/internal/cli/setup/plan_flow_test.go
+++ b/internal/cli/setup/plan_flow_test.go
@@ -584,6 +584,21 @@ func TestBundledRegistryInternalIssuerKeepsNonACMEIssuer(t *testing.T) {
 	}
 }
 
+func TestBundledRegistryInternalIssuerIncludesKubectlStderr(t *testing.T) {
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{
+		DefaultOutput: []byte("Error from server (Forbidden): clusterissuers is forbidden"),
+		DefaultErr:    fmt.Errorf("exit status 1"),
+	})
+
+	_, err := bundledRegistryInternalIssuerName(kubectl, setupplan.Plan{
+		RegistryMode:     setupplan.RegistryModeBundledHTTPS,
+		TLSClusterIssuer: "letsencrypt-prod",
+	})
+	if err == nil || !strings.Contains(err.Error(), "clusterissuers is forbidden") {
+		t.Fatalf("expected kubectl stderr in error, got %v", err)
+	}
+}
+
 func TestValidateNonTestSetupRejectsDevRegistryURLInStrictProd(t *testing.T) {
 	setPublicDomainEnv(t)
 

--- a/internal/cli/setup/plan_flow_test.go
+++ b/internal/cli/setup/plan_flow_test.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"mcp-runtime/internal/cli/certmanager"
 	"mcp-runtime/internal/cli/cluster"
 	"mcp-runtime/internal/cli/core"
 	"mcp-runtime/internal/cli/registry/config"
@@ -550,6 +551,36 @@ func TestRegistryCertificateSANsStayPublicForBundledHTTPS(t *testing.T) {
 		if contains(dnsNames, internal) || contains(ipAddresses, internal) {
 			t.Fatalf("public registry cert unexpectedly contains internal SAN %q (dns=%v ips=%v)", internal, dnsNames, ipAddresses)
 		}
+	}
+}
+
+func TestBundledRegistryInternalIssuerUsesPrivateCAForACMEIssuer(t *testing.T) {
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("https://acme-v02.api.letsencrypt.org/directory")})
+
+	got, err := bundledRegistryInternalIssuerName(kubectl, setupplan.Plan{
+		RegistryMode:     setupplan.RegistryModeBundledHTTPS,
+		TLSClusterIssuer: "letsencrypt-prod",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != certmanager.CertClusterIssuerName {
+		t.Fatalf("expected internal registry issuer %q, got %q", certmanager.CertClusterIssuerName, got)
+	}
+}
+
+func TestBundledRegistryInternalIssuerKeepsNonACMEIssuer(t *testing.T) {
+	kubectl := core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("")})
+
+	got, err := bundledRegistryInternalIssuerName(kubectl, setupplan.Plan{
+		RegistryMode:     setupplan.RegistryModeBundledHTTPS,
+		TLSClusterIssuer: "company-ca",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "company-ca" {
+		t.Fatalf("expected company-ca issuer, got %q", got)
 	}
 }
 

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -517,8 +517,11 @@ func clusterNodeArchitectures(kubectl core.KubectlRunner) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not inspect Kubernetes node architectures: %w", err)
 	}
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if detail := strings.TrimSpace(string(out)); detail != "" {
+			return nil, fmt.Errorf("could not inspect Kubernetes node architectures: %w: %s", err, detail)
+		}
 		return nil, fmt.Errorf("could not inspect Kubernetes node architectures: %w", err)
 	}
 	seen := map[string]struct{}{}
@@ -2853,8 +2856,10 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 	}
 	envPlatformAdminEmail := setupSecretEnvValue("MCP_PLATFORM_ADMIN_EMAIL", "PLATFORM_ADMIN_EMAIL")
 	envPlatformAdminPassword := setupSecretEnvValue("MCP_PLATFORM_ADMIN_PASSWORD", "PLATFORM_ADMIN_PASSWORD")
-	if envPlatformAdminEmail != "" && envPlatformAdminPassword != "" {
+	if envPlatformAdminEmail != "" {
 		platformAdminEmail = envPlatformAdminEmail
+	}
+	if envPlatformAdminPassword != "" {
 		platformAdminPassword = envPlatformAdminPassword
 	}
 	if platformAdminEmail == "" || platformAdminPassword == "" {
@@ -3335,8 +3340,11 @@ func clusterIssuerUsesACME(kubectl core.KubectlRunner, name string) (bool, error
 	if err != nil {
 		return false, err
 	}
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
+		if detail := strings.TrimSpace(string(out)); detail != "" {
+			return false, fmt.Errorf("inspect ClusterIssuer %q: %w: %s", name, err, detail)
+		}
 		return false, err
 	}
 	return strings.TrimSpace(string(out)) != "", nil

--- a/internal/cli/setup/platform.go
+++ b/internal/cli/setup/platform.go
@@ -461,6 +461,82 @@ func setupImageTag() string {
 	return setupImageTagResolver()
 }
 
+func resolveSetupImagePlatform(kubectl core.KubectlRunner) (string, error) {
+	var explicitPlatform string
+	if core.DefaultCLIConfig != nil {
+		if platform := strings.TrimSpace(core.DefaultCLIConfig.ImagePlatform); platform != "" {
+			validated, err := validateSetupImagePlatform(platform)
+			if err != nil {
+				return "", err
+			}
+			explicitPlatform = validated
+		}
+	}
+
+	archs, err := clusterNodeArchitectures(kubectl)
+	if err != nil {
+		if explicitPlatform != "" {
+			return explicitPlatform, nil
+		}
+		return "", err
+	}
+	if len(archs) == 0 {
+		return "", fmt.Errorf("could not resolve setup image platform: no Kubernetes node architectures were reported; set MCP_IMAGE_PLATFORM=linux/amd64 or linux/arm64")
+	}
+	if len(archs) > 1 {
+		return "", fmt.Errorf("mixed Kubernetes node architectures detected (%s); setup-built images are single-platform today, so set up homogeneous nodes or prebuild multi-arch images before running setup", strings.Join(archs, ", "))
+	}
+	if explicitPlatform != "" {
+		if arch := strings.TrimPrefix(explicitPlatform, "linux/"); arch != archs[0] {
+			return "", fmt.Errorf("MCP_IMAGE_PLATFORM %q does not match Kubernetes node architecture %q", explicitPlatform, archs[0])
+		}
+		return explicitPlatform, nil
+	}
+	return validateSetupImagePlatform("linux/" + archs[0])
+}
+
+func validateSetupImagePlatform(platform string) (string, error) {
+	platform = strings.TrimSpace(platform)
+	parts := strings.Split(platform, "/")
+	if len(parts) != 2 || parts[0] != "linux" {
+		return "", fmt.Errorf("invalid MCP_IMAGE_PLATFORM %q; expected linux/amd64 or linux/arm64", platform)
+	}
+	switch parts[1] {
+	case "amd64", "arm64":
+		return platform, nil
+	default:
+		return "", fmt.Errorf("unsupported MCP_IMAGE_PLATFORM %q; expected linux/amd64 or linux/arm64", platform)
+	}
+}
+
+func clusterNodeArchitectures(kubectl core.KubectlRunner) ([]string, error) {
+	if kubectl == nil {
+		return nil, fmt.Errorf("could not resolve setup image platform: kubectl runner is nil")
+	}
+	cmd, err := kubectl.CommandArgs([]string{"get", "nodes", "-o", "jsonpath={range .items[*]}{.status.nodeInfo.architecture}{\"\\n\"}{end}"})
+	if err != nil {
+		return nil, fmt.Errorf("could not inspect Kubernetes node architectures: %w", err)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("could not inspect Kubernetes node architectures: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, line := range strings.Split(string(out), "\n") {
+		arch := strings.TrimSpace(line)
+		if arch == "" {
+			continue
+		}
+		seen[arch] = struct{}{}
+	}
+	archs := make([]string, 0, len(seen))
+	for arch := range seen {
+		archs = append(archs, arch)
+	}
+	slices.Sort(archs)
+	return archs, nil
+}
+
 func setupClusterSteps(logger *zap.Logger, kubeconfig, context string, ingressOpts cluster.IngressOptions, deps SetupDeps) error {
 	// Step 1: Initialize cluster
 	core.Step("Step 1: Initialize cluster")
@@ -1347,9 +1423,13 @@ data:
 }
 
 func buildOperatorImage(image string) error {
+	platform, err := resolveSetupImagePlatform(core.DefaultKubectlClient())
+	if err != nil {
+		return err
+	}
 	target := "docker-build-operator-no-test"
 	// #nosec G204 -- command arguments are built from trusted inputs and fixed verbs.
-	cmd, err := core.ExecCommandWithValidators("make", []string{"-f", "Makefile.operator", target, "IMG=" + image})
+	cmd, err := core.ExecCommandWithValidators("make", []string{"-f", "Makefile.operator", target, "IMG=" + image, "DOCKER_PLATFORM=" + platform})
 	if err != nil {
 		return err
 	}
@@ -1362,6 +1442,10 @@ func buildOperatorImage(image string) error {
 }
 
 func buildGatewayProxyImage(image string) error {
+	platform, err := resolveSetupImagePlatform(core.DefaultKubectlClient())
+	if err != nil {
+		return err
+	}
 	dockerfilePath, err := assetpath.ResolveRepoAssetPath(gatewayProxyDockerfilePath)
 	if err != nil {
 		return err
@@ -1374,6 +1458,7 @@ func buildGatewayProxyImage(image string) error {
 	// #nosec G204 -- command arguments are built from trusted inputs and fixed verbs.
 	cmd, err := core.ExecCommandWithValidators("docker", []string{
 		"build",
+		"--platform", platform,
 		"-f", dockerfilePath,
 		"-t", image,
 		buildContext,
@@ -1387,6 +1472,10 @@ func buildGatewayProxyImage(image string) error {
 }
 
 func buildAnalyticsImage(image, dockerfilePath, buildContext string) error {
+	platform, err := resolveSetupImagePlatform(core.DefaultKubectlClient())
+	if err != nil {
+		return err
+	}
 	resolvedDockerfilePath, err := assetpath.ResolveRepoAssetPath(dockerfilePath)
 	if err != nil {
 		return err
@@ -1399,6 +1488,7 @@ func buildAnalyticsImage(image, dockerfilePath, buildContext string) error {
 	// #nosec G204 -- command arguments are built from trusted inputs and fixed verbs.
 	cmd, err := core.ExecCommandWithValidators("docker", []string{
 		"build",
+		"--platform", platform,
 		"-f", resolvedDockerfilePath,
 		"-t", image,
 		resolvedBuildContext,
@@ -2753,21 +2843,25 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	if envValue := setupSecretEnvValue("MCP_PLATFORM_ADMIN_EMAIL", "PLATFORM_ADMIN_EMAIL"); envValue != "" {
-		platformAdminEmail = envValue
-	}
 	platformAdminPassword, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_ADMIN_PASSWORD")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
-	}
-	if envValue := setupSecretEnvValue("MCP_PLATFORM_ADMIN_PASSWORD", "PLATFORM_ADMIN_PASSWORD"); envValue != "" {
-		platformAdminPassword = envValue
 	}
 	adminUsers, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "ADMIN_USERS")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	adminUsers = ensureCSVIncludesValues(adminUsers, setupSecretEnvValue("MCP_ADMIN_USERS", "ADMIN_USERS"), platformAdminEmail)
+	envPlatformAdminEmail := setupSecretEnvValue("MCP_PLATFORM_ADMIN_EMAIL", "PLATFORM_ADMIN_EMAIL")
+	envPlatformAdminPassword := setupSecretEnvValue("MCP_PLATFORM_ADMIN_PASSWORD", "PLATFORM_ADMIN_PASSWORD")
+	if envPlatformAdminEmail != "" && envPlatformAdminPassword != "" {
+		platformAdminEmail = envPlatformAdminEmail
+		platformAdminPassword = envPlatformAdminPassword
+	}
+	if platformAdminEmail == "" || platformAdminPassword == "" {
+		platformAdminEmail = ""
+		platformAdminPassword = ""
+	}
+	adminUsers = ensureCSVIncludesValues(adminUsers, setupSecretEnvValue("MCP_ADMIN_USERS", "ADMIN_USERS"), envPlatformAdminEmail, platformAdminEmail)
 	platformDevLoginEnabled := ""
 	platformDevUserEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_EMAIL")
 	if err != nil {
@@ -3217,11 +3311,35 @@ func registryInternalCertificateSANs(plan setupplan.Plan) ([]string, []string) {
 	return dedupeStrings(dnsNames), dedupeStrings(ipAddresses)
 }
 
-func bundledRegistryInternalIssuerName(plan setupplan.Plan) string {
-	if strings.TrimSpace(plan.TLSClusterIssuer) != "" {
-		return strings.TrimSpace(plan.TLSClusterIssuer)
+func bundledRegistryInternalIssuerName(kubectl core.KubectlRunner, plan setupplan.Plan) (string, error) {
+	issuerName := strings.TrimSpace(plan.TLSClusterIssuer)
+	if issuerName == "" {
+		return certmanager.CertClusterIssuerName, nil
 	}
-	return certmanager.CertClusterIssuerName
+	usesACME, err := clusterIssuerUsesACME(kubectl, issuerName)
+	if err != nil {
+		return "", err
+	}
+	if usesACME {
+		core.Warn(fmt.Sprintf("ClusterIssuer %q uses ACME and cannot issue internal registry DNS names; using %s for registry-internal-tls", issuerName, certmanager.CertClusterIssuerName))
+		return certmanager.CertClusterIssuerName, nil
+	}
+	return issuerName, nil
+}
+
+func clusterIssuerUsesACME(kubectl core.KubectlRunner, name string) (bool, error) {
+	if kubectl == nil {
+		return false, fmt.Errorf("kubectl runner is nil")
+	}
+	cmd, err := kubectl.CommandArgs([]string{"get", "clusterissuer", name, "-o", "jsonpath={.spec.acme.server}"})
+	if err != nil {
+		return false, err
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
 }
 
 func addRegistrySAN(raw string, dnsNames, ipAddresses *[]string) {
@@ -3580,7 +3698,15 @@ func setupBundledRegistryInternalTLSStep(kubectl core.KubectlRunner, logger *zap
 	if plan.RegistryMode != setupplan.RegistryModeBundledHTTPS {
 		return nil
 	}
-	issuerName := bundledRegistryInternalIssuerName(plan)
+	issuerName, err := bundledRegistryInternalIssuerName(kubectl, plan)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrClusterIssuerNotFound, err, fmt.Sprintf("failed to inspect internal registry ClusterIssuer: %v", err))
+		core.Error("Internal registry issuer unavailable")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Internal registry issuer unavailable")
+		}
+		return wrappedErr
+	}
 	if issuerName == certmanager.CertClusterIssuerName {
 		core.Info("Ensuring internal registry CA secret")
 		created, err := certmanager.EnsureCASecretWithKubectl(kubectl)

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -15,8 +15,10 @@ COPY services/api/*.go ./services/api/
 COPY services/api/internal/ ./services/api/internal/
 
 # Build from service directory
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN cd services/api && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/api .
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/api .
 
 FROM gcr.io/distroless/base-debian12
 WORKDIR /app

--- a/services/ingest/Dockerfile
+++ b/services/ingest/Dockerfile
@@ -8,8 +8,10 @@ COPY services/ingest/go.mod services/ingest/go.sum ./services/ingest/
 RUN cd services/ingest && go mod download
 
 COPY services/ingest/*.go ./services/ingest/
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN cd services/ingest && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/ingest .
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/ingest .
 
 FROM gcr.io/distroless/base-debian12
 WORKDIR /app

--- a/services/mcp-gateway/Dockerfile
+++ b/services/mcp-gateway/Dockerfile
@@ -13,10 +13,10 @@ RUN cd services/mcp-gateway && go mod download
 # whole directory (rather than *.go) picks up subpackages, embedded assets,
 # and any non-Go source files added later.
 COPY services/mcp-gateway/ ./services/mcp-gateway/
-# GOARCH is left unset so Docker BuildKit's --platform can produce arm64
-# images (Apple Silicon, Graviton, etc.) without a Dockerfile change.
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN cd services/mcp-gateway && \
-    CGO_ENABLED=0 GOOS=linux go build -o /out/mcp-gateway .
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/mcp-gateway .
 
 FROM gcr.io/distroless/base-debian12
 WORKDIR /app

--- a/services/processor/Dockerfile
+++ b/services/processor/Dockerfile
@@ -8,8 +8,10 @@ COPY services/processor/go.mod services/processor/go.sum ./services/processor/
 RUN cd services/processor && go mod download
 
 COPY services/processor/*.go ./services/processor/
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN cd services/processor && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/processor .
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/processor .
 
 FROM gcr.io/distroless/base-debian12
 WORKDIR /app

--- a/services/ui/Dockerfile
+++ b/services/ui/Dockerfile
@@ -9,8 +9,10 @@ RUN cd services/ui && go mod download
 
 COPY services/ui/*.go ./services/ui/
 COPY services/ui/static/ ./services/ui/static/
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
 RUN cd services/ui && \
-    mkdir -p /out && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /out/ui .
+    mkdir -p /out && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/ui .
 
 FROM gcr.io/distroless/base-debian12
 WORKDIR /app


### PR DESCRIPTION
## Summary
- build setup-managed images for the target Kubernetes node architecture and reject unsupported or mixed-arch setup builds
- keep bundled registry internal TLS on a non-ACME issuer path while allowing public ACME for platform hosts
- avoid seeding a partial platform admin password pair, and add tests/docs for the setup guards
- add a four-node k3s on-prem/public-demo runbook with a five-node extension and Cloudflare/WAF/internal proxy front-door guidance

Fixes #223.

## Validation
- `go test ./internal/cli/setup ./internal/cli/core -count=1`
- `go build -o bin/mcp-runtime ./cmd/mcp-runtime`
- `pre-commit run gitleaks --all-files`
- commit hooks: gitleaks, staticcheck, go vet, generated-file drift
- live VPS k3s setup completed with bundled HTTPS registry and public TLS issuer
- live `mcp-runtime status` reported all platform components OK
- live `mcp-runtime cluster doctor` passed 24 checks
- public smoke: platform returned 200, unauthenticated registry `/v2/` returned guarded 401, docs/site stayed on the docs node