### PR TITLE
feat(services-api): add apierr helper and adopt in runtimeapi

### DIFF
--- a/internal/cli/platformapi/client.go
+++ b/internal/cli/platformapi/client.go
@@ -464,6 +464,9 @@ func readBody(r io.Reader) ([]byte, error) {
 func httpAPIError(status int, body []byte) error {
 	var m map[string]string
 	if err := json.Unmarshal(body, &m); err == nil {
+		if message := m["message"]; message != "" {
+			return fmt.Errorf("API %d: %s", status, message)
+		}
 		if e := m["error"]; e != "" {
 			return fmt.Errorf("API %d: %s", status, e)
 		}

--- a/internal/cli/platformapi/client_test.go
+++ b/internal/cli/platformapi/client_test.go
@@ -158,6 +158,13 @@ func TestValidateCredentials(t *testing.T) {
 	}
 }
 
+func TestHTTPAPIErrorPrefersMessageField(t *testing.T) {
+	err := httpAPIError(http.StatusForbidden, []byte(`{"error":"forbidden_namespace","message":"forbidden namespace"}`))
+	if got, want := err.Error(), "API 403: forbidden namespace"; got != want {
+		t.Fatalf("httpAPIError() = %q, want %q", got, want)
+	}
+}
+
 func TestResolvePlatformOrKubeModeSelection(t *testing.T) {
 	t.Run("uses platform by default when auth is configured", func(t *testing.T) {
 		t.Setenv(authfile.EnvAPIToken, "token-1")

--- a/services/api/go.mod
+++ b/services/api/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/lib/pq v1.12.3
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.uber.org/automaxprocs v1.6.0
+	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.51.0
 	k8s.io/api v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -74,6 +75,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.53.0 // indirect

--- a/services/api/internal/apierr/error.go
+++ b/services/api/internal/apierr/error.go
@@ -1,0 +1,86 @@
+package apierr
+
+import (
+	"errors"
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"mcp-runtime/pkg/serviceutil"
+)
+
+// Error is a safe, typed HTTP error for API responses.
+type Error struct {
+	Status  int
+	Code    string
+	Message string
+	Cause   error
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}
+
+func (e *Error) Unwrap() error {
+	return e.Cause
+}
+
+func BadRequest(code, message string, cause ...error) *Error {
+	return newError(http.StatusBadRequest, code, message, cause...)
+}
+
+func Unauthorized(code, message string, cause ...error) *Error {
+	return newError(http.StatusUnauthorized, code, message, cause...)
+}
+
+func Forbidden(code, message string, cause ...error) *Error {
+	return newError(http.StatusForbidden, code, message, cause...)
+}
+
+func NotFound(code, message string, cause ...error) *Error {
+	return newError(http.StatusNotFound, code, message, cause...)
+}
+
+func Conflict(code, message string, cause ...error) *Error {
+	return newError(http.StatusConflict, code, message, cause...)
+}
+
+func Internal(code, message string, cause ...error) *Error {
+	return newError(http.StatusInternalServerError, code, message, cause...)
+}
+
+func ServiceUnavailable(code, message string, cause ...error) *Error {
+	return newError(http.StatusServiceUnavailable, code, message, cause...)
+}
+
+// Write renders err as a JSON API error response.
+func Write(w http.ResponseWriter, logger *zap.Logger, err error) {
+	var apiError *Error
+	if errors.As(err, &apiError) {
+		if logger != nil && apiError.Cause != nil {
+			logger.Error("api error", zap.Int("status", apiError.Status), zap.String("code", apiError.Code), zap.Error(apiError.Cause))
+		}
+		serviceutil.WriteJSON(w, apiError.Status, map[string]string{
+			"error":   apiError.Code,
+			"message": apiError.Message,
+		})
+		return
+	}
+
+	if logger != nil && err != nil {
+		logger.Error("api error", zap.Error(err))
+	}
+	serviceutil.WriteJSON(w, http.StatusInternalServerError, map[string]string{
+		"error":   "internal_error",
+		"message": "internal server error",
+	})
+}
+
+func newError(status int, code, message string, cause ...error) *Error {
+	return &Error{
+		Status:  status,
+		Code:    code,
+		Message: message,
+		Cause:   errors.Join(cause...),
+	}
+}

--- a/services/api/internal/apierr/error_test.go
+++ b/services/api/internal/apierr/error_test.go
@@ -1,0 +1,87 @@
+package apierr
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestConstructors(t *testing.T) {
+	cause := errors.New("cause")
+	tests := []struct {
+		name   string
+		status int
+		build  func(string, string, ...error) *Error
+	}{
+		{name: "BadRequest", status: http.StatusBadRequest, build: BadRequest},
+		{name: "Unauthorized", status: http.StatusUnauthorized, build: Unauthorized},
+		{name: "Forbidden", status: http.StatusForbidden, build: Forbidden},
+		{name: "NotFound", status: http.StatusNotFound, build: NotFound},
+		{name: "Conflict", status: http.StatusConflict, build: Conflict},
+		{name: "Internal", status: http.StatusInternalServerError, build: Internal},
+		{name: "ServiceUnavailable", status: http.StatusServiceUnavailable, build: ServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.build("test_code", "test message", cause)
+			if err.Status != tt.status {
+				t.Fatalf("Status = %d, want %d", err.Status, tt.status)
+			}
+			if err.Code != "test_code" {
+				t.Fatalf("Code = %q, want test_code", err.Code)
+			}
+			if err.Message != "test message" {
+				t.Fatalf("Message = %q, want test message", err.Message)
+			}
+			if err.Error() != "test message" {
+				t.Fatalf("Error() = %q, want test message", err.Error())
+			}
+			if !errors.Is(err, cause) {
+				t.Fatalf("Unwrap() does not expose cause")
+			}
+		})
+	}
+}
+
+func TestWriteTypedError(t *testing.T) {
+	core, logs := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(core)
+	recorder := httptest.NewRecorder()
+	cause := errors.New("database unavailable")
+
+	Write(recorder, logger, ServiceUnavailable("store_unavailable", "store unavailable", cause))
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if got, want := recorder.Body.String(), `{"error":"store_unavailable","message":"store unavailable"}`; got != want {
+		t.Fatalf("body = %s, want %s", got, want)
+	}
+	if logs.Len() != 1 {
+		t.Fatalf("logged entries = %d, want 1", logs.Len())
+	}
+}
+
+func TestWriteGenericError(t *testing.T) {
+	core, logs := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(core)
+	recorder := httptest.NewRecorder()
+
+	Write(recorder, logger, errors.New("sensitive backend detail"))
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if got, want := recorder.Body.String(), `{"error":"internal_error","message":"internal server error"}`; got != want {
+		t.Fatalf("body = %s, want %s", got, want)
+	}
+	if logs.Len() != 1 {
+		t.Fatalf("logged entries = %d, want 1", logs.Len())
+	}
+}

--- a/services/api/internal/runtimeapi/access.go
+++ b/services/api/internal/runtimeapi/access.go
@@ -50,13 +50,13 @@ func (s *RuntimeServer) HandleRuntimeGrants(w http.ResponseWriter, r *http.Reque
 		s.handleRuntimeGrantApply(w, r)
 	default:
 		w.Header().Set("allow", "GET, POST")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 func (s *RuntimeServer) handleRuntimeGrantList(w http.ResponseWriter, r *http.Request) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -65,12 +65,12 @@ func (s *RuntimeServer) handleRuntimeGrantList(w http.ResponseWriter, r *http.Re
 
 	namespace, err := s.scopedNamespaceForPrincipal(r.Context(), r.URL.Query().Get("namespace"))
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	grants, err := s.accessMgr.ListGrants(ctx, namespace)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list grants"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to list grants")
 		return
 	}
 
@@ -81,7 +81,7 @@ func (s *RuntimeServer) handleRuntimeGrantList(w http.ResponseWriter, r *http.Re
 		serverCache, err = s.accessServerCacheForGrantRefs(ctx, namespace, grants.Items)
 		if err != nil {
 			log.Printf("runtime grant list: list MCPServers for visibility failed: %v", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect server references"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to inspect server references")
 			return
 		}
 	}
@@ -99,7 +99,7 @@ func (s *RuntimeServer) handleRuntimeGrantList(w http.ResponseWriter, r *http.Re
 
 func (s *RuntimeServer) handleRuntimeGrantApply(w http.ResponseWriter, r *http.Request) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -113,17 +113,17 @@ func (s *RuntimeServer) handleRuntimeGrantApply(w http.ResponseWriter, r *http.R
 		req.Namespace = strings.TrimSpace(p.Namespace)
 	}
 	if err := validateGrantRequest(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	scopedNamespace, err := s.scopedAccessWriteNamespaceForPrincipal(r.Context(), req.Namespace)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	req.Namespace = scopedNamespace
 	if err := bindAccessServerRefNamespace(req.Namespace, &req.ServerRef); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -135,26 +135,26 @@ func (s *RuntimeServer) handleRuntimeGrantApply(w http.ResponseWriter, r *http.R
 	targetServer, err := s.accessMgr.GetMCPServerRef(ctx, req.ServerRef)
 	if err != nil {
 		if sentinelaccess.IsMCPServerNotFoundForRef(err) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 		} else {
 			log.Printf("runtime grant: assert MCPServer ref failed: %v", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to verify server reference")
 		}
 		return
 	}
 	if err := s.bindAccessSubjectTeamID(ctx, req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	if !s.principalCanAdministerAccessServer(r.Context(), *targetServer) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 
 	disabled, err := s.grantDisabledForApply(ctx, req)
 	if err != nil {
 		log.Printf("read grant state %s/%s failed: %v", req.Namespace, req.Name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read grant state"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to read grant state")
 		return
 	}
 
@@ -190,13 +190,13 @@ func (s *RuntimeServer) HandleRuntimeSessions(w http.ResponseWriter, r *http.Req
 		s.handleRuntimeSessionApply(w, r)
 	default:
 		w.Header().Set("allow", "GET, POST")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 func (s *RuntimeServer) handleRuntimeSessionList(w http.ResponseWriter, r *http.Request) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -205,12 +205,12 @@ func (s *RuntimeServer) handleRuntimeSessionList(w http.ResponseWriter, r *http.
 
 	namespace, err := s.scopedNamespaceForPrincipal(r.Context(), r.URL.Query().Get("namespace"))
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	sessions, err := s.accessMgr.ListSessions(ctx, namespace)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list sessions"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to list sessions")
 		return
 	}
 
@@ -221,7 +221,7 @@ func (s *RuntimeServer) handleRuntimeSessionList(w http.ResponseWriter, r *http.
 		serverCache, err = s.accessServerCacheForSessionRefs(ctx, namespace, sessions.Items)
 		if err != nil {
 			log.Printf("runtime session list: list MCPServers for visibility failed: %v", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect server references"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to inspect server references")
 			return
 		}
 	}
@@ -239,11 +239,11 @@ func (s *RuntimeServer) handleRuntimeSessionList(w http.ResponseWriter, r *http.
 
 func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http.Request) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	if p, ok := principalFromContext(r.Context()); ok && p.Role != roleAdmin {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin role required"})
+		writeAPIError(w, http.StatusForbidden, "admin role required")
 		return
 	}
 
@@ -257,17 +257,17 @@ func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http
 		req.Namespace = strings.TrimSpace(p.Namespace)
 	}
 	if err := validateSessionRequest(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	scopedNamespace, err := s.scopedAccessWriteNamespaceForPrincipal(r.Context(), req.Namespace)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	req.Namespace = scopedNamespace
 	if err := bindAccessServerRefNamespace(req.Namespace, &req.ServerRef); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -278,26 +278,26 @@ func (s *RuntimeServer) handleRuntimeSessionApply(w http.ResponseWriter, r *http
 	targetServer, err := s.accessMgr.GetMCPServerRef(ctx, req.ServerRef)
 	if err != nil {
 		if sentinelaccess.IsMCPServerNotFoundForRef(err) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 		} else {
 			log.Printf("runtime session: assert MCPServer ref failed: %v", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to verify server reference")
 		}
 		return
 	}
 	if err := s.bindAccessSubjectTeamID(ctx, req.Namespace, targetServer.Spec.TeamID, &req.Subject); err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	if !s.principalCanAdministerAccessServer(r.Context(), *targetServer) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 
 	revoked, err := s.sessionRevokedForApply(ctx, req)
 	if err != nil {
 		log.Printf("read session state %s/%s failed: %v", req.Namespace, req.Name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read session state"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to read session state")
 		return
 	}
 
@@ -432,7 +432,7 @@ func (s *RuntimeServer) HandleGrantItemPath(w http.ResponseWriter, r *http.Reque
 	case http.MethodGet:
 		ns, name, err := extractNamespacedPath(r.URL.Path, "/api/runtime/grants/", 2)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		s.handleGrantGet(w, r, ns, name)
@@ -440,7 +440,7 @@ func (s *RuntimeServer) HandleGrantItemPath(w http.ResponseWriter, r *http.Reque
 	case http.MethodDelete:
 		ns, name, err := serviceutil.ExtractNamespacedResourceDelete(r, "/api/runtime/grants/")
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		s.handleGrantDelete(w, r, ns, name)
@@ -450,18 +450,18 @@ func (s *RuntimeServer) HandleGrantItemPath(w http.ResponseWriter, r *http.Reque
 		return
 	default:
 		w.Header().Set("allow", "GET, POST, DELETE")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 func (s *RuntimeServer) handleGrantGet(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	namespace, err := s.scopedNamespaceForPrincipal(r.Context(), namespace)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -469,11 +469,11 @@ func (s *RuntimeServer) handleGrantGet(w http.ResponseWriter, r *http.Request, n
 	grant, err := s.accessMgr.GetGrant(ctx, name, namespace)
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	}
 	if !s.grantVisibleToPrincipal(ctx, *grant) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"grant": sentinelaccess.ToGrantSummary(*grant)})
@@ -481,12 +481,12 @@ func (s *RuntimeServer) handleGrantGet(w http.ResponseWriter, r *http.Request, n
 
 func (s *RuntimeServer) handleGrantDelete(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	namespace, err := s.scopedAccessWriteNamespaceForPrincipal(r.Context(), namespace)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -495,23 +495,23 @@ func (s *RuntimeServer) handleGrantDelete(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		log.Printf("delete grant %s/%s failed before authz (status=%d): %v", namespace, name, code, err)
-		writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to delete grant: %s", msg)})
+		writeAPIError(w, code, fmt.Sprintf("failed to delete grant: %s", msg))
 		return
 	}
 	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, grant.Spec.ServerRef)
 	if err != nil {
 		log.Printf("delete grant %s/%s authz lookup failed: %v", namespace, name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to verify server reference")
 		return
 	}
 	if !allowed {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 	if err := s.accessMgr.DeleteGrant(ctx, name, namespace); err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		log.Printf("delete grant %s/%s failed (status=%d): %v", namespace, name, code, err)
-		writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to delete grant: %s", msg)})
+		writeAPIError(w, code, fmt.Sprintf("failed to delete grant: %s", msg))
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -526,9 +526,9 @@ func (s *RuntimeServer) handleGrantPostTogglePath(w http.ResponseWriter, r *http
 	params, err := serviceutil.ExtractGrantActionParams(r, "/api/runtime/grants/")
 	if err != nil {
 		if errors.Is(err, serviceutil.ErrMethodNotAllowed) {
-			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusMethodNotAllowed, err.Error())
 		} else {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 		}
 		return
 	}
@@ -539,13 +539,13 @@ func (s *RuntimeServer) handleGrantPostTogglePath(w http.ResponseWriter, r *http
 
 func (s *RuntimeServer) handleGrantToggle(w http.ResponseWriter, r *http.Request, namespace, name string, disable bool) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
 	namespace, nsErr := s.scopedAccessWriteNamespaceForPrincipal(r.Context(), namespace)
 	if nsErr != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": nsErr.Error()})
+		writeAPIError(w, http.StatusForbidden, nsErr.Error())
 		return
 	}
 
@@ -554,17 +554,17 @@ func (s *RuntimeServer) handleGrantToggle(w http.ResponseWriter, r *http.Request
 	grant, err := s.accessMgr.GetGrant(ctx, name, namespace)
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	}
 	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, grant.Spec.ServerRef)
 	if err != nil {
 		log.Printf("toggle grant %s/%s authz lookup failed: %v", namespace, name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to verify server reference")
 		return
 	}
 	if !allowed {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 
@@ -576,7 +576,7 @@ func (s *RuntimeServer) handleGrantToggle(w http.ResponseWriter, r *http.Request
 	}
 
 	if updateErr != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update grant"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to update grant")
 		return
 	}
 
@@ -704,7 +704,7 @@ func defaultPolicyVersion(policyVersion string) string {
 func writeK8sApplyError(w http.ResponseWriter, kind, namespace, name string, err error) {
 	code, msg := k8sclient.HTTPStatusFromK8sError(err)
 	log.Printf("apply %s %s/%s failed (status=%d): %v", kind, namespace, name, code, err)
-	writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to apply %s: %s", kind, msg)})
+	writeAPIError(w, code, fmt.Sprintf("failed to apply %s: %s", kind, msg))
 }
 
 func normalizeTrust(trust sentinelaccess.TrustLevel) sentinelaccess.TrustLevel {
@@ -748,7 +748,7 @@ func (s *RuntimeServer) HandleSessionItemPath(w http.ResponseWriter, r *http.Req
 	case http.MethodGet:
 		ns, name, err := extractNamespacedPath(r.URL.Path, "/api/runtime/sessions/", 2)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		s.handleSessionGet(w, r, ns, name)
@@ -756,7 +756,7 @@ func (s *RuntimeServer) HandleSessionItemPath(w http.ResponseWriter, r *http.Req
 	case http.MethodDelete:
 		ns, name, err := serviceutil.ExtractNamespacedResourceDelete(r, "/api/runtime/sessions/")
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		s.handleSessionDelete(w, r, ns, name)
@@ -766,18 +766,18 @@ func (s *RuntimeServer) HandleSessionItemPath(w http.ResponseWriter, r *http.Req
 		return
 	default:
 		w.Header().Set("allow", "GET, POST, DELETE")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 func (s *RuntimeServer) handleSessionGet(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	namespace, err := s.scopedNamespaceForPrincipal(r.Context(), namespace)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -785,11 +785,11 @@ func (s *RuntimeServer) handleSessionGet(w http.ResponseWriter, r *http.Request,
 	session, err := s.accessMgr.GetSession(ctx, name, namespace)
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	}
 	if !s.sessionVisibleToPrincipal(ctx, *session) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"session": sentinelaccess.ToSessionSummary(*session)})
@@ -817,12 +817,12 @@ func extractNamespacedPath(path, prefix string, expectedParts int) (string, stri
 
 func (s *RuntimeServer) handleSessionDelete(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	namespace, err := s.scopedAccessWriteNamespaceForPrincipal(r.Context(), namespace)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -831,23 +831,23 @@ func (s *RuntimeServer) handleSessionDelete(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		log.Printf("delete session %s/%s failed before authz (status=%d): %v", namespace, name, code, err)
-		writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to delete session: %s", msg)})
+		writeAPIError(w, code, fmt.Sprintf("failed to delete session: %s", msg))
 		return
 	}
 	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, session.Spec.ServerRef)
 	if err != nil {
 		log.Printf("delete session %s/%s authz lookup failed: %v", namespace, name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to verify server reference")
 		return
 	}
 	if !allowed {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 	if err := s.accessMgr.DeleteSession(ctx, name, namespace); err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		log.Printf("delete session %s/%s failed (status=%d): %v", namespace, name, code, err)
-		writeJSON(w, code, map[string]string{"error": fmt.Sprintf("failed to delete session: %s", msg)})
+		writeAPIError(w, code, fmt.Sprintf("failed to delete session: %s", msg))
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -862,9 +862,9 @@ func (s *RuntimeServer) handleSessionPostTogglePath(w http.ResponseWriter, r *ht
 	params, err := serviceutil.ExtractSessionActionParams(r, "/api/runtime/sessions/")
 	if err != nil {
 		if errors.Is(err, serviceutil.ErrMethodNotAllowed) {
-			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusMethodNotAllowed, err.Error())
 		} else {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			writeAPIError(w, http.StatusBadRequest, err.Error())
 		}
 		return
 	}
@@ -875,13 +875,13 @@ func (s *RuntimeServer) handleSessionPostTogglePath(w http.ResponseWriter, r *ht
 
 func (s *RuntimeServer) handleSessionToggle(w http.ResponseWriter, r *http.Request, namespace, name string, revoke bool) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
 	namespace, nsErr := s.scopedAccessWriteNamespaceForPrincipal(r.Context(), namespace)
 	if nsErr != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": nsErr.Error()})
+		writeAPIError(w, http.StatusForbidden, nsErr.Error())
 		return
 	}
 
@@ -890,17 +890,17 @@ func (s *RuntimeServer) handleSessionToggle(w http.ResponseWriter, r *http.Reque
 	session, err := s.accessMgr.GetSession(ctx, name, namespace)
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	}
 	allowed, err := s.canAdministerAccessServerRef(ctx, namespace, session.Spec.ServerRef)
 	if err != nil {
 		log.Printf("toggle session %s/%s authz lookup failed: %v", namespace, name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to verify server reference"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to verify server reference")
 		return
 	}
 	if !allowed {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 
@@ -912,7 +912,7 @@ func (s *RuntimeServer) handleSessionToggle(w http.ResponseWriter, r *http.Reque
 	}
 
 	if updateErr != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update session"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to update session")
 		return
 	}
 

--- a/services/api/internal/runtimeapi/actions.go
+++ b/services/api/internal/runtimeapi/actions.go
@@ -3,6 +3,7 @@ package runtimeapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 // HandleActionRestart restarts one or all Sentinel runtime components.
 func (s *RuntimeServer) HandleActionRestart(w http.ResponseWriter, r *http.Request) {
 	if s.sentinelMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -22,7 +23,7 @@ func (s *RuntimeServer) HandleActionRestart(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		writeAPIError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
 
@@ -32,14 +33,7 @@ func (s *RuntimeServer) HandleActionRestart(w http.ResponseWriter, r *http.Reque
 	if req.All {
 		errs := s.sentinelMgr.RestartAllComponents(ctx)
 		if len(errs) > 0 {
-			errMsgs := make([]string, 0, len(errs))
-			for _, e := range errs {
-				errMsgs = append(errMsgs, e.Error())
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
-				"error":  "some components failed to restart",
-				"errors": errMsgs,
-			})
+			writeAPIError(w, http.StatusInternalServerError, "some components failed to restart", errors.Join(errs...))
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -50,18 +44,18 @@ func (s *RuntimeServer) HandleActionRestart(w http.ResponseWriter, r *http.Reque
 	}
 
 	if req.Component == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "component required"})
+		writeAPIError(w, http.StatusBadRequest, "component required")
 		return
 	}
 
 	// Validate component exists
 	if _, err := sentinel.FindComponent(req.Component); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown component"})
+		writeAPIError(w, http.StatusBadRequest, "unknown component")
 		return
 	}
 
 	if err := s.sentinelMgr.RestartComponent(ctx, req.Component); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to restart component"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to restart component")
 		return
 	}
 

--- a/services/api/internal/runtimeapi/adapter.go
+++ b/services/api/internal/runtimeapi/adapter.go
@@ -69,11 +69,11 @@ type adapterSessionResponse struct {
 func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -89,16 +89,16 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 
 	principal, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "no principal on request"})
+		writeAPIError(w, http.StatusUnauthorized, "no principal on request")
 		return
 	}
 
 	if req.ServerName == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "serverName is required"})
+		writeAPIError(w, http.StatusBadRequest, "serverName is required")
 		return
 	}
 	if req.AgentID == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agentID is required"})
+		writeAPIError(w, http.StatusBadRequest, "agentID is required")
 		return
 	}
 	if req.Namespace == "" {
@@ -107,7 +107,7 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 		req.Namespace = strings.TrimSpace(principal.Namespace)
 	}
 	if req.Namespace == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace is required"})
+		writeAPIError(w, http.StatusBadRequest, "namespace is required")
 		return
 	}
 
@@ -116,7 +116,7 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 		humanID = strings.TrimSpace(principal.Email)
 	}
 	if humanID == "" {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "principal has no subject or email"})
+		writeAPIError(w, http.StatusUnauthorized, "principal has no subject or email")
 		return
 	}
 
@@ -125,12 +125,12 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 
 	requestedTrust, err := parseAdapterTrust(req.RequestedTrust)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	requestedTTL, err := parseAdapterTTL(req.RequestedTTL)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -139,7 +139,7 @@ func (s *RuntimeServer) HandleAdapterSession(w http.ResponseWriter, r *http.Requ
 
 	grant, teamID, err := s.selectAdapterGrant(ctx, req.Namespace, req.ServerName, humanID, req.AgentID, teamIDs, defaultTeamID, principal.Role == roleAdmin)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 

--- a/services/api/internal/runtimeapi/components.go
+++ b/services/api/internal/runtimeapi/components.go
@@ -14,7 +14,7 @@ func (s *RuntimeServer) HandleDashboardSummary(w http.ResponseWriter, r *http.Re
 	// Get analytics data from ClickHouse
 	summary, err := s.db.QueryDashboardSummary(ctx)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to query dashboard summary"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to query dashboard summary")
 		return
 	}
 	if control := s.controlPlane(); control != nil {
@@ -54,11 +54,11 @@ func (s *RuntimeServer) HandleDashboardSummary(w http.ResponseWriter, r *http.Re
 // HandleRuntimeComponents returns admin-only health details for Sentinel platform components.
 func (s *RuntimeServer) HandleRuntimeComponents(w http.ResponseWriter, r *http.Request) {
 	if p, ok := principalFromContext(r.Context()); !ok || p.Role != roleAdmin {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	if s.sentinelMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -67,7 +67,7 @@ func (s *RuntimeServer) HandleRuntimeComponents(w http.ResponseWriter, r *http.R
 
 	statuses, err := s.sentinelMgr.GetAllComponentStatuses(ctx)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to get component statuses"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to get component statuses")
 		return
 	}
 

--- a/services/api/internal/runtimeapi/deployments.go
+++ b/services/api/internal/runtimeapi/deployments.go
@@ -78,7 +78,7 @@ func (s *RuntimeServer) HandleDeployments(w http.ResponseWriter, r *http.Request
 		s.handleDeploymentApply(w, r)
 	default:
 		w.Header().Set("allow", "GET, POST")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
@@ -86,44 +86,44 @@ func (s *RuntimeServer) HandleDeployments(w http.ResponseWriter, r *http.Request
 func (s *RuntimeServer) HandleDeploymentItem(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodDelete {
 		w.Header().Set("allow", "DELETE")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	ns, name, err := extractNamespaceName(r.URL.Path, "/api/deployments/")
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if p.Role != roleAdmin && (!p.HasNamespace(ns) || ns == sharedCatalogNamespace) {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_delete", "denied", name, ns, "", "forbidden"))
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	client, err := s.clientForPrincipal(p)
 	if err != nil {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_delete", "error", name, ns, "", err.Error()))
 		if errors.Is(err, errPrincipalIdentityRequired) {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user identity required"})
+			writeAPIError(w, http.StatusForbidden, "authenticated user identity required")
 			return
 		}
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
 	defer cancel()
 	if err := client.AppsV1().Deployments(ns).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_delete", "error", name, ns, "", err.Error()))
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete deployment"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to delete deployment")
 		return
 	}
 	if err := client.CoreV1().Services(ns).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_delete", "error", name, ns, "", err.Error()))
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete service"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to delete service")
 		return
 	}
 	s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_delete", "success", name, ns, "", ""))
@@ -133,11 +133,11 @@ func (s *RuntimeServer) HandleDeploymentItem(w http.ResponseWriter, r *http.Requ
 func (s *RuntimeServer) handleDeploymentList(w http.ResponseWriter, r *http.Request) {
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	if s.k8sClients == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
@@ -146,28 +146,28 @@ func (s *RuntimeServer) handleDeploymentList(w http.ResponseWriter, r *http.Requ
 			namespace = strings.TrimSpace(p.Namespace)
 		}
 		if namespace == "" {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			writeAPIError(w, http.StatusForbidden, "forbidden")
 			return
 		}
 		if !p.HasNamespace(namespace) || namespace == sharedCatalogNamespace {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			writeAPIError(w, http.StatusForbidden, "forbidden")
 			return
 		}
 	}
 	client, err := s.clientForPrincipal(p)
 	if err != nil {
 		if errors.Is(err, errPrincipalIdentityRequired) {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user identity required"})
+			writeAPIError(w, http.StatusForbidden, "authenticated user identity required")
 			return
 		}
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 	list, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{LabelSelector: platformManagedLabel + "=true"})
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list deployments"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to list deployments")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deployments": deploymentSummaries(list.Items)})
@@ -177,23 +177,23 @@ func (s *RuntimeServer) handleDeploymentList(w http.ResponseWriter, r *http.Requ
 func (s *RuntimeServer) HandleAdminDeployments(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("allow", http.MethodGet)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok || p.Role != roleAdmin {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	if s.k8sClients == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
 	namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	summaries, err := s.ListAdminDeploymentSummaries(r.Context(), namespace)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list deployments"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to list deployments")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deployments": summaries})
@@ -221,7 +221,7 @@ func (s *RuntimeServer) ListAdminDeploymentSummaries(ctx context.Context, namesp
 func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Request) {
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	var req deployRequest
@@ -241,7 +241,7 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	}
 	if req.Name == "" || req.Image == "" {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, firstNonEmpty(strings.TrimSpace(req.Namespace), p.Namespace), req.Image, "name and image are required"))
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and image are required"})
+		writeAPIError(w, http.StatusBadRequest, "name and image are required")
 		return
 	}
 	namespace := p.Namespace
@@ -253,19 +253,19 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	}
 	if namespace == "" {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, namespace, req.Image, "namespace required"))
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace required"})
+		writeAPIError(w, http.StatusBadRequest, "namespace required")
 		return
 	}
 	if p.Role != roleAdmin && (!p.HasNamespace(namespace) || namespace == sharedCatalogNamespace) {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, namespace, req.Image, "forbidden"))
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	image := req.Image
 	if req.Version != "" && !strings.Contains(image[strings.LastIndex(image, "/")+1:], ":") {
 		if !deployImageTagPattern.MatchString(req.Version) {
 			s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, namespace, req.Image, "version must be a valid image tag"))
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "version must be a valid image tag"})
+			writeAPIError(w, http.StatusBadRequest, "version must be a valid image tag")
 			return
 		}
 		image += ":" + req.Version
@@ -277,23 +277,23 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	}
 	if p.Role != roleAdmin && !teamNamespace {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, namespace, image, "tenant deployments require a team namespace"))
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "tenant deployments require a team namespace"})
+		writeAPIError(w, http.StatusForbidden, "tenant deployments require a team namespace")
 		return
 	}
 	image = ResolveDeployImageReference(image, namespace, teamSlug)
 	if err := ValidateDeployImage(image, namespace, teamSlug, p.Role); err != nil {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "denied", req.Name, namespace, image, err.Error()))
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	client, err := s.clientForPrincipal(p)
 	if err != nil {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
 		if errors.Is(err, errPrincipalIdentityRequired) {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "authenticated user identity required"})
+			writeAPIError(w, http.StatusForbidden, "authenticated user identity required")
 			return
 		}
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
@@ -306,12 +306,12 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 			Namespace: team.Namespace,
 		}); err != nil {
 			s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to ensure team namespace"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to ensure team namespace")
 			return
 		}
 		if err := s.ensureNamespaceUserWorkloadRBAC(ctx, namespace, p.UserID()); err != nil {
 			s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to ensure namespace access"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to ensure namespace access")
 			return
 		}
 	} else if p.Role == roleAdmin {
@@ -321,7 +321,7 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 		}
 		if err := s.ensureManagedNamespace(ctx, namespace, labels, managedNamespaceOptions{}); err != nil {
 			s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to ensure namespace"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to ensure namespace")
 			return
 		}
 	}
@@ -341,13 +341,13 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 	applied, err := upsertDeployment(ctx, client, dep)
 	if err != nil {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to apply deployment"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to apply deployment")
 		return
 	}
 	svc := desiredService(req.Name, namespace, req.Port, labels)
 	if _, err := upsertService(ctx, client, svc); err != nil {
 		s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to apply service"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to apply service")
 		return
 	}
 	s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "success", req.Name, namespace, image, ""))

--- a/services/api/internal/runtimeapi/deployments_test.go
+++ b/services/api/internal/runtimeapi/deployments_test.go
@@ -312,8 +312,9 @@ func TestHandleDeploymentApplyRejectsInvalidVersionTag(t *testing.T) {
 	if recorder.Code != http.StatusBadRequest {
 		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
 	}
-	if !strings.Contains(recorder.Body.String(), "version must be a valid image tag") {
-		t.Fatalf("body = %q, want invalid version message", recorder.Body.String())
+	wantBody := `{"error":"version_must_be_a_valid_image_tag","message":"version must be a valid image tag"}`
+	if strings.TrimSpace(recorder.Body.String()) != wantBody {
+		t.Fatalf("body = %q, want %s", recorder.Body.String(), wantBody)
 	}
 }
 

--- a/services/api/internal/runtimeapi/deps.go
+++ b/services/api/internal/runtimeapi/deps.go
@@ -2,10 +2,17 @@ package runtimeapi
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
+	"unicode"
+
+	"go.uber.org/zap"
 
 	"mcp-runtime/pkg/serviceutil"
 	"mcp-sentinel-api/internal/apiauth"
+	"mcp-sentinel-api/internal/apierr"
 	"mcp-sentinel-api/internal/apihttp"
 	"mcp-sentinel-api/internal/platformstore"
 )
@@ -51,7 +58,61 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 }
 
 func writeBodyDecodeError(w http.ResponseWriter, err error) {
-	apihttp.WriteBodyDecodeError(w, err)
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		writeAPIError(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("request body exceeds %d bytes", maxBytesErr.Limit), err)
+		return
+	}
+	writeAPIError(w, http.StatusBadRequest, "invalid request body", err)
+}
+
+func writeAPIError(w http.ResponseWriter, status int, message string, cause ...error) {
+	apierr.Write(w, zap.L(), newAPIError(status, errorCode(message, status), message, cause...))
+}
+
+func newAPIError(status int, code, message string, cause ...error) error {
+	switch status {
+	case http.StatusBadRequest:
+		return apierr.BadRequest(code, message, cause...)
+	case http.StatusUnauthorized:
+		return apierr.Unauthorized(code, message, cause...)
+	case http.StatusForbidden:
+		return apierr.Forbidden(code, message, cause...)
+	case http.StatusNotFound:
+		return apierr.NotFound(code, message, cause...)
+	case http.StatusConflict:
+		return apierr.Conflict(code, message, cause...)
+	case http.StatusInternalServerError:
+		return apierr.Internal(code, message, cause...)
+	case http.StatusServiceUnavailable:
+		return apierr.ServiceUnavailable(code, message, cause...)
+	default:
+		return &apierr.Error{Status: status, Code: code, Message: message, Cause: errors.Join(cause...)}
+	}
+}
+
+func errorCode(message string, status int) string {
+	if message = strings.TrimSpace(message); message == "" {
+		message = http.StatusText(status)
+	}
+	var b strings.Builder
+	previousUnderscore := false
+	for _, r := range strings.ToLower(message) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			previousUnderscore = false
+			continue
+		}
+		if !previousUnderscore && b.Len() > 0 {
+			b.WriteByte('_')
+			previousUnderscore = true
+		}
+	}
+	code := strings.Trim(b.String(), "_")
+	if code == "" {
+		return "error"
+	}
+	return code
 }
 
 func requestIP(r *http.Request) string {

--- a/services/api/internal/runtimeapi/policy.go
+++ b/services/api/internal/runtimeapi/policy.go
@@ -11,7 +11,7 @@ import (
 // HandleRuntimePolicy returns the rendered gateway policy for a server the caller can administer.
 func (s *RuntimeServer) HandleRuntimePolicy(w http.ResponseWriter, r *http.Request) {
 	if s.accessMgr == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 
@@ -20,13 +20,13 @@ func (s *RuntimeServer) HandleRuntimePolicy(w http.ResponseWriter, r *http.Reque
 
 	namespace, err := s.scopedNamespaceForPrincipal(r.Context(), r.URL.Query().Get("namespace"))
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	server := r.URL.Query().Get("server")
 
 	if strings.TrimSpace(namespace) == "" || server == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace and server parameters required"})
+		writeAPIError(w, http.StatusBadRequest, "namespace and server parameters required")
 		return
 	}
 	if allowed, err := s.canAdministerNamedServer(ctx, strings.TrimSpace(namespace), strings.TrimSpace(server)); err != nil {
@@ -34,16 +34,16 @@ func (s *RuntimeServer) HandleRuntimePolicy(w http.ResponseWriter, r *http.Reque
 		if code == http.StatusInternalServerError {
 			log.Printf("runtime policy: inspect server %s/%s failed: %v", namespace, server, err)
 		}
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	} else if !allowed {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 
 	policy, err := s.accessMgr.GetServerPolicy(ctx, strings.TrimSpace(namespace), server)
 	if err != nil {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "policy not found"})
+		writeAPIError(w, http.StatusNotFound, "policy not found")
 		return
 	}
 

--- a/services/api/internal/runtimeapi/publish_policy.go
+++ b/services/api/internal/runtimeapi/publish_policy.go
@@ -239,8 +239,9 @@ func (r *serverPublishPolicyRejection) retryAfterHeader() string {
 
 func (r *serverPublishPolicyRejection) payload() map[string]any {
 	payload := map[string]any{
-		"error": r.message,
-		"code":  r.code,
+		"error":   r.code,
+		"code":    r.code,
+		"message": r.message,
 	}
 	if !r.nextAllowedAt.IsZero() {
 		payload["next_allowed_at"] = r.nextAllowedAt.UTC().Format(time.RFC3339)

--- a/services/api/internal/runtimeapi/server_events.go
+++ b/services/api/internal/runtimeapi/server_events.go
@@ -13,26 +13,26 @@ import (
 func (s *RuntimeServer) HandleRuntimeServerEvents(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		w.Header().Set("allow", http.MethodGet)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
 	server := strings.TrimSpace(r.URL.Query().Get("server"))
 	if namespace == "" || server == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace and server are required"})
+		writeAPIError(w, http.StatusBadRequest, "namespace and server are required")
 		return
 	}
 	if s == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "analytics not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "analytics not available")
 		return
 	}
 	if p.Role != roleAdmin && !principalCanReadNamespace(p, namespace) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+		writeAPIError(w, http.StatusForbidden, "forbidden namespace")
 		return
 	}
 	if allowed, err := s.canAdministerNamedServer(r.Context(), namespace, server); err != nil {
@@ -40,14 +40,14 @@ func (s *RuntimeServer) HandleRuntimeServerEvents(w http.ResponseWriter, r *http
 		if code == http.StatusInternalServerError {
 			log.Printf("runtime server events: inspect server %s/%s failed: %v", namespace, server, err)
 		}
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	} else if !allowed {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden server"})
+		writeAPIError(w, http.StatusForbidden, "forbidden server")
 		return
 	}
 	if s.db == nil || s.db.Conn == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "analytics not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "analytics not available")
 		return
 	}
 	events, err := s.db.QueryEventsFiltered(r.Context(), chpkg.EventFilters{
@@ -56,7 +56,7 @@ func (s *RuntimeServer) HandleRuntimeServerEvents(w http.ResponseWriter, r *http
 		Limit:     clampServerEventsLimit(r.URL.Query().Get("limit")),
 	})
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "query_failed"})
+		writeAPIError(w, http.StatusInternalServerError, "query_failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"events": events})

--- a/services/api/internal/runtimeapi/servers.go
+++ b/services/api/internal/runtimeapi/servers.go
@@ -45,19 +45,19 @@ func (s *RuntimeServer) HandleRuntimeServers(w http.ResponseWriter, r *http.Requ
 		s.handleRuntimeServerApply(w, r)
 	default:
 		w.Header().Set("allow", "GET, POST")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 func (s *RuntimeServer) handleRuntimeServerList(w http.ResponseWriter, r *http.Request) {
 	control := s.controlPlane()
 	if control == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
@@ -71,7 +71,7 @@ func (s *RuntimeServer) handleRuntimeServerList(w http.ResponseWriter, r *http.R
 		if namespace == "" {
 			namespaces = catalogNamespacesForPrincipal(p)
 		} else if !principalCanReadNamespace(p, namespace) {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+			writeAPIError(w, http.StatusForbidden, "forbidden namespace")
 			return
 		}
 	} else if namespace == "" {
@@ -92,13 +92,13 @@ func (s *RuntimeServer) handleRuntimeServerList(w http.ResponseWriter, r *http.R
 	servers := make([]controlplane.ServerInfo, 0)
 	for _, namespace := range namespaces {
 		if p.Role != roleAdmin && !principalCanReadNamespace(p, namespace) {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+			writeAPIError(w, http.StatusForbidden, "forbidden namespace")
 			return
 		}
 
 		result, err := control.ListServers(ctx, namespace)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list servers"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to list servers")
 			return
 		}
 		if result.CRDError != nil && !apierrors.IsNotFound(result.CRDError) {
@@ -143,12 +143,12 @@ func dedupeNonEmptyStrings(values []string) []string {
 func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.Request) {
 	control := s.controlPlane()
 	if control == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 
@@ -163,25 +163,25 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 	req.Scope = strings.TrimSpace(req.Scope)
 	req.Spec.Image = strings.TrimSpace(req.Spec.Image)
 	if req.Name == "" || req.Spec.Image == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and spec.image are required"})
+		writeAPIError(w, http.StatusBadRequest, "name and spec.image are required")
 		return
 	}
 	scope, err := publishscope.Normalize(req.Scope)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	namespace, err := s.scopedNamespaceForServerApply(r.Context(), req.Namespace, scope)
 	if err != nil {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusForbidden, err.Error())
 		return
 	}
 	if p.Role != roleAdmin && namespace == sharedCatalogNamespace && !sharedCatalogWritableForUsers() {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "shared catalog namespace is read-only for team users"})
+		writeAPIError(w, http.StatusForbidden, "shared catalog namespace is read-only for team users")
 		return
 	}
 	if p.Role != roleAdmin && !principalCanPublishNamespace(p, namespace) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+		writeAPIError(w, http.StatusForbidden, "forbidden namespace")
 		return
 	}
 	namespaceTeamID := strings.TrimSpace(s.teamIDForPrincipalNamespace(r.Context(), namespace))
@@ -190,15 +190,15 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 		req.Spec.TeamID = namespaceTeamID
 	}
 	if err := validateTeamIDValue("spec.teamID", req.Spec.TeamID); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if namespaceTeamID != "" && req.Spec.TeamID != namespaceTeamID {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "spec.teamID must match namespace team"})
+		writeAPIError(w, http.StatusForbidden, "spec.teamID must match namespace team")
 		return
 	}
 	if p.Role != roleAdmin && namespaceTeamID == "" && req.Spec.TeamID != "" {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "spec.teamID is only allowed in a team namespace"})
+		writeAPIError(w, http.StatusForbidden, "spec.teamID is only allowed in a team namespace")
 		return
 	}
 	team, isTeamNamespace := p.TeamForNamespace(namespace)
@@ -208,7 +208,7 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 	}
 	req.Spec.Image = ResolveDeployImageReference(req.Spec.Image, namespace, teamSlug)
 	if err := ValidateDeployImage(req.Spec.Image, namespace, teamSlug, p.Role); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -230,20 +230,20 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 
 	if err := s.ensureServerApplyNamespace(ctx, p, namespace, team, isTeamNamespace); err != nil {
 		log.Printf("runtime servers: ensure namespace %q before apply failed: %v", namespace, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": serverApplyNamespaceEnsureError(p, namespace, isTeamNamespace)})
+		writeAPIError(w, http.StatusInternalServerError, serverApplyNamespaceEnsureError(p, namespace, isTeamNamespace))
 		return
 	}
 
 	current, err := control.GetServer(ctx, namespace, req.Name)
 	if err != nil && !apierrors.IsNotFound(err) {
 		log.Printf("runtime servers: fetch MCPServer %s/%s before apply failed: %v", namespace, req.Name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect existing server"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to inspect existing server")
 		return
 	}
 	if p.Role != roleAdmin && current != nil && !serverWritableByPrincipal(*current, p) {
 		msg := "server already exists and is not owned by this user"
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_publish", "denied", req.Name, namespace, req.Spec.Image, msg))
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": msg})
+		writeAPIError(w, http.StatusForbidden, msg)
 		return
 	}
 	// This is an API-layer guard. Strict global quota enforcement under highly
@@ -252,7 +252,7 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 	if err != nil {
 		log.Printf("runtime servers: evaluate publish policy for %s/%s failed: %v", namespace, req.Name, err)
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_publish", "error", req.Name, namespace, req.Spec.Image, err.Error()))
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to evaluate publish policy"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to evaluate publish policy")
 		return
 	}
 	if rejection != nil {
@@ -265,7 +265,7 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 	}
 	if err := s.applyPublishedServerDefaults(ctx, namespace, req.Name, &req.Spec); err != nil {
 		log.Printf("runtime servers: apply defaults for %s/%s failed: %v", namespace, req.Name, err)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to configure gateway analytics"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to configure gateway analytics")
 		return
 	}
 
@@ -313,7 +313,7 @@ func (s *RuntimeServer) handleRuntimeServerApply(w http.ResponseWriter, r *http.
 	if err != nil {
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_publish", "error", req.Name, namespace, req.Spec.Image, msg))
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	}
 	s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_publish", "success", req.Name, namespace, req.Spec.Image, ""))
@@ -638,28 +638,28 @@ func (s *RuntimeServer) HandleRuntimeServerItem(w http.ResponseWriter, r *http.R
 		s.handleRuntimeServerDelete(w, r)
 	default:
 		w.Header().Set("allow", "GET, DELETE")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 func (s *RuntimeServer) handleRuntimeServerGet(w http.ResponseWriter, r *http.Request) {
 	control := s.controlPlane()
 	if control == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	namespace, name, err := extractNamespaceName(r.URL.Path, "/api/runtime/servers/")
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if p.Role != roleAdmin && !principalCanReadNamespace(p, namespace) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+		writeAPIError(w, http.StatusForbidden, "forbidden namespace")
 		return
 	}
 
@@ -667,11 +667,11 @@ func (s *RuntimeServer) handleRuntimeServerGet(w http.ResponseWriter, r *http.Re
 	defer cancel()
 	info, err := control.GetServerInfo(ctx, namespace, name)
 	if apierrors.IsNotFound(err) {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "server not found"})
+		writeAPIError(w, http.StatusNotFound, "server not found")
 		return
 	}
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect server"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to inspect server")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"server": s.serverInfoWithRuntimeData(ctx, info, r)})
@@ -680,22 +680,22 @@ func (s *RuntimeServer) handleRuntimeServerGet(w http.ResponseWriter, r *http.Re
 func (s *RuntimeServer) handleRuntimeServerDelete(w http.ResponseWriter, r *http.Request) {
 	control := s.controlPlane()
 	if control == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "kubernetes not available"})
+		writeAPIError(w, http.StatusServiceUnavailable, "kubernetes not available")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	namespace, name, err := extractNamespaceName(r.URL.Path, "/api/runtime/servers/")
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if p.Role != roleAdmin && !principalCanPublishNamespace(p, namespace) {
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_retire", "denied", name, namespace, "", "forbidden namespace"))
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden namespace"})
+		writeAPIError(w, http.StatusForbidden, "forbidden namespace")
 		return
 	}
 
@@ -708,19 +708,19 @@ func (s *RuntimeServer) handleRuntimeServerDelete(w http.ResponseWriter, r *http
 	}
 	if err != nil {
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_retire", "error", name, namespace, "", err.Error()))
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to inspect server"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to inspect server")
 		return
 	}
 	if p.Role != roleAdmin && !serverWritableByPrincipal(*current, p) {
 		msg := "server is not owned by this user"
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_retire", "denied", name, namespace, "", msg))
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": msg})
+		writeAPIError(w, http.StatusForbidden, msg)
 		return
 	}
 	if err := control.DeleteServer(ctx, namespace, name); err != nil {
 		s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_retire", "error", name, namespace, current.Spec.Image, err.Error()))
 		code, msg := k8sclient.HTTPStatusFromK8sError(err)
-		writeJSON(w, code, map[string]string{"error": msg})
+		writeAPIError(w, code, msg)
 		return
 	}
 	s.writeAudit(r.Context(), serverPublishAuditEvent(r, p, "server_retire", "success", name, namespace, current.Spec.Image, ""))

--- a/services/api/internal/runtimeapi/teams.go
+++ b/services/api/internal/runtimeapi/teams.go
@@ -14,12 +14,12 @@ import (
 // HandleRuntimeTeams lists visible teams and lets admins create team identity records.
 func (s *RuntimeServer) HandleRuntimeTeams(w http.ResponseWriter, r *http.Request) {
 	if s.platform == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		writeAPIError(w, http.StatusServiceUnavailable, "platform identity database not configured")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	switch r.Method {
@@ -27,31 +27,31 @@ func (s *RuntimeServer) HandleRuntimeTeams(w http.ResponseWriter, r *http.Reques
 		s.handleRuntimeTeamList(w, r, p)
 	case http.MethodPost:
 		if p.Role != roleAdmin {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+			writeAPIError(w, http.StatusForbidden, "forbidden")
 			return
 		}
 		s.handleRuntimeTeamCreate(w, r, p)
 	default:
 		w.Header().Set("allow", "GET, POST")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 // HandleRuntimeTeamItemPath routes team detail, membership, and team-user operations after role checks.
 func (s *RuntimeServer) HandleRuntimeTeamItemPath(w http.ResponseWriter, r *http.Request) {
 	if s.platform == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		writeAPIError(w, http.StatusServiceUnavailable, "platform identity database not configured")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/runtime/teams/"), "/")
 	parts := strings.Split(path, "/")
 	if len(parts) == 0 || strings.TrimSpace(parts[0]) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid path"})
+		writeAPIError(w, http.StatusBadRequest, "invalid path")
 		return
 	}
 	teamSlug := NormalizeTeamSlug(parts[0])
@@ -74,24 +74,24 @@ func (s *RuntimeServer) HandleRuntimeTeamItemPath(w http.ResponseWriter, r *http
 		return
 	default:
 		w.Header().Set("allow", "GET, POST, DELETE")
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 	}
 }
 
 // HandleRuntimeNamespaces lists namespaces visible to the caller, including catalog namespace entries for the current platform mode.
 func (s *RuntimeServer) HandleRuntimeNamespaces(w http.ResponseWriter, r *http.Request) {
 	if s.platform == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		writeAPIError(w, http.StatusServiceUnavailable, "platform identity database not configured")
 		return
 	}
 	if r.Method != http.MethodGet {
 		w.Header().Set("allow", http.MethodGet)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
@@ -100,7 +100,7 @@ func (s *RuntimeServer) HandleRuntimeNamespaces(w http.ResponseWriter, r *http.R
 	if p.Role == roleAdmin {
 		namespaces, err := s.platform.ListNamespaces(ctx)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list namespaces"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to list namespaces")
 			return
 		}
 		namespaces = appendCatalogNamespaceEntries(namespaces)
@@ -142,28 +142,28 @@ func (s *RuntimeServer) HandleRuntimeNamespaces(w http.ResponseWriter, r *http.R
 // HandleRuntimeNamespaceItem returns one visible namespace record or synthetic catalog namespace entry.
 func (s *RuntimeServer) HandleRuntimeNamespaceItem(w http.ResponseWriter, r *http.Request) {
 	if s.platform == nil {
-		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "platform identity database not configured"})
+		writeAPIError(w, http.StatusServiceUnavailable, "platform identity database not configured")
 		return
 	}
 	if r.Method != http.MethodGet {
 		w.Header().Set("allow", http.MethodGet)
-		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method_not_allowed"})
+		writeAPIError(w, http.StatusMethodNotAllowed, "method_not_allowed")
 		return
 	}
 	p, ok := principalFromContext(r.Context())
 	if !ok {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		writeAPIError(w, http.StatusUnauthorized, "unauthorized")
 		return
 	}
 	namespace := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/api/runtime/namespaces/"))
 	namespace = strings.Trim(namespace, "/")
 	if namespace == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace required"})
+		writeAPIError(w, http.StatusBadRequest, "namespace required")
 		return
 	}
 
 	if p.Role != roleAdmin && !principalCanReadNamespace(p, namespace) {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 
@@ -171,7 +171,7 @@ func (s *RuntimeServer) HandleRuntimeNamespaceItem(w http.ResponseWriter, r *htt
 	defer cancel()
 	item, ok, err := s.platform.GetNamespace(ctx, namespace)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch namespace"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to fetch namespace")
 		return
 	}
 	if ok {
@@ -187,7 +187,7 @@ func (s *RuntimeServer) HandleRuntimeNamespaceItem(w http.ResponseWriter, r *htt
 		writeJSON(w, http.StatusOK, map[string]any{"namespace": entry})
 		return
 	}
-	writeJSON(w, http.StatusNotFound, map[string]string{"error": "namespace not found"})
+	writeAPIError(w, http.StatusNotFound, "namespace not found")
 }
 
 func catalogNamespaceEntry(namespace string) map[string]any {
@@ -238,7 +238,7 @@ func (s *RuntimeServer) handleRuntimeTeamList(w http.ResponseWriter, r *http.Req
 	if p.Role == roleAdmin {
 		teams, err := s.platform.ListTeams(ctx)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list teams"})
+			writeAPIError(w, http.StatusInternalServerError, "failed to list teams")
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"teams": teams})
@@ -246,7 +246,7 @@ func (s *RuntimeServer) handleRuntimeTeamList(w http.ResponseWriter, r *http.Req
 	}
 	teams, err := s.platform.ListUserTeams(ctx, p.UserID())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list teams"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to list teams")
 		return
 	}
 	out := make([]teamRecord, 0, len(teams))
@@ -267,15 +267,15 @@ func (s *RuntimeServer) handleRuntimeTeamGet(w http.ResponseWriter, r *http.Requ
 	defer cancel()
 	team, ok, err := s.platform.GetTeamBySlug(ctx, teamSlug)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch team"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to fetch team")
 		return
 	}
 	if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "team not found"})
+		writeAPIError(w, http.StatusNotFound, "team not found")
 		return
 	}
 	if p.Role != roleAdmin && p.TeamRole(teamSlug) == "" {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"team": team})
@@ -297,14 +297,14 @@ func (s *RuntimeServer) handleRuntimeTeamCreate(w http.ResponseWriter, r *http.R
 	team, err := s.platform.CreateTeam(ctx, req.Slug, req.Name, p.UserID())
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "duplicate") || strings.Contains(strings.ToLower(err.Error()), "unique") {
-			writeJSON(w, http.StatusConflict, map[string]string{"error": "team already exists"})
+			writeAPIError(w, http.StatusConflict, "team already exists")
 			return
 		}
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := s.ensureTeamNamespace(ctx, team); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to provision team namespace"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to provision team namespace")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"team": team})
@@ -312,14 +312,14 @@ func (s *RuntimeServer) handleRuntimeTeamCreate(w http.ResponseWriter, r *http.R
 
 func (s *RuntimeServer) handleRuntimeTeamMemberList(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
 	if p.Role != roleAdmin && p.TeamRole(teamSlug) == "" {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 	memberships, err := s.platform.ListTeamMemberships(ctx, teamSlug)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list team members"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to list team members")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"members": memberships})
@@ -327,7 +327,7 @@ func (s *RuntimeServer) handleRuntimeTeamMemberList(w http.ResponseWriter, r *ht
 
 func (s *RuntimeServer) handleRuntimeTeamMemberUpsert(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
 	if p.Role != roleAdmin && p.TeamRole(teamSlug) != teamRoleOwner {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	var req struct {
@@ -344,10 +344,10 @@ func (s *RuntimeServer) handleRuntimeTeamMemberUpsert(w http.ResponseWriter, r *
 	membership, err := s.platform.UpsertTeamMembership(ctx, teamSlug, req.UserID, req.Role)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "team or user not found"})
+			writeAPIError(w, http.StatusNotFound, "team or user not found")
 			return
 		}
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"membership": membership})
@@ -355,7 +355,7 @@ func (s *RuntimeServer) handleRuntimeTeamMemberUpsert(w http.ResponseWriter, r *
 
 func (s *RuntimeServer) handleRuntimeTeamUserCreate(w http.ResponseWriter, r *http.Request, p principal, teamSlug string) {
 	if p.Role != roleAdmin {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "admin role required"})
+		writeAPIError(w, http.StatusForbidden, "admin role required")
 		return
 	}
 	var req struct {
@@ -373,30 +373,30 @@ func (s *RuntimeServer) handleRuntimeTeamUserCreate(w http.ResponseWriter, r *ht
 		membershipRole = teamRoleMember
 	}
 	if membershipRole != teamRoleMember && membershipRole != teamRoleOwner {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role must be member or owner"})
+		writeAPIError(w, http.StatusBadRequest, "role must be member or owner")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 	if _, ok, err := s.platform.GetTeamBySlug(ctx, teamSlug); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch team"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to fetch team")
 		return
 	} else if !ok {
-		writeJSON(w, http.StatusNotFound, map[string]string{"error": "team not found"})
+		writeAPIError(w, http.StatusNotFound, "team not found")
 		return
 	}
 	u, err := s.platform.EnsureTeamPasswordUser(ctx, req.Email, req.Password)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	membership, err := s.platform.UpsertTeamMembership(ctx, teamSlug, u.ID, membershipRole)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "team or user not found"})
+			writeAPIError(w, http.StatusNotFound, "team or user not found")
 			return
 		}
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		writeAPIError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	membership.Email = u.Email
@@ -416,17 +416,17 @@ func (s *RuntimeServer) handleRuntimeTeamUserCreate(w http.ResponseWriter, r *ht
 
 func (s *RuntimeServer) handleRuntimeTeamMemberDelete(w http.ResponseWriter, r *http.Request, p principal, teamSlug, userID string) {
 	if p.Role != roleAdmin && p.TeamRole(teamSlug) != teamRoleOwner {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		writeAPIError(w, http.StatusForbidden, "forbidden")
 		return
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 	if err := s.platform.DeleteTeamMembership(ctx, teamSlug, userID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "membership not found"})
+			writeAPIError(w, http.StatusNotFound, "membership not found")
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete membership"})
+		writeAPIError(w, http.StatusInternalServerError, "failed to delete membership")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/services/ui/static/app.js
+++ b/services/ui/static/app.js
@@ -90,6 +90,7 @@ function readErrorMessage(err, fallback) {
   if (!message) return fallback;
   try {
     const parsed = JSON.parse(message);
+    if (parsed?.message) return parsed.message;
     if (parsed?.error) return parsed.error;
   } catch (_) {
     // Use the plain error text below.


### PR DESCRIPTION
## Motivation

Sentinel API runtime handlers repeatedly rendered ad hoc `writeJSON(..., map[string]string{"error": ...})` responses. This adds a typed helper so runtime API errors share a consistent status/code/message contract while keeping the existing `error` field name for compatibility.

## Design

- Added `services/api/internal/apierr` with `Error{Status, Code, Message, Cause}` plus `Error()` and `Unwrap()`.
- Added constructors: `BadRequest`, `Unauthorized`, `Forbidden`, `NotFound`, `Conflict`, `Internal`, and `ServiceUnavailable`.
- Added `apierr.Write(w, logger, err)` to render typed errors as `{"error":"<code>","message":"<safe message>"}` and generic errors as a safe internal error while logging causes server-side.
- Adopted the helper in `services/api/internal/runtimeapi` for prior error response paths, keeping success responses on the existing JSON helper.

## UI compatibility

Ran `grep -rn 'json\.error\|err\.error\|"error"' services/ui/static/` after rebasing onto current `origin/main`. It found toast/status string usage only; no consumer expecting `error` as an object.

## Test plan

- `cd services/api && go test ./... -race -count=1` - passed
- `gofmt -s -l .` - passed, no output
- `go vet ./...` from repo root - passed
- `cd services/api && go vet ./...` - passed
- `staticcheck ./...` from repo root - passed
- `cd services/api && staticcheck ./...` - failed on pre-existing unused-symbol findings in `authz.go`, `internal/runtimeapi/deps.go`, `internal/runtimeapi/servers.go`, and `internal/runtimeapi/user_keys.go`
- `pre-commit run --all-files` - failed in `go-integration-tests` because adapter stdio tests timed out waiting for stdout; targeted rerun `go test ./test/integration -run 'TestAdapterStdio(SessionRequiredHappyPath|AnonymousModeBlocksDisallowedMethod)' -count=1 -v` passed
- Manual API invalid JSON check not run; no local API environment was started

Refs #235