### PR TITLE
fix(api): harden tenant admin boundaries

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -306,21 +306,21 @@ routes require an authenticated platform bearer token or `x-api-key`; requests
 without authentication receive `401`. `POST` requests create or update the
 Kubernetes CRs that the operator renders into the gateway policy ConfigMap.
 
-For `POST /api/runtime/grants` and `POST /api/runtime/sessions`, the API resolves `serverRef` to an `MCPServer` in the cluster. If that server does not exist, the call returns `400` with a clear `unknown serverRef` message. The server lookup is **not** part of a single distributed transaction with the grant/session write — a concurrent delete can leave a stale reference (same as `kubectl apply`). Kubernetes apply errors are surfaced with the status the API server would use, when available.
+For `POST /api/runtime/grants` and admin-only direct `POST /api/runtime/sessions`, the API resolves `serverRef` to an `MCPServer` in the cluster. If that server does not exist, the call returns `400` with a clear `unknown serverRef` message. The server lookup is **not** part of a single distributed transaction with the grant/session write — a concurrent delete can leave a stale reference (same as `kubectl apply`). Kubernetes apply errors are surfaced with the status the API server would use, when available. Non-admin grant mutations and session item mutations require the caller to be the server owner or a team owner for the server namespace; normal adapter flows should use `POST /api/runtime/adapter/sessions` instead of direct session apply.
 
 ```text
 GET  /api/runtime/servers              # List authenticated MCP catalog entries
 GET  /api/runtime/servers/{namespace}/{name} # Get one MCPServer catalog entry
 POST /api/runtime/servers              # Create/update MCPServer in an authorized namespace
 DELETE /api/runtime/servers/{namespace}/{name} # Retire one MCPServer
-GET  /api/runtime/server-events?namespace=&server= # Recent analytics events for one server
+GET  /api/runtime/server-events?namespace=&server= # Recent analytics events for one administered server
 GET  /api/runtime/grants               # List MCPAccessGrant resources
 GET  /api/runtime/grants/{namespace}/{name}   # Get one MCPAccessGrant
 POST /api/runtime/grants               # Create or update an MCPAccessGrant (x-api-key)
 DELETE /api/runtime/grants/{namespace}/{name} # Delete one MCPAccessGrant
 GET  /api/runtime/sessions             # List MCPAgentSession resources
 GET  /api/runtime/sessions/{namespace}/{name} # Get one MCPAgentSession
-POST /api/runtime/sessions             # Create or update an MCPAgentSession (x-api-key)
+POST /api/runtime/sessions             # Admin/internal direct MCPAgentSession apply
 DELETE /api/runtime/sessions/{namespace}/{name} # Delete one MCPAgentSession
 POST /api/runtime/adapter/sessions     # Issue/reuse an adapter MCPAgentSession for a human/user principal
 GET  /api/runtime/teams                # Admin: all teams; user: caller memberships
@@ -332,8 +332,8 @@ POST /api/runtime/teams/{team}/users   # Admin-only password user create/update 
 DELETE /api/runtime/teams/{team}/members/{userID}
 GET  /api/runtime/namespaces           # Allowed namespaces + org catalog metadata
 GET  /api/runtime/namespaces/{namespace}
-GET  /api/runtime/components           # Sentinel component health status
-GET  /api/runtime/policy?namespace=&server=   # Get rendered policy for a server
+GET  /api/runtime/components           # Admin-only Sentinel component health status
+GET  /api/runtime/policy?namespace=&server=   # Get rendered policy for an administered server
 ```
 
 For non-admin users, runtime scope depends on `PLATFORM_MODE` / setup

--- a/docs/security/authz-matrix.md
+++ b/docs/security/authz-matrix.md
@@ -28,6 +28,8 @@ include both the prefix and the meaningful sub-paths in the table.
 `admin-role` is enforced by the `requireRole(roleAdmin, …)` wrap in
 `services/api/main.go`. `user-cookie` and `user-key` distinguish which
 calls require browser identity vs accept a bearer-style key.
+When `ADMIN_API_KEYS` is unset, static `API_KEYS` authenticate as `user`
+unless the explicit legacy dev/test fallback is enabled.
 
 Expected codes:
 
@@ -70,24 +72,20 @@ Expected codes:
 | `/api/runtime/namespaces/{name}`                      | GET           | 401  | 200         | 200      | 200       | 401/403    | |
 | `/api/deployments`                                    | GET           | 401  | 200         | 200      | 200       | 401/403    | |
 | `/api/deployments/{id}`                               | GET           | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/grants`                                 | GET, POST     | 401  | 200         | 200      | 200       | 401/403    | Mutating; serverRef cross-ns checks are best-effort (CLAUDE.md). |
-| `/api/runtime/grants/{ns}/{name}`                     | DELETE        | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/grants/{ns}/{name}/enable`              | POST          | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/grants/{ns}/{name}/disable`             | POST          | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/sessions`                               | GET, POST     | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/sessions/{ns}/{name}`                   | DELETE        | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/sessions/{ns}/{name}/revoke`            | POST          | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/sessions/{ns}/{name}/unrevoke`          | POST          | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/components`                             | GET           | 401  | 200         | 200      | 200       | 401/403    | |
-| `/api/runtime/policy`                                 | GET           | 401  | 200         | 200      | 200       | 401/403    | |
-
-> **Open question** for the next audit pass: which of the
-> `/api/runtime/*` mutating routes (grants/sessions create, enable,
-> disable, revoke, unrevoke) should be admin-only? `services/api/main.go`
-> wraps them with `server.auth(...)` only, not `requireRole(roleAdmin, …)`,
-> meaning any authenticated user can mutate governance state. If that is
-> by design, document the per-tenant scoping invariant; if not, this is
-> a **Critical** governance finding.
+| `/api/runtime/server-events`                          | GET           | 401  | 200/403     | 200/403  | 200       | 401/403    | Full event details only for admin, server owner, or team owner; regular namespace readers are forbidden. |
+| `/api/runtime/grants`                                 | GET           | 401  | 200         | 200      | 200       | 401/403    | Lists only grants for servers the caller can administer; regular team/catalog readers receive an empty scoped set. |
+| `/api/runtime/grants`                                 | POST          | 401  | 200/403     | 200/403  | 200       | 401/403    | Create/update requires admin, server owner, or team owner. |
+| `/api/runtime/grants/{ns}/{name}`                     | GET           | 401  | 200/403     | 200/403  | 200       | 401/403    | Full grant summary only for admin, server owner, or team owner. |
+| `/api/runtime/grants/{ns}/{name}`                     | DELETE        | 401  | 200/403     | 200/403  | 200       | 401/403    | Mutating; same owner/team-owner gate as apply. |
+| `/api/runtime/grants/{ns}/{name}/enable`              | POST          | 401  | 200/403     | 200/403  | 200       | 401/403    | Mutating; same owner/team-owner gate as apply. |
+| `/api/runtime/grants/{ns}/{name}/disable`             | POST          | 401  | 200/403     | 200/403  | 200       | 401/403    | Mutating; same owner/team-owner gate as apply. |
+| `/api/runtime/sessions`                               | GET           | 401  | 200         | 200      | 200       | 401/403    | Lists only sessions for servers the caller can administer. |
+| `/api/runtime/sessions`                               | POST          | 401  | 403         | 403      | 200       | 401/403    | Direct session apply is admin/internal-only; users should use `/api/runtime/adapter/sessions`. |
+| `/api/runtime/sessions/{ns}/{name}`                   | GET           | 401  | 200/403     | 200/403  | 200       | 401/403    | Full session summary only for admin, server owner, or team owner. |
+| `/api/runtime/sessions/{ns}/{name}`                   | DELETE        | 401  | 200/403     | 200/403  | 200       | 401/403    | Mutating; requires admin, server owner, or team owner. |
+| `/api/runtime/sessions/{ns}/{name}/revoke`            | POST          | 401  | 200/403     | 200/403  | 200       | 401/403    | Mutating; requires admin, server owner, or team owner. |
+| `/api/runtime/sessions/{ns}/{name}/unrevoke`          | POST          | 401  | 200/403     | 200/403  | 200       | 401/403    | Mutating; requires admin, server owner, or team owner. |
+| `/api/runtime/policy`                                 | GET           | 401  | 200/403     | 200/403  | 200       | 401/403    | Rendered policy is visible only to admin, server owner, or team owner. |
 
 ## Admin-only endpoints (`requireRole(roleAdmin, …)`)
 
@@ -104,6 +102,7 @@ Expected codes:
 | `/api/admin/audit`                | GET           | 401  | 403                     | 403      | 200       | 403        | |
 | `/api/admin/operations`           | GET           | 401  | 403                     | 403      | 200       | 403        | |
 | `/api/admin/deployments`          | GET           | 401  | 403                     | 403      | 200       | 403        | |
+| `/api/runtime/components`         | GET           | 401  | 403                     | 403      | 200       | 403        | Cluster component/workload health and errors. |
 | `/api/runtime/actions/restart`    | POST          | 401  | 403                     | 403      | 200       | 403        | Cluster-affecting. |
 
 ## Method gating

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -110,8 +110,8 @@ For local `setup --test-mode` clusters, setup seeds two email/password logins:
 
 | Service | Auth behavior |
 |---|---|
-| **api** | `/health` is open. Authenticated `/api/*` routes accept `x-api-key` from `API_KEYS`, user-generated API keys, platform JWT bearer tokens, or OIDC JWT bearer tokens when OIDC is configured. If `ADMIN_API_KEYS` is set, only those keys get admin role; other `API_KEYS` values are user role. Registry forward-auth keeps admin credentials global and allows normal user credentials only on repository paths scoped to the caller's team slug or team namespace. |
-| **ui** | `/auth/login` creates an HttpOnly UI session from `api_key`, `id_token`, or `email`/`password`. The UI then proxies `/api/*` with an upstream API key or bearer token. |
+| **api** | `/health` is open. Authenticated `/api/*` routes accept `x-api-key` from `API_KEYS`, user-generated API keys, platform JWT bearer tokens, or OIDC JWT bearer tokens when OIDC is configured. Only keys listed in `ADMIN_API_KEYS` get admin role; other `API_KEYS` values are user role unless the explicit legacy dev/test fallback is enabled. Registry forward-auth keeps admin credentials global and allows normal user credentials only on repository paths scoped to the caller's team slug or team namespace. |
+| **ui** | `/auth/login` creates an HttpOnly UI session from `api_key`, `id_token`, or `email`/`password`. The UI then proxies `/api/*` with an upstream API key or bearer token. `/auth/admin-check` accepts admin UI sessions or keys from `ADMIN_API_KEYS`; it falls back to `API_KEYS` only when the explicit legacy dev/test fallback is enabled. |
 | **ingest** | `/live`, `/ready`, and `/health` are open. `/events` accepts `x-api-key` from `INGEST_API_KEYS`, legacy `API_KEYS`, or a configured OIDC bearer token. If no API keys and no JWKS are configured, intake auth is bypassed. |
 | **processor** | No data API. It exposes metrics and a simple health check on the metrics port. |
 | **mcp-gateway** | No admin API. It authenticates MCP requests according to the rendered server policy: header identity or OAuth bearer tokens, depending on `spec.auth`. |
@@ -139,15 +139,15 @@ metrics on `METRICS_PORT` (default `9090`).
 | `GET` | `/api/event-types` | Event counts grouped by event type. Admin role required. |
 | `GET`, `POST` | `/api/runtime/servers` | List or apply `MCPServer` resources through runtime authz scope. `tenant` mode defaults signed-in users to team namespaces they belong to; `org` mode includes the org catalog plus team namespaces; `public` mode allows anonymous catalog reads and signed-in publishes in the public catalog plus team namespaces. Responses include `publish_policy` for active-server quota/cooldown visibility. |
 | `DELETE` | `/api/runtime/servers/{namespace}/{name}` | Retire an owned MCPServer. Retiring deletes the MCPServer from Kubernetes and frees one active-server quota slot. |
-| `GET` | `/api/runtime/server-events?namespace=&server=` | Recent analytics events for one readable MCPServer, used by the user server detail view. |
-| `GET`, `POST` | `/api/runtime/grants` | List or apply `MCPAccessGrant` resources. |
-| `GET`, `DELETE` | `/api/runtime/grants/{namespace}/{name}` | Read or delete one grant. |
-| `POST` | `/api/runtime/grants/{namespace}/{name}/disable` | Set `spec.disabled=true`. |
-| `POST` | `/api/runtime/grants/{namespace}/{name}/enable` | Set `spec.disabled=false`. |
-| `GET`, `POST` | `/api/runtime/sessions` | List or apply `MCPAgentSession` resources. |
-| `GET`, `DELETE` | `/api/runtime/sessions/{namespace}/{name}` | Read or delete one session. |
-| `POST` | `/api/runtime/sessions/{namespace}/{name}/revoke` | Set `spec.revoked=true`. |
-| `POST` | `/api/runtime/sessions/{namespace}/{name}/unrevoke` | Set `spec.revoked=false`. |
+| `GET` | `/api/runtime/server-events?namespace=&server=` | Recent analytics events for one administered MCPServer; full identity/session/payload details are not exposed to regular namespace readers. |
+| `GET`, `POST` | `/api/runtime/grants` | List or apply `MCPAccessGrant` resources. Lists are scoped to administered servers; apply requires admin, server owner, or team owner. |
+| `GET`, `DELETE` | `/api/runtime/grants/{namespace}/{name}` | Read or delete one grant for an administered server. |
+| `POST` | `/api/runtime/grants/{namespace}/{name}/disable` | Set `spec.disabled=true`; requires admin, server owner, or team owner. |
+| `POST` | `/api/runtime/grants/{namespace}/{name}/enable` | Set `spec.disabled=false`; requires admin, server owner, or team owner. |
+| `GET`, `POST` | `/api/runtime/sessions` | List scoped `MCPAgentSession` resources; direct session apply is admin/internal-only. User adapter flows use `/api/runtime/adapter/sessions`. |
+| `GET`, `DELETE` | `/api/runtime/sessions/{namespace}/{name}` | Read or delete one session for an administered server. |
+| `POST` | `/api/runtime/sessions/{namespace}/{name}/revoke` | Set `spec.revoked=true`; requires admin, server owner, or team owner. |
+| `POST` | `/api/runtime/sessions/{namespace}/{name}/unrevoke` | Set `spec.revoked=false`; requires admin, server owner, or team owner. |
 | `GET`, `POST` | `/api/runtime/teams` | List teams (admin: all, user: memberships) or create a team+namespace (admin-only). |
 | `GET` | `/api/runtime/teams/{team}` | Read team metadata for admins and team members. |
 | `GET` | `/api/runtime/teams/{team}/members` | List team memberships for admins and team members. |
@@ -156,8 +156,8 @@ metrics on `METRICS_PORT` (default `9090`).
 | `DELETE` | `/api/runtime/teams/{team}/members/{userID}` | Remove team membership (admin or team owner). |
 | `GET` | `/api/runtime/namespaces` | List allowed namespaces and org catalog metadata for caller scope. |
 | `GET` | `/api/runtime/namespaces/{namespace}` | Read one namespace metadata entry when authorized. |
-| `GET` | `/api/runtime/components` | Operator, Sentinel service, and observability component health from Kubernetes. |
-| `GET` | `/api/runtime/policy?namespace=&server=` | Rendered gateway policy for one server. |
+| `GET` | `/api/runtime/components` | Admin-only operator, Sentinel service, and observability component health from Kubernetes. |
+| `GET` | `/api/runtime/policy?namespace=&server=` | Rendered gateway policy for one administered server. |
 | `POST` | `/api/runtime/actions/restart` | Restart one Sentinel component or all components. Admin role required. |
 | `GET`, `POST` | `/api/deployments` | User-scoped platform deployment list/apply. |
 | `DELETE` | `/api/deployments/{namespace}/{name}` | Delete a platform-managed deployment and service. |

--- a/pkg/access/manager.go
+++ b/pkg/access/manager.go
@@ -104,6 +104,25 @@ func (m *Manager) GetMCPServerRef(ctx context.Context, ref ServerReference) (*mc
 	return &server, nil
 }
 
+// ListMCPServers returns all MCPServer resources, optionally filtered by namespace.
+func (m *Manager) ListMCPServers(ctx context.Context, namespace string) (*mcpv1alpha1.MCPServerList, error) {
+	var obj *unstructured.UnstructuredList
+	var err error
+	if namespace != "" {
+		obj, err = m.dynamic.Resource(serverGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	} else {
+		obj, err = m.dynamic.Resource(serverGVR).List(ctx, metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list MCPServers: %w", err)
+	}
+	var servers mcpv1alpha1.MCPServerList
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), &servers); err != nil {
+		return nil, fmt.Errorf("decode MCPServers: %w", err)
+	}
+	return &servers, nil
+}
+
 // ListGrants returns all MCPAccessGrant resources, optionally filtered by namespace.
 func (m *Manager) ListGrants(ctx context.Context, namespace string) (*MCPAccessGrantList, error) {
 	var result *MCPAccessGrantList

--- a/services/api/authz_test.go
+++ b/services/api/authz_test.go
@@ -18,7 +18,7 @@ func TestSplitCSVSet(t *testing.T) {
 	}
 }
 
-func TestAuthenticateRequestStaticKey_DefaultAdmin(t *testing.T) {
+func TestAuthenticateRequestStaticKey_DefaultUserWhenAdminKeysUnset(t *testing.T) {
 	srv := &apiServer{
 		apiKeys: map[string]struct{}{"key-1": {}},
 	}
@@ -31,8 +31,47 @@ func TestAuthenticateRequestStaticKey_DefaultAdmin(t *testing.T) {
 	if !ok {
 		t.Fatal("expected authenticated")
 	}
+	if p.Role != roleUser {
+		t.Fatalf("role = %q, want %q", p.Role, roleUser)
+	}
+}
+
+func TestAuthenticateRequestStaticKey_LegacyAdminFallback(t *testing.T) {
+	srv := &apiServer{
+		apiKeys:         map[string]struct{}{"key-1": {}},
+		legacyAdminKeys: true,
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+	req.Header.Set("x-api-key", "key-1")
+	p, ok, err := srv.authenticateRequest(req)
+	if err != nil {
+		t.Fatalf("authenticateRequest error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected authenticated")
+	}
 	if p.Role != roleAdmin {
 		t.Fatalf("role = %q, want %q", p.Role, roleAdmin)
+	}
+}
+
+func TestLegacyAdminAPIKeyFallbackEnabledOnlyForExplicitDevTest(t *testing.T) {
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "")
+	t.Setenv("MCP_LEGACY_ADMIN_API_KEY_FALLBACK", "")
+	t.Setenv("LEGACY_ADMIN_API_KEY_FALLBACK", "")
+	if legacyAdminAPIKeyFallbackEnabled() {
+		t.Fatal("legacy fallback should be disabled by default")
+	}
+
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "1")
+	if !legacyAdminAPIKeyFallbackEnabled() {
+		t.Fatal("legacy fallback should be enabled in runtime test mode")
+	}
+
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "")
+	t.Setenv("MCP_LEGACY_ADMIN_API_KEY_FALLBACK", "true")
+	if !legacyAdminAPIKeyFallbackEnabled() {
+		t.Fatal("legacy fallback should honor explicit override")
 	}
 }
 

--- a/services/api/internal/runtimeapi/access.go
+++ b/services/api/internal/runtimeapi/access.go
@@ -12,6 +12,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
 	sentinelaccess "mcp-runtime/pkg/access"
 	"mcp-runtime/pkg/k8sclient"
 	"mcp-runtime/pkg/serviceutil"
@@ -72,8 +73,23 @@ func (s *RuntimeServer) handleRuntimeGrantList(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	p, filterByPrincipal := principalFromContext(ctx)
+	filterByPrincipal = filterByPrincipal && p.Role != roleAdmin
+	var serverCache accessServerCache
+	if filterByPrincipal {
+		serverCache, err = s.accessServerCacheForGrantRefs(ctx, namespace, grants.Items)
+		if err != nil {
+			log.Printf("runtime grant list: list MCPServers for visibility failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect server references"})
+			return
+		}
+	}
+
 	summaries := make([]sentinelaccess.GrantSummary, 0, len(grants.Items))
 	for _, g := range grants.Items {
+		if filterByPrincipal && !accessRefVisibleWithServerCache(p, g.Namespace, g.Spec.ServerRef, serverCache) {
+			continue
+		}
 		summaries = append(summaries, sentinelaccess.ToGrantSummary(g))
 	}
 
@@ -127,6 +143,10 @@ func (s *RuntimeServer) handleRuntimeGrantApply(w http.ResponseWriter, r *http.R
 	}
 	if err := s.bindAccessSubjectTeamID(ctx, req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+	if !s.principalCanAdministerAccessServer(r.Context(), *targetServer) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
 		return
 	}
 
@@ -193,8 +213,23 @@ func (s *RuntimeServer) handleRuntimeSessionList(w http.ResponseWriter, r *http.
 		return
 	}
 
+	p, filterByPrincipal := principalFromContext(ctx)
+	filterByPrincipal = filterByPrincipal && p.Role != roleAdmin
+	var serverCache accessServerCache
+	if filterByPrincipal {
+		serverCache, err = s.accessServerCacheForSessionRefs(ctx, namespace, sessions.Items)
+		if err != nil {
+			log.Printf("runtime session list: list MCPServers for visibility failed: %v", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect server references"})
+			return
+		}
+	}
+
 	summaries := make([]sentinelaccess.SessionSummary, 0, len(sessions.Items))
 	for _, sess := range sessions.Items {
+		if filterByPrincipal && !accessRefVisibleWithServerCache(p, sess.Namespace, sess.Spec.ServerRef, serverCache) {
+			continue
+		}
 		summaries = append(summaries, sentinelaccess.ToSessionSummary(sess))
 	}
 
@@ -204,6 +239,10 @@ func (s *RuntimeServer) handleRuntimeSessionList(w http.ResponseWriter, r *http.
 func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http.Request) {
 	if s.accessMgr == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		return
+	}
+	if p, ok := principalFromContext(r.Context()); ok && p.Role != roleAdmin {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin role required"})
 		return
 	}
 
@@ -247,6 +286,10 @@ func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http
 	}
 	if err := s.bindAccessSubjectTeamID(ctx, req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		return
+	}
+	if !s.principalCanAdministerAccessServer(r.Context(), *targetServer) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
 		return
 	}
 
@@ -306,6 +349,82 @@ func (s *RuntimeServer) sessionRevokedForApply(ctx context.Context, req accessSe
 	}
 	return existing.Spec.Revoked, nil
 }
+
+func (s *RuntimeServer) grantVisibleToPrincipal(ctx context.Context, grant sentinelaccess.MCPAccessGrant) bool {
+	if p, ok := principalFromContext(ctx); !ok || p.Role == roleAdmin {
+		return true
+	}
+	allowed, err := s.canAdministerAccessServerRef(ctx, grant.Namespace, grant.Spec.ServerRef)
+	return err == nil && allowed
+}
+
+func (s *RuntimeServer) sessionVisibleToPrincipal(ctx context.Context, session sentinelaccess.MCPAgentSession) bool {
+	if p, ok := principalFromContext(ctx); !ok || p.Role == roleAdmin {
+		return true
+	}
+	allowed, err := s.canAdministerAccessServerRef(ctx, session.Namespace, session.Spec.ServerRef)
+	return err == nil && allowed
+}
+
+type accessServerCache map[string]mcpv1alpha1.MCPServer
+
+func (s *RuntimeServer) accessServerCacheForGrantRefs(ctx context.Context, namespace string, grants []sentinelaccess.MCPAccessGrant) (accessServerCache, error) {
+	refs := make([]sentinelaccess.ServerReference, 0, len(grants))
+	for _, grant := range grants {
+		refs = append(refs, grant.Spec.ServerRef)
+	}
+	return s.accessServerCacheForRefs(ctx, namespace, refs)
+}
+
+func (s *RuntimeServer) accessServerCacheForSessionRefs(ctx context.Context, namespace string, sessions []sentinelaccess.MCPAgentSession) (accessServerCache, error) {
+	refs := make([]sentinelaccess.ServerReference, 0, len(sessions))
+	for _, session := range sessions {
+		refs = append(refs, session.Spec.ServerRef)
+	}
+	return s.accessServerCacheForRefs(ctx, namespace, refs)
+}
+
+func (s *RuntimeServer) accessServerCacheForRefs(ctx context.Context, namespace string, refs []sentinelaccess.ServerReference) (accessServerCache, error) {
+	namespaces := map[string]struct{}{}
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Name) == "" {
+			continue
+		}
+		namespaces[accessServerRefNamespace(namespace, ref)] = struct{}{}
+	}
+
+	cache := accessServerCache{}
+	for ns := range namespaces {
+		servers, err := s.accessMgr.ListMCPServers(ctx, ns)
+		if err != nil {
+			return nil, err
+		}
+		for _, server := range servers.Items {
+			cache[accessServerCacheKey(server.Namespace, server.Name)] = server
+		}
+	}
+	return cache, nil
+}
+
+func accessRefVisibleWithServerCache(p principal, resourceNamespace string, ref sentinelaccess.ServerReference, cache accessServerCache) bool {
+	serverNamespace := accessServerRefNamespace(resourceNamespace, ref)
+	if server, ok := cache[accessServerCacheKey(serverNamespace, ref.Name)]; ok {
+		return principalCanAdministerMCPServer(p, server)
+	}
+	return principalCanAdministerServerLabels(p, defaultAccessNamespace(resourceNamespace), nil)
+}
+
+func accessServerRefNamespace(resourceNamespace string, ref sentinelaccess.ServerReference) string {
+	if ns := strings.TrimSpace(ref.Namespace); ns != "" {
+		return ns
+	}
+	return defaultAccessNamespace(resourceNamespace)
+}
+
+func accessServerCacheKey(namespace, name string) string {
+	return strings.TrimSpace(namespace) + "\x00" + strings.TrimSpace(name)
+}
+
 func (s *RuntimeServer) HandleGrantItemPath(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -351,6 +470,10 @@ func (s *RuntimeServer) handleGrantGet(w http.ResponseWriter, r *http.Request, n
 		writeJSON(w, code, map[string]string{"error": msg})
 		return
 	}
+	if !s.grantVisibleToPrincipal(ctx, *grant) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"grant": sentinelaccess.ToGrantSummary(*grant)})
 }
 
@@ -366,6 +489,23 @@ func (s *RuntimeServer) handleGrantDelete(w http.ResponseWriter, r *http.Request
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
+	grant, err := s.accessMgr.GetGrant(ctx, name, namespace)
+	if err != nil {
+		code, msg := k8sclient.HTTPStatusFromK8sError(err)
+		log.Printf("delete grant %s/%s failed before authz (status=%d): %v", namespace, name, code, err)
+		writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to delete grant: %s", msg)})
+		return
+	}
+	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, grant.Spec.ServerRef)
+	if err != nil {
+		log.Printf("delete grant %s/%s authz lookup failed: %v", namespace, name, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		return
+	}
+	if !allowed {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
+	}
 	if err := s.accessMgr.DeleteGrant(ctx, name, namespace); err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		log.Printf("delete grant %s/%s failed (status=%d): %v", namespace, name, code, err)
@@ -409,15 +549,31 @@ func (s *RuntimeServer) handleGrantToggle(w http.ResponseWriter, r *http.Request
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
-
-	var err error
-	if disable {
-		err = s.accessMgr.DisableGrant(ctx, name, namespace)
-	} else {
-		err = s.accessMgr.EnableGrant(ctx, name, namespace)
+	grant, err := s.accessMgr.GetGrant(ctx, name, namespace)
+	if err != nil {
+		code, msg := k8sclient.HTTPStatusFromK8sError(err)
+		writeJSON(w, code, map[string]string{"error": msg})
+		return
+	}
+	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, grant.Spec.ServerRef)
+	if err != nil {
+		log.Printf("toggle grant %s/%s authz lookup failed: %v", namespace, name, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		return
+	}
+	if !allowed {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
 	}
 
-	if err != nil {
+	var updateErr error
+	if disable {
+		updateErr = s.accessMgr.DisableGrant(ctx, name, namespace)
+	} else {
+		updateErr = s.accessMgr.EnableGrant(ctx, name, namespace)
+	}
+
+	if updateErr != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update grant"})
 		return
 	}
@@ -631,6 +787,10 @@ func (s *RuntimeServer) handleSessionGet(w http.ResponseWriter, r *http.Request,
 		writeJSON(w, code, map[string]string{"error": msg})
 		return
 	}
+	if !s.sessionVisibleToPrincipal(ctx, *session) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"session": sentinelaccess.ToSessionSummary(*session)})
 }
 
@@ -666,6 +826,23 @@ func (s *RuntimeServer) handleSessionDelete(w http.ResponseWriter, r *http.Reque
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
+	session, err := s.accessMgr.GetSession(ctx, name, namespace)
+	if err != nil {
+		code, msg := k8sclient.HTTPStatusFromK8sError(err)
+		log.Printf("delete session %s/%s failed before authz (status=%d): %v", namespace, name, code, err)
+		writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to delete session: %s", msg)})
+		return
+	}
+	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, session.Spec.ServerRef)
+	if err != nil {
+		log.Printf("delete session %s/%s authz lookup failed: %v", namespace, name, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		return
+	}
+	if !allowed {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
+	}
 	if err := s.accessMgr.DeleteSession(ctx, name, namespace); err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		log.Printf("delete session %s/%s failed (status=%d): %v", namespace, name, code, err)
@@ -709,15 +886,31 @@ func (s *RuntimeServer) handleSessionToggle(w http.ResponseWriter, r *http.Reque
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
-
-	var err error
-	if revoke {
-		err = s.accessMgr.RevokeSession(ctx, name, namespace)
-	} else {
-		err = s.accessMgr.UnrevokeSession(ctx, name, namespace)
+	session, err := s.accessMgr.GetSession(ctx, name, namespace)
+	if err != nil {
+		code, msg := k8sclient.HTTPStatusFromK8sError(err)
+		writeJSON(w, code, map[string]string{"error": msg})
+		return
+	}
+	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, session.Spec.ServerRef)
+	if err != nil {
+		log.Printf("toggle session %s/%s authz lookup failed: %v", namespace, name, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		return
+	}
+	if !allowed {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
 	}
 
-	if err != nil {
+	var updateErr error
+	if revoke {
+		updateErr = s.accessMgr.RevokeSession(ctx, name, namespace)
+	} else {
+		updateErr = s.accessMgr.UnrevokeSession(ctx, name, namespace)
+	}
+
+	if updateErr != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update session"})
 		return
 	}

--- a/services/api/internal/runtimeapi/authz_boundaries.go
+++ b/services/api/internal/runtimeapi/authz_boundaries.go
@@ -1,0 +1,98 @@
+package runtimeapi
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
+	sentinelaccess "mcp-runtime/pkg/access"
+)
+
+func principalCanAdministerServerLabels(p principal, namespace string, serverLabels map[string]string) bool {
+	if p.Role == roleAdmin {
+		return true
+	}
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return false
+	}
+	if team, ok := p.TeamForNamespace(namespace); ok && strings.TrimSpace(team.Role) == teamRoleOwner {
+		return true
+	}
+	userID := strings.TrimSpace(p.UserID())
+	if userID == "" {
+		return false
+	}
+	owner := strings.TrimSpace(serverLabels[platformUserIDLabel])
+	if owner == userID {
+		return true
+	}
+	if owner != "" {
+		return false
+	}
+	if _, ok := p.TeamForNamespace(namespace); ok {
+		return false
+	}
+	if namespace == sharedCatalogNamespace || isModeCatalogNamespace(namespace) {
+		return false
+	}
+	return strings.TrimSpace(p.Namespace) == namespace
+}
+
+func principalCanAdministerMCPServer(p principal, server mcpv1alpha1.MCPServer) bool {
+	return principalCanAdministerServerLabels(p, server.Namespace, server.Labels)
+}
+
+func (s *RuntimeServer) principalCanAdministerAccessServer(ctx context.Context, server mcpv1alpha1.MCPServer) bool {
+	p, ok := principalFromContext(ctx)
+	if !ok {
+		return true
+	}
+	return principalCanAdministerMCPServer(p, server)
+}
+
+func (s *RuntimeServer) canAdministerAccessServerRef(ctx context.Context, namespace string, ref sentinelaccess.ServerReference) (bool, error) {
+	ref.Namespace = strings.TrimSpace(ref.Namespace)
+	if ref.Namespace == "" {
+		ref.Namespace = defaultAccessNamespace(namespace)
+	}
+	targetServer, err := s.accessMgr.GetMCPServerRef(ctx, ref)
+	if err != nil {
+		if sentinelaccess.IsMCPServerNotFoundForRef(err) || apierrors.IsNotFound(err) {
+			if p, ok := principalFromContext(ctx); ok {
+				return principalCanAdministerServerLabels(p, namespace, nil), nil
+			}
+			return false, nil
+		}
+		return false, err
+	}
+	return s.principalCanAdministerAccessServer(ctx, *targetServer), nil
+}
+
+func (s *RuntimeServer) canAdministerNamedServer(ctx context.Context, namespace, name string) (bool, error) {
+	p, ok := principalFromContext(ctx)
+	if !ok || p.Role == roleAdmin {
+		return true, nil
+	}
+	control := s.controlPlane()
+	if control == nil {
+		return false, errors.New("kubernetes not available")
+	}
+	current, err := control.GetServer(ctx, namespace, name)
+	if err != nil {
+		return false, err
+	}
+	return principalCanAdministerMCPServer(p, *current), nil
+}
+
+func sensitiveServerReadStatus(err error) (int, string) {
+	if err == nil {
+		return 403, "forbidden server"
+	}
+	if apierrors.IsNotFound(err) {
+		return 404, "server not found"
+	}
+	return 500, "failed to inspect server"
+}

--- a/services/api/internal/runtimeapi/components.go
+++ b/services/api/internal/runtimeapi/components.go
@@ -51,6 +51,10 @@ func (s *RuntimeServer) HandleDashboardSummary(w http.ResponseWriter, r *http.Re
 }
 
 func (s *RuntimeServer) HandleRuntimeComponents(w http.ResponseWriter, r *http.Request) {
+	if p, ok := principalFromContext(r.Context()); !ok || p.Role != roleAdmin {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
 	if s.sentinelMgr == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
 		return

--- a/services/api/internal/runtimeapi/policy.go
+++ b/services/api/internal/runtimeapi/policy.go
@@ -2,6 +2,7 @@ package runtimeapi
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -25,6 +26,17 @@ func (s *RuntimeServer) HandleRuntimePolicy(w http.ResponseWriter, r *http.Reque
 
 	if strings.TrimSpace(namespace) == "" || server == "" {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace and server parameters required"})
+		return
+	}
+	if allowed, err := s.canAdministerNamedServer(ctx, strings.TrimSpace(namespace), strings.TrimSpace(server)); err != nil {
+		code, msg := sensitiveServerReadStatus(err)
+		if code == http.StatusInternalServerError {
+			log.Printf("runtime policy: inspect server %s/%s failed: %v", namespace, server, err)
+		}
+		writeJSON(w, code, map[string]string{"error": msg})
+		return
+	} else if !allowed {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
 		return
 	}
 

--- a/services/api/internal/runtimeapi/runtime_test.go
+++ b/services/api/internal/runtimeapi/runtime_test.go
@@ -122,17 +122,22 @@ func TestValidateSessionRequestRequiresSubject(t *testing.T) {
 
 func newTestAccessManager(t *testing.T) *sentinelaccess.Manager {
 	t.Helper()
-	scheme := runtime.NewScheme()
-	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("AddToScheme: %v", err)
-	}
 	srv := &mcpv1alpha1.MCPServer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "demo",
 			Namespace: sentinelaccess.DefaultMCPResourceNamespace,
 		},
 	}
-	return sentinelaccess.NewManager(dynamicfake.NewSimpleDynamicClient(scheme, srv), nil)
+	return newTestAccessManagerWithObjects(t, srv)
+}
+
+func newTestAccessManagerWithObjects(t *testing.T, objects ...runtime.Object) *sentinelaccess.Manager {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	return sentinelaccess.NewManager(dynamicfake.NewSimpleDynamicClient(scheme, objects...), nil)
 }
 
 func TestRuntimeGrantApplyRejectsUnknownServer(t *testing.T) {
@@ -1641,6 +1646,123 @@ func TestRuntimeGrantApplyAllowsForeignSubjectTeamID(t *testing.T) {
 	}
 }
 
+func TestRuntimeGrantApplyRejectsTeamMemberForTeamServer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	accessMgr := sentinelaccess.NewManager(dynamicfake.NewSimpleDynamicClient(scheme, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "owner-1",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			TeamID: "team-acme-id",
+		},
+	}), nil)
+	server := &RuntimeServer{accessMgr: accessMgr}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/runtime/grants", bytes.NewReader([]byte(`{
+		"name": "grant-team",
+		"namespace": "mcp-team-acme",
+		"serverRef": {"name": "demo"},
+		"subject": {"humanID": "user-2"},
+		"allowedSideEffects": ["read"],
+		"maxTrust": "low"
+	}`)))
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	server.handleRuntimeGrantApply(recorder, request)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRuntimeGrantApplyAllowsServerOwnerInTeamNamespace(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	accessMgr := sentinelaccess.NewManager(dynamicfake.NewSimpleDynamicClient(scheme, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "user-1",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			TeamID: "team-acme-id",
+		},
+	}), nil)
+	server := &RuntimeServer{accessMgr: accessMgr}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/runtime/grants", bytes.NewReader([]byte(`{
+		"name": "grant-team",
+		"namespace": "mcp-team-acme",
+		"serverRef": {"name": "demo"},
+		"subject": {"humanID": "user-2"},
+		"allowedSideEffects": ["read"],
+		"maxTrust": "low"
+	}`)))
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	server.handleRuntimeGrantApply(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if _, err := accessMgr.GetGrant(ctx, "grant-team", "mcp-team-acme"); err != nil {
+		t.Fatalf("expected grant in team namespace: %v", err)
+	}
+}
+
+func TestRuntimeGrantApplyRejectsPublicCatalogReader(t *testing.T) {
+	t.Setenv("PLATFORM_MODE", "public")
+	accessMgr := newTestAccessManagerWithObjects(t, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: defaultPublicCatalogNamespace,
+		},
+	})
+	server := &RuntimeServer{accessMgr: accessMgr}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/runtime/grants", bytes.NewReader([]byte(`{
+		"name": "grant-public",
+		"namespace": "mcp-servers-public",
+		"serverRef": {"name": "demo"},
+		"subject": {"humanID": "user-1"},
+		"allowedSideEffects": ["read"],
+		"maxTrust": "low"
+	}`)))
+	request = request.WithContext(withPrincipal(request.Context(), PublicCatalogPrincipal()))
+	server.handleRuntimeGrantApply(recorder, request)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestRuntimeGrantApplyRejectsCrossNamespaceServerRef(t *testing.T) {
 	accessMgr := newTestAccessManager(t)
 	server := &RuntimeServer{accessMgr: accessMgr}
@@ -1679,6 +1801,36 @@ func TestRuntimeSessionApplyRejectsCrossNamespaceServerRef(t *testing.T) {
 	}
 }
 
+func TestRuntimeSessionApplyRejectsNonAdminDirectApply(t *testing.T) {
+	accessMgr := newTestAccessManagerWithObjects(t, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "user-1",
+			Labels: map[string]string{
+				platformUserIDLabel: "user-1",
+			},
+		},
+	})
+	server := &RuntimeServer{accessMgr: accessMgr}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions", bytes.NewReader([]byte(`{
+		"name": "session-user",
+		"namespace": "user-1",
+		"serverRef": {"name": "demo"},
+		"subject": {"humanID": "user-1"},
+		"consentedTrust": "low"
+	}`)))
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "user-1",
+	}))
+	server.handleRuntimeSessionApply(recorder, request)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestRuntimeGrantApplyNonAdminRejectsSharedCatalogNamespace(t *testing.T) {
 	accessMgr := newTestAccessManager(t)
 	server := &RuntimeServer{accessMgr: accessMgr}
@@ -1706,6 +1858,328 @@ func TestRuntimeGrantApplyNonAdminRejectsSharedCatalogNamespace(t *testing.T) {
 	}
 }
 
+func TestRuntimeGrantListScopesTeamMemberAccessResources(t *testing.T) {
+	ctx := context.Background()
+	accessMgr := newTestAccessManagerWithObjects(t, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "owner-1",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	if _, err := accessMgr.ApplyGrant(ctx, &sentinelaccess.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "grant-team", Namespace: "mcp-team-acme"},
+		Spec: sentinelaccess.MCPAccessGrantSpec{
+			ServerRef:          sentinelaccess.ServerReference{Name: "demo"},
+			Subject:            sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+			MaxTrust:           sentinelaccess.TrustLevel("low"),
+			AllowedSideEffects: []sentinelaccess.ToolSideEffect{"read"},
+		},
+	}); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+
+	memberReq := httptest.NewRequest(http.MethodGet, "/api/runtime/grants?namespace=mcp-team-acme", nil)
+	memberReq = memberReq.WithContext(withPrincipal(memberReq.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	memberRec := httptest.NewRecorder()
+	server.handleRuntimeGrantList(memberRec, memberReq)
+	if memberRec.Code != http.StatusOK {
+		t.Fatalf("member status = %d body=%s", memberRec.Code, memberRec.Body.String())
+	}
+	var memberPayload struct {
+		Grants []sentinelaccess.GrantSummary `json:"grants"`
+	}
+	if err := json.NewDecoder(memberRec.Body).Decode(&memberPayload); err != nil {
+		t.Fatalf("decode member grants: %v", err)
+	}
+	if len(memberPayload.Grants) != 0 {
+		t.Fatalf("member grants = %#v, want no sensitive grants", memberPayload.Grants)
+	}
+
+	ownerReq := httptest.NewRequest(http.MethodGet, "/api/runtime/grants?namespace=mcp-team-acme", nil)
+	ownerReq = ownerReq.WithContext(withPrincipal(ownerReq.Context(), principal{
+		Role:      roleUser,
+		Subject:   "owner-2",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleOwner,
+		}},
+	}))
+	ownerRec := httptest.NewRecorder()
+	server.handleRuntimeGrantList(ownerRec, ownerReq)
+	if ownerRec.Code != http.StatusOK {
+		t.Fatalf("owner status = %d body=%s", ownerRec.Code, ownerRec.Body.String())
+	}
+	var ownerPayload struct {
+		Grants []sentinelaccess.GrantSummary `json:"grants"`
+	}
+	if err := json.NewDecoder(ownerRec.Body).Decode(&ownerPayload); err != nil {
+		t.Fatalf("decode owner grants: %v", err)
+	}
+	if len(ownerPayload.Grants) != 1 {
+		t.Fatalf("owner grants = %#v, want grant visible", ownerPayload.Grants)
+	}
+}
+
+func TestRuntimeGrantListPrefetchesServersForVisibility(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	serverGets := 0
+	serverLists := 0
+	dynamicClient.Fake.PrependReactor("get", "mcpservers", func(ktesting.Action) (bool, runtime.Object, error) {
+		serverGets++
+		return false, nil, nil
+	})
+	dynamicClient.Fake.PrependReactor("list", "mcpservers", func(ktesting.Action) (bool, runtime.Object, error) {
+		serverLists++
+		return false, nil, nil
+	})
+	accessMgr := sentinelaccess.NewManager(dynamicClient, nil)
+	for _, name := range []string{"grant-one", "grant-two"} {
+		if _, err := accessMgr.ApplyGrant(ctx, &sentinelaccess.MCPAccessGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "mcp-team-acme"},
+			Spec: sentinelaccess.MCPAccessGrantSpec{
+				ServerRef:          sentinelaccess.ServerReference{Name: "demo"},
+				Subject:            sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+				MaxTrust:           sentinelaccess.TrustLevel("low"),
+				AllowedSideEffects: []sentinelaccess.ToolSideEffect{"read"},
+			},
+		}); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/grants?namespace=mcp-team-acme", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "owner-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleOwner,
+		}},
+	}))
+	recorder := httptest.NewRecorder()
+	server.handleRuntimeGrantList(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Grants []sentinelaccess.GrantSummary `json:"grants"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode grants: %v", err)
+	}
+	if len(payload.Grants) != 2 {
+		t.Fatalf("grants = %#v, want both grants visible", payload.Grants)
+	}
+	if serverLists != 1 {
+		t.Fatalf("server list calls = %d, want 1", serverLists)
+	}
+	if serverGets != 0 {
+		t.Fatalf("server get calls = %d, want 0", serverGets)
+	}
+}
+
+func TestRuntimeGrantGetRejectsTeamMemberForSensitiveGrant(t *testing.T) {
+	ctx := context.Background()
+	accessMgr := newTestAccessManagerWithObjects(t, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "owner-1",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	if _, err := accessMgr.ApplyGrant(ctx, &sentinelaccess.MCPAccessGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "grant-team", Namespace: "mcp-team-acme"},
+		Spec: sentinelaccess.MCPAccessGrantSpec{
+			ServerRef:          sentinelaccess.ServerReference{Name: "demo"},
+			Subject:            sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+			MaxTrust:           sentinelaccess.TrustLevel("low"),
+			AllowedSideEffects: []sentinelaccess.ToolSideEffect{"read"},
+		},
+	}); err != nil {
+		t.Fatalf("seed grant: %v", err)
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/grants/mcp-team-acme/grant-team", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	server.handleGrantGet(recorder, request, "mcp-team-acme", "grant-team")
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRuntimePolicyRequiresServerAdministrator(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "server-owner",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-gateway-policy",
+			Namespace: "mcp-team-acme",
+		},
+		Data: map[string]string{
+			"policy.json": `{"rules":[{"subject":{"humanID":"other-user"}}]}`,
+		},
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, mcpServer)
+	clientset := kubernetesfake.NewSimpleClientset(cm)
+	server := &RuntimeServer{
+		k8sClients: &k8sclient.Clients{Dynamic: dynamicClient, Clientset: clientset},
+		accessMgr:  sentinelaccess.NewManager(dynamicClient, clientset),
+	}
+
+	memberReq := httptest.NewRequest(http.MethodGet, "/api/runtime/policy?namespace=mcp-team-acme&server=demo", nil)
+	memberReq = memberReq.WithContext(withPrincipal(memberReq.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	memberRec := httptest.NewRecorder()
+	server.HandleRuntimePolicy(memberRec, memberReq)
+	if memberRec.Code != http.StatusForbidden {
+		t.Fatalf("member status = %d body=%s", memberRec.Code, memberRec.Body.String())
+	}
+
+	ownerReq := httptest.NewRequest(http.MethodGet, "/api/runtime/policy?namespace=mcp-team-acme&server=demo", nil)
+	ownerReq = ownerReq.WithContext(withPrincipal(ownerReq.Context(), principal{
+		Role:      roleUser,
+		Subject:   "owner-2",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleOwner,
+		}},
+	}))
+	ownerRec := httptest.NewRecorder()
+	server.HandleRuntimePolicy(ownerRec, ownerReq)
+	if ownerRec.Code != http.StatusOK {
+		t.Fatalf("owner status = %d body=%s", ownerRec.Code, ownerRec.Body.String())
+	}
+	if strings.Contains(ownerRec.Body.String(), "other-user") == false {
+		t.Fatalf("owner policy body = %s, want rendered policy", ownerRec.Body.String())
+	}
+}
+
+func TestRuntimeServerEventsRejectsTeamMemberBeforeAnalyticsQuery(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "server-owner",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	server := &RuntimeServer{
+		k8sClients: &k8sclient.Clients{Dynamic: dynamicClient, Clientset: kubernetesfake.NewSimpleClientset()},
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/server-events?namespace=mcp-team-acme&server=demo", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	recorder := httptest.NewRecorder()
+	server.HandleRuntimeServerEvents(recorder, request)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRuntimeComponentsRequiresAdmin(t *testing.T) {
+	server := &RuntimeServer{}
+	userReq := httptest.NewRequest(http.MethodGet, "/api/runtime/components", nil)
+	userReq = userReq.WithContext(withPrincipal(userReq.Context(), principal{Role: roleUser, Subject: "user-1"}))
+	userRec := httptest.NewRecorder()
+	server.HandleRuntimeComponents(userRec, userReq)
+	if userRec.Code != http.StatusForbidden {
+		t.Fatalf("user status = %d body=%s", userRec.Code, userRec.Body.String())
+	}
+
+	adminReq := httptest.NewRequest(http.MethodGet, "/api/runtime/components", nil)
+	adminReq = adminReq.WithContext(withPrincipal(adminReq.Context(), principal{Role: roleAdmin, Subject: "admin-1"}))
+	adminRec := httptest.NewRecorder()
+	server.HandleRuntimeComponents(adminRec, adminReq)
+	if adminRec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("admin status = %d body=%s", adminRec.Code, adminRec.Body.String())
+	}
+}
+
 func TestRuntimeGrantDeleteMapsNotFound(t *testing.T) {
 	server := &RuntimeServer{accessMgr: newTestAccessManager(t)}
 	recorder := httptest.NewRecorder()
@@ -1716,12 +2190,273 @@ func TestRuntimeGrantDeleteMapsNotFound(t *testing.T) {
 	}
 }
 
+func TestRuntimeGrantDeleteAllowsNamespaceOwnerWithStaleServerRef(t *testing.T) {
+	ctx := context.Background()
+	accessMgr := newTestAccessManagerWithObjects(t)
+	for _, name := range []string{"stale-owner", "stale-member"} {
+		if _, err := accessMgr.ApplyGrant(ctx, &sentinelaccess.MCPAccessGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "mcp-team-acme"},
+			Spec: sentinelaccess.MCPAccessGrantSpec{
+				ServerRef:          sentinelaccess.ServerReference{Name: "deleted"},
+				Subject:            sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+				MaxTrust:           sentinelaccess.TrustLevel("low"),
+				AllowedSideEffects: []sentinelaccess.ToolSideEffect{"read"},
+			},
+		}); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+
+	memberReq := httptest.NewRequest(http.MethodDelete, "/api/runtime/grants/mcp-team-acme/stale-member", nil)
+	memberReq = memberReq.WithContext(withPrincipal(memberReq.Context(), principal{
+		Role:      roleUser,
+		Subject:   "member-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	memberRec := httptest.NewRecorder()
+	server.handleGrantDelete(memberRec, memberReq, "mcp-team-acme", "stale-member")
+	if memberRec.Code != http.StatusForbidden {
+		t.Fatalf("member status = %d body=%s", memberRec.Code, memberRec.Body.String())
+	}
+
+	ownerReq := httptest.NewRequest(http.MethodDelete, "/api/runtime/grants/mcp-team-acme/stale-owner", nil)
+	ownerReq = ownerReq.WithContext(withPrincipal(ownerReq.Context(), principal{
+		Role:      roleUser,
+		Subject:   "owner-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleOwner,
+		}},
+	}))
+	ownerRec := httptest.NewRecorder()
+	server.handleGrantDelete(ownerRec, ownerReq, "mcp-team-acme", "stale-owner")
+	if ownerRec.Code != http.StatusOK {
+		t.Fatalf("owner status = %d body=%s", ownerRec.Code, ownerRec.Body.String())
+	}
+	if _, err := accessMgr.GetGrant(ctx, "stale-owner", "mcp-team-acme"); !apierrors.IsNotFound(err) {
+		t.Fatalf("stale-owner should be deleted, got err=%v", err)
+	}
+	if _, err := accessMgr.GetGrant(ctx, "stale-member", "mcp-team-acme"); err != nil {
+		t.Fatalf("stale-member should remain after forbidden delete: %v", err)
+	}
+}
+
 func TestRuntimeSessionDeleteMapsNotFound(t *testing.T) {
 	server := &RuntimeServer{accessMgr: newTestAccessManager(t)}
 	recorder := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodDelete, "/api/runtime/sessions/mcp-servers/missing", nil)
 	server.handleSessionDelete(recorder, request, "mcp-servers", "missing")
 	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRuntimeSessionDeleteAllowsNamespaceOwnerWithStaleServerRef(t *testing.T) {
+	ctx := context.Background()
+	accessMgr := newTestAccessManagerWithObjects(t)
+	if _, err := accessMgr.ApplySession(ctx, &sentinelaccess.MCPAgentSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "stale-session", Namespace: "mcp-team-acme"},
+		Spec: sentinelaccess.MCPAgentSessionSpec{
+			ServerRef:      sentinelaccess.ServerReference{Name: "deleted"},
+			Subject:        sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+			ConsentedTrust: sentinelaccess.TrustLevel("low"),
+		},
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+	request := httptest.NewRequest(http.MethodDelete, "/api/runtime/sessions/mcp-team-acme/stale-session", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "owner-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleOwner,
+		}},
+	}))
+	recorder := httptest.NewRecorder()
+	server.handleSessionDelete(recorder, request, "mcp-team-acme", "stale-session")
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if _, err := accessMgr.GetSession(ctx, "stale-session", "mcp-team-acme"); !apierrors.IsNotFound(err) {
+		t.Fatalf("stale-session should be deleted, got err=%v", err)
+	}
+}
+
+func TestRuntimeSessionListScopesTeamMemberAccessResources(t *testing.T) {
+	ctx := context.Background()
+	accessMgr := newTestAccessManagerWithObjects(t, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "owner-1",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	if _, err := accessMgr.ApplySession(ctx, &sentinelaccess.MCPAgentSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session-team", Namespace: "mcp-team-acme"},
+		Spec: sentinelaccess.MCPAgentSessionSpec{
+			ServerRef:      sentinelaccess.ServerReference{Name: "demo"},
+			Subject:        sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+			ConsentedTrust: sentinelaccess.TrustLevel("low"),
+		},
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/sessions?namespace=mcp-team-acme", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	recorder := httptest.NewRecorder()
+	server.handleRuntimeSessionList(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Sessions []sentinelaccess.SessionSummary `json:"sessions"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode sessions: %v", err)
+	}
+	if len(payload.Sessions) != 0 {
+		t.Fatalf("sessions = %#v, want no sensitive sessions", payload.Sessions)
+	}
+}
+
+func TestRuntimeSessionListPrefetchesServersForVisibility(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := mcpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(scheme, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	serverGets := 0
+	serverLists := 0
+	dynamicClient.Fake.PrependReactor("get", "mcpservers", func(ktesting.Action) (bool, runtime.Object, error) {
+		serverGets++
+		return false, nil, nil
+	})
+	dynamicClient.Fake.PrependReactor("list", "mcpservers", func(ktesting.Action) (bool, runtime.Object, error) {
+		serverLists++
+		return false, nil, nil
+	})
+	accessMgr := sentinelaccess.NewManager(dynamicClient, nil)
+	for _, name := range []string{"session-one", "session-two"} {
+		if _, err := accessMgr.ApplySession(ctx, &sentinelaccess.MCPAgentSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "mcp-team-acme"},
+			Spec: sentinelaccess.MCPAgentSessionSpec{
+				ServerRef:      sentinelaccess.ServerReference{Name: "demo"},
+				Subject:        sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+				ConsentedTrust: sentinelaccess.TrustLevel("low"),
+			},
+		}); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+	request := httptest.NewRequest(http.MethodGet, "/api/runtime/sessions?namespace=mcp-team-acme", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "owner-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleOwner,
+		}},
+	}))
+	recorder := httptest.NewRecorder()
+	server.handleRuntimeSessionList(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Sessions []sentinelaccess.SessionSummary `json:"sessions"`
+	}
+	if err := json.NewDecoder(recorder.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode sessions: %v", err)
+	}
+	if len(payload.Sessions) != 2 {
+		t.Fatalf("sessions = %#v, want both sessions visible", payload.Sessions)
+	}
+	if serverLists != 1 {
+		t.Fatalf("server list calls = %d, want 1", serverLists)
+	}
+	if serverGets != 0 {
+		t.Fatalf("server get calls = %d, want 0", serverGets)
+	}
+}
+
+func TestRuntimeSessionToggleRejectsTeamMemberForTeamServer(t *testing.T) {
+	ctx := context.Background()
+	accessMgr := newTestAccessManagerWithObjects(t, &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo",
+			Namespace: "mcp-team-acme",
+			Labels: map[string]string{
+				platformUserIDLabel: "owner-1",
+			},
+		},
+		Spec: mcpv1alpha1.MCPServerSpec{TeamID: "team-acme-id"},
+	})
+	if _, err := accessMgr.ApplySession(ctx, &sentinelaccess.MCPAgentSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "session-team", Namespace: "mcp-team-acme"},
+		Spec: sentinelaccess.MCPAgentSessionSpec{
+			ServerRef:      sentinelaccess.ServerReference{Name: "demo"},
+			Subject:        sentinelaccess.SubjectRef{HumanID: "other-user", TeamID: "team-acme-id"},
+			ConsentedTrust: sentinelaccess.TrustLevel("low"),
+		},
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	server := &RuntimeServer{accessMgr: accessMgr}
+	request := httptest.NewRequest(http.MethodPost, "/api/runtime/sessions/mcp-team-acme/session-team/revoke", nil)
+	request = request.WithContext(withPrincipal(request.Context(), principal{
+		Role:      roleUser,
+		Subject:   "user-1",
+		Namespace: "mcp-team-acme",
+		Teams: []principalTeam{{
+			ID:        "team-acme-id",
+			Slug:      "acme",
+			Namespace: "mcp-team-acme",
+			Role:      teamRoleMember,
+		}},
+	}))
+	recorder := httptest.NewRecorder()
+	server.handleSessionToggle(recorder, request, "mcp-team-acme", "session-team", true)
+	if recorder.Code != http.StatusForbidden {
 		t.Fatalf("status = %d body=%s", recorder.Code, recorder.Body.String())
 	}
 }

--- a/services/api/internal/runtimeapi/server_events.go
+++ b/services/api/internal/runtimeapi/server_events.go
@@ -1,6 +1,7 @@
 package runtimeapi
 
 import (
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,10 +15,6 @@ func (s *RuntimeServer) HandleRuntimeServerEvents(w http.ResponseWriter, r *http
 		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
 		return
 	}
-	if s == nil || s.db == nil || s.db.Conn == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "analytics not available"})
-		return
-	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
@@ -29,8 +26,27 @@ func (s *RuntimeServer) HandleRuntimeServerEvents(w http.ResponseWriter, r *http
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace and server are required"})
 		return
 	}
+	if s == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "analytics not available"})
+		return
+	}
 	if p.Role != roleAdmin && !principalCanReadNamespace(p, namespace) {
 		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+		return
+	}
+	if allowed, err := s.canAdministerNamedServer(r.Context(), namespace, server); err != nil {
+		code, msg := sensitiveServerReadStatus(err)
+		if code == http.StatusInternalServerError {
+			log.Printf("runtime server events: inspect server %s/%s failed: %v", namespace, server, err)
+		}
+		writeJSON(w, code, map[string]string{"error": msg})
+		return
+	} else if !allowed {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		return
+	}
+	if s.db == nil || s.db.Conn == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "analytics not available"})
 		return
 	}
 	events, err := s.db.QueryEventsFiltered(r.Context(), chpkg.EventFilters{

--- a/services/api/main.go
+++ b/services/api/main.go
@@ -139,6 +139,7 @@ type apiServer struct {
 	events            *clickhousepkg.Client
 	apiKeys           map[string]struct{}
 	adminAPIKeys      map[string]struct{}
+	legacyAdminKeys   bool
 	adminUsers        map[string]struct{}
 	jwks              *keyfunc.JWKS
 	oidcIssuer        string
@@ -196,11 +197,19 @@ func main() {
 		}
 	}
 	adminAPIKeys := splitCSVSet(envOr("ADMIN_API_KEYS", ""))
+	legacyAdminKeys := legacyAdminAPIKeyFallbackEnabled()
 	adminUsers := splitCSVSet(envOr("ADMIN_USERS", ""))
 	for entry := range adminUsers {
 		normalized := strings.ToLower(strings.TrimSpace(entry))
 		if normalized != "" {
 			adminUsers[normalized] = struct{}{}
+		}
+	}
+	if len(adminAPIKeys) == 0 && len(apiKeys) > 0 {
+		if legacyAdminKeys {
+			log.Printf("warning: ADMIN_API_KEYS is unset; API_KEYS entries authenticate as role=admin because legacy dev/test fallback is enabled")
+		} else {
+			log.Printf("warning: ADMIN_API_KEYS is unset; API_KEYS entries authenticate as role=user")
 		}
 	}
 	if len(adminAPIKeys) > 0 {
@@ -245,16 +254,17 @@ func main() {
 	}
 
 	server := &apiServer{
-		db:            conn,
-		dbName:        dbName,
-		events:        &clickhousepkg.Client{Conn: conn, DBName: dbName},
-		apiKeys:       apiKeys,
-		adminAPIKeys:  adminAPIKeys,
-		adminUsers:    adminUsers,
-		jwks:          jwks,
-		oidcIssuer:    oidcIssuer,
-		oidcAudience:  oidcAudience,
-		registryAuthz: newRegistryAuthzConfigFromEnv(),
+		db:              conn,
+		dbName:          dbName,
+		events:          &clickhousepkg.Client{Conn: conn, DBName: dbName},
+		apiKeys:         apiKeys,
+		adminAPIKeys:    adminAPIKeys,
+		legacyAdminKeys: legacyAdminKeys,
+		adminUsers:      adminUsers,
+		jwks:            jwks,
+		oidcIssuer:      oidcIssuer,
+		oidcAudience:    oidcAudience,
+		registryAuthz:   newRegistryAuthzConfigFromEnv(),
 	}
 	var store *platformStore
 	if dsn := platformDSNFromEnv(); dsn != "" {
@@ -343,7 +353,7 @@ func main() {
 		mux.Handle("/api/runtime/grants", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimeGrants)))
 		mux.Handle("/api/runtime/sessions", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimeSessions)))
 		mux.Handle("/api/runtime/adapter/sessions", server.auth(http.HandlerFunc(runtimeServer.HandleAdapterSession)))
-		mux.Handle("/api/runtime/components", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimeComponents)))
+		mux.Handle("/api/runtime/components", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.HandleRuntimeComponents))))
 		mux.Handle("/api/runtime/policy", server.auth(http.HandlerFunc(runtimeServer.HandleRuntimePolicy)))
 		mux.Handle("/api/runtime/actions/restart", server.auth(server.requireRole(roleAdmin, http.HandlerFunc(runtimeServer.HandleActionRestart))))
 		// Grant item (POST /api/runtime/grants/{namespace}/{name}/disable|enable, DELETE /api/runtime/grants/{namespace}/{name})
@@ -1099,14 +1109,17 @@ func (s *apiServer) authenticateRequest(r *http.Request) (principal, bool, error
 	apiKey := strings.TrimSpace(r.Header.Get("x-api-key"))
 	if apiKey != "" {
 		if _, ok := s.apiKeys[apiKey]; ok {
-			role := roleAdmin // backward-compatible default when ADMIN_API_KEYS is unset.
+			role := roleUser
 			if len(s.adminAPIKeys) > 0 {
 				// When ADMIN_API_KEYS is configured, API_KEYS values not present in
 				// ADMIN_API_KEYS are intentionally demoted to role=user.
-				role = roleUser
 				if _, admin := s.adminAPIKeys[apiKey]; admin {
 					role = roleAdmin
 				}
+			} else if s.legacyAdminKeys {
+				// Explicit dev/test compatibility path for legacy local setups that
+				// predate ADMIN_API_KEYS.
+				role = roleAdmin
 			}
 			return principal{Role: role, AuthType: "service_api_key", IsService: true}, true, nil
 		}
@@ -1288,6 +1301,15 @@ func splitCSVSet(raw string) map[string]struct{} {
 		out[part] = struct{}{}
 	}
 	return out
+}
+
+func legacyAdminAPIKeyFallbackEnabled() bool {
+	for _, key := range []string{"MCP_LEGACY_ADMIN_API_KEY_FALLBACK", "LEGACY_ADMIN_API_KEY_FALLBACK"} {
+		if enabled, ok := boolEnv(key); ok {
+			return enabled
+		}
+	}
+	return strings.TrimSpace(os.Getenv("MCP_RUNTIME_TEST_MODE")) == "1"
 }
 
 func maskCredentialForLog(value string) string {

--- a/services/ui/main.go
+++ b/services/ui/main.go
@@ -203,7 +203,7 @@ func newMux(apiBase, apiUpstream, apiKey, apiKeys, adminAPIKeys string) (*http.S
 	mux.HandleFunc("/auth/status", handleStatus(sessions))
 	parsedAPIKeys := parseAPIKeyList(apiKeys)
 	parsedAdminAPIKeys := parseAPIKeyList(adminAPIKeys)
-	mux.HandleFunc("/auth/admin-check", handleAdminCheck(sessions, parsedAPIKeys, parsedAdminAPIKeys))
+	mux.HandleFunc("/auth/admin-check", handleAdminCheck(sessions, parsedAPIKeys, parsedAdminAPIKeys, legacyAdminAPIKeyFallbackEnabled()))
 
 	apiProxy := newAPIProxy(target, apiBase, upstreamAPIKey, parsedAPIKeys, sessions, publicCatalog)
 	mux.Handle(apiBase+"/", apiProxy)
@@ -873,11 +873,9 @@ func handleLogout(store *uiSessionStore) http.HandlerFunc {
 // session or admin API key) and 401 otherwise. The original request body and
 // path do not matter — Traefik forwards only headers and consumes the status.
 // The Cache-Control header is set by securityHeadersMiddleware for /auth/.
-func handleAdminCheck(store *uiSessionStore, apiKeys, adminAPIKeys []string) http.HandlerFunc {
-	// When ADMIN_API_KEYS is unset, any value from API_KEYS authenticates as
-	// admin — matches the API service's backward-compatible default.
+func handleAdminCheck(store *uiSessionStore, apiKeys, adminAPIKeys []string, legacyAdminKeys bool) http.HandlerFunc {
 	gateKeys := adminAPIKeys
-	if len(gateKeys) == 0 {
+	if len(gateKeys) == 0 && legacyAdminKeys {
 		gateKeys = apiKeys
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -1265,4 +1263,13 @@ func boolEnvOr(key string, fallback bool) bool {
 		return parsed
 	}
 	return fallback
+}
+
+func legacyAdminAPIKeyFallbackEnabled() bool {
+	for _, key := range []string{"MCP_LEGACY_ADMIN_API_KEY_FALLBACK", "LEGACY_ADMIN_API_KEY_FALLBACK"} {
+		if parsed, ok := serviceutil.BoolEnv(key); ok {
+			return parsed
+		}
+	}
+	return strings.TrimSpace(os.Getenv("MCP_RUNTIME_TEST_MODE")) == "1"
 }

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -1463,6 +1463,7 @@ func TestHandleAdminCheck(t *testing.T) {
 		apiKeys      string
 		cookie       *http.Cookie
 		apiKeyHeader string
+		legacyAdmin  bool
 		want         int
 	}{
 		{name: "no_credential", apiKeys: "ui-key,admin-key", adminKeys: "admin-key", want: http.StatusUnauthorized},
@@ -1470,13 +1471,14 @@ func TestHandleAdminCheck(t *testing.T) {
 		{name: "user_session_rejected", apiKeys: "ui-key", cookie: &http.Cookie{Name: sessionCookieName, Value: userSess.ID}, want: http.StatusUnauthorized},
 		{name: "admin_api_key", apiKeys: "ui-key,admin-key", adminKeys: "admin-key", apiKeyHeader: "admin-key", want: http.StatusNoContent},
 		{name: "non_admin_api_key_rejected", apiKeys: "ui-key,admin-key", adminKeys: "admin-key", apiKeyHeader: "ui-key", want: http.StatusUnauthorized},
-		{name: "fallback_any_api_key_when_admin_unset", apiKeys: "ui-key", apiKeyHeader: "ui-key", want: http.StatusNoContent},
+		{name: "admin_unset_rejects_api_key_by_default", apiKeys: "ui-key", apiKeyHeader: "ui-key", want: http.StatusUnauthorized},
+		{name: "legacy_fallback_allows_api_key_when_admin_unset", apiKeys: "ui-key", apiKeyHeader: "ui-key", legacyAdmin: true, want: http.StatusNoContent},
 		{name: "unknown_api_key", apiKeys: "ui-key", apiKeyHeader: "rando", want: http.StatusUnauthorized},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := handleAdminCheck(store, parseAPIKeyList(tc.apiKeys), parseAPIKeyList(tc.adminKeys))
+			h := handleAdminCheck(store, parseAPIKeyList(tc.apiKeys), parseAPIKeyList(tc.adminKeys), tc.legacyAdmin)
 			req := httptest.NewRequest(http.MethodGet, "/auth/admin-check", nil)
 			if tc.cookie != nil {
 				req.AddCookie(tc.cookie)
@@ -1490,6 +1492,26 @@ func TestHandleAdminCheck(t *testing.T) {
 				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.want, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestLegacyAdminAPIKeyFallbackEnabledForUIAdminCheck(t *testing.T) {
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "")
+	t.Setenv("MCP_LEGACY_ADMIN_API_KEY_FALLBACK", "")
+	t.Setenv("LEGACY_ADMIN_API_KEY_FALLBACK", "")
+	if legacyAdminAPIKeyFallbackEnabled() {
+		t.Fatal("legacy fallback should be disabled by default")
+	}
+
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "1")
+	if !legacyAdminAPIKeyFallbackEnabled() {
+		t.Fatal("legacy fallback should be enabled in runtime test mode")
+	}
+
+	t.Setenv("MCP_RUNTIME_TEST_MODE", "")
+	t.Setenv("MCP_LEGACY_ADMIN_API_KEY_FALLBACK", "true")
+	if !legacyAdminAPIKeyFallbackEnabled() {
+		t.Fatal("legacy fallback should honor explicit override")
 	}
 }
 


### PR DESCRIPTION
## Summary
- gate sensitive grant/session/policy/event APIs to admins, server owners, or team owners
- make direct session apply admin/internal-only while preserving adapter session issuance
- make static API keys default to user when ADMIN_API_KEYS is unset, including UI admin-check, unless legacy dev/test fallback is enabled
- document the runtime boundary changes

Closes #227

## Tests
- git diff --check
- (cd services/ui && go test ./... -count=1)
- (cd services/api && go test ./... -count=1)
- pre-commit hooks: gitleaks, gofmt, staticcheck, go vet, Go unit tests, generated drift