### PR TITLE
fix: stop dropping error chain in 5 fmt.Errorf %v sites

### DIFF
--- a/internal/cli/certmanager/manager_test.go
+++ b/internal/cli/certmanager/manager_test.go
@@ -594,6 +594,41 @@ func TestCheckRegistryCertificateOwnershipWithKubectl(t *testing.T) {
 	})
 }
 
+func TestRegistryTLSCertificateOwnersWrapsListError(t *testing.T) {
+	cause := errors.New("kubectl get certificates failed")
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			cmd := &core.MockCommand{Args: spec.Args}
+			if commandHasArgs(spec, "get", "certificates", "-n", core.NamespaceRegistry, "-o", "json") {
+				cmd.RunFunc = func() error {
+					if cmd.StderrW != nil {
+						_, _ = cmd.StderrW.Write([]byte("forbidden"))
+					}
+					return cause
+				}
+			}
+			return cmd
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	_, err := registryTLSCertificateOwners(kubectl)
+	if !errors.Is(err, cause) {
+		t.Fatalf("registryTLSCertificateOwners() error = %v, want errors.Is(..., cause)", err)
+	}
+}
+
+func TestRegistryTLSCertificateOwnersWrapsParseError(t *testing.T) {
+	mock := certificateListMock(`{"items":[`)
+	kubectl := core.NewTestKubectlClient(mock)
+
+	_, err := registryTLSCertificateOwners(kubectl)
+	var cause *json.SyntaxError
+	if !errors.As(err, &cause) {
+		t.Fatalf("registryTLSCertificateOwners() error = %v, want json syntax error in chain", err)
+	}
+}
+
 func TestApplyClusterIssuerWithKubectlError(t *testing.T) {
 	mock := &core.MockExecutor{DefaultRunErr: errors.New("apply failed")}
 	kubectl := core.NewTestKubectlClient(mock)

--- a/internal/cli/cluster/doctor/doctor_impl_test.go
+++ b/internal/cli/cluster/doctor/doctor_impl_test.go
@@ -284,6 +284,23 @@ func TestCheckTraefikWebEntrypoint(t *testing.T) {
 	})
 }
 
+func TestReadTraefikServicePortsWrapsCommandArgsError(t *testing.T) {
+	cause := errors.New("validator rejected command")
+	kubectl := core.NewTestKubectlClientWithValidators(
+		&core.MockExecutor{},
+		[]core.ExecValidator{
+			func(core.ExecSpec) error {
+				return cause
+			},
+		},
+	)
+
+	_, err := readTraefikServicePorts(kubectl, doctorTraefikEndpoint{Namespace: "traefik", Name: "traefik"})
+	if !errors.Is(err, cause) {
+		t.Fatalf("readTraefikServicePorts() error = %v, want errors.Is(..., cause)", err)
+	}
+}
+
 func TestCheckPublicIngressHostConfig(t *testing.T) {
 	t.Run("ok when all three hosts resolve from platform domain", func(t *testing.T) {
 		t.Setenv("MCP_PLATFORM_DOMAIN", "mcpruntime.org")

--- a/internal/cli/registry/manager_test.go
+++ b/internal/cli/registry/manager_test.go
@@ -827,6 +827,30 @@ spec:
 	})
 }
 
+func TestRenderKustomizeManifestWrapsRunError(t *testing.T) {
+	cause := errors.New("kustomize failed")
+	mock := &core.MockExecutor{
+		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+			cmd := &core.MockCommand{Args: spec.Args}
+			if contains(spec.Args, "kustomize") {
+				cmd.RunFunc = func() error {
+					if cmd.StderrW != nil {
+						_, _ = cmd.StderrW.Write([]byte("bad overlay"))
+					}
+					return cause
+				}
+			}
+			return cmd
+		},
+	}
+	kubectl := core.NewTestKubectlClient(mock)
+
+	_, err := renderKustomizeManifest(kubectl, "config/registry")
+	if !errors.Is(err, cause) {
+		t.Fatalf("renderKustomizeManifest() error = %v, want errors.Is(..., cause)", err)
+	}
+}
+
 func TestCheckRegistryStatusStarting(t *testing.T) {
 	mock := &core.MockExecutor{
 		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {

--- a/pkg/authfile/authfile_test.go
+++ b/pkg/authfile/authfile_test.go
@@ -1,6 +1,7 @@
 package authfile
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -95,6 +96,10 @@ func TestLoad_InvalidJSON(t *testing.T) {
 	_, err := Load(p)
 	if !errors.Is(err, ErrInvalid) {
 		t.Fatalf("Load() = %v, want ErrInvalid", err)
+	}
+	var cause *json.SyntaxError
+	if !errors.As(err, &cause) {
+		t.Fatalf("Load() = %v, want json syntax error in chain", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

After rebasing onto current `origin/main`, the five implementation sites already use `%w`; this PR adds focused regression coverage proving those chains stay intact with `errors.Is` / `errors.As`.

## Covered sites

- `internal/cli/cluster/doctor/doctor_traefik.go` (`readTraefikServicePorts`): keeps kubectl command construction errors discoverable through `errors.Is`.
- `internal/cli/certmanager/manager.go` (`registryTLSCertificateOwners`, list path): keeps failed `kubectl get certificates` causes discoverable while retaining stderr context.
- `internal/cli/certmanager/manager.go` (`registryTLSCertificateOwners`, parse path): keeps JSON parse causes discoverable for malformed certificate lists.
- `internal/cli/registry/manager.go` (`renderKustomizeManifest`): keeps `kubectl kustomize` run failures discoverable while retaining stderr context.
- `pkg/authfile/authfile.go` (`Load`): keeps both `ErrInvalid` and the JSON parse cause discoverable for invalid credentials files.

## Test plan

- `grep -rn --include="*.go" --exclude-dir=vendor --exclude-dir=inspirations --exclude="*_test.go" 'fmt\.Errorf.*%v.*err\|fmt\.Errorf.*%v.*Err' .` (only remaining hit is the expected `pkg/k8sclient/client.go` slice-formatting case)
- `go test ./internal/cli/certmanager ./internal/cli/registry ./pkg/authfile -race -count=1`
- `go test ./internal/cli/cluster/doctor -run TestReadTraefikServicePortsWrapsCommandArgsError -race -count=1`
- `gofmt -s -l .`
- `go vet ./...`
- `staticcheck ./...`
- `go test ./... -race -count=1` (failed once in `test/integration` on `TestAdapterStdioSessionRequiredHappyPath`: timed out waiting for adapter stdout after 5s; rerunning that single test passed)
- `go test ./test/integration -run TestAdapterStdioSessionRequiredHappyPath -race -count=1 -v`
- `pre-commit run --all-files`

Refs #235