### PR TITLE
fix(k8sclient): use client-go for platform setup operations

### DIFF
--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -4480,6 +4480,7 @@ _No package overview is documented._
 - [`func ApplyRegistryCertificateForACME(kubectl core.KubectlRunner, dnsNames []string, issuerName string) error`](#cli-cert-manager-func-applyregistrycertificateforacme-kubectl-core-kubectlrunner-dnsnames-string-issuername-string-error)
 - [`func ApplyRegistryCertificateWithKubectl(kubectl core.KubectlRunner) error`](#cli-cert-manager-func-applyregistrycertificatewithkubectl-kubectl-core-kubectlrunner-error)
 - [`func ApplyRegistryInternalCertificate(kubectl core.KubectlRunner, dnsNames, ipAddresses []string, issuerName string) error`](#cli-cert-manager-func-applyregistryinternalcertificate-kubectl-core-kubectlrunner-dnsnames-ipaddresses-string-issuername-string-error)
+- [`func CertManagerInstallManifestURL() string`](#cli-cert-manager-func-certmanagerinstallmanifesturl-string)
 - [`func CheckCASecretWithKubectl(kubectl core.KubectlRunner) error`](#cli-cert-manager-func-checkcasecretwithkubectl-kubectl-core-kubectlrunner-error)
 - [`func CheckCertManagerInstalledWithKubectl(kubectl core.KubectlRunner) error`](#cli-cert-manager-func-checkcertmanagerinstalledwithkubectl-kubectl-core-kubectlrunner-error)
 - [`func CheckCertificateWithKubectl(kubectl core.KubectlRunner, name, namespace string) error`](#cli-cert-manager-func-checkcertificatewithkubectl-kubectl-core-kubectlrunner-name-namespace-string-error)
@@ -4491,6 +4492,9 @@ _No package overview is documented._
 - [`func EnsureCertManagerInstalled(kubectl core.KubectlRunner, logger *zap.Logger) error`](#cli-cert-manager-func-ensurecertmanagerinstalled-kubectl-core-kubectlrunner-logger-zap-logger-error)
 - [`func PreflightACMEHostnamesPort80(dnsNames []string)`](#cli-cert-manager-func-preflightacmehostnamesport80-dnsnames-string)
 - [`func RemoveRegistryIngressShimAnnotationWithKubectl(kubectl core.KubectlRunner) error`](#cli-cert-manager-func-removeregistryingressshimannotationwithkubectl-kubectl-core-kubectlrunner-error)
+- [`func RenderGeneratedCASecretManifest(now time.Time) (string, error)`](#cli-cert-manager-func-rendergeneratedcasecretmanifest-now-time-time-string-error)
+- [`func RenderLetsEncryptClusterIssuerManifest(name, email, serverURL string) string`](#cli-cert-manager-func-renderletsencryptclusterissuermanifest-name-email-serverurl-string-string)
+- [`func RenderRegistryCertificate(certName, secretName string, dnsNames, ipAddresses []string, issuerName string) string`](#cli-cert-manager-func-renderregistrycertificate-certname-secretname-string-dnsnames-ipaddresses-string-issuername-string-string)
 - [`func ValidateACMEHostnameForPublicCA() error`](#cli-cert-manager-func-validateacmehostnameforpublicca-error)
 - [`func ValidateIngressManifestForACME(ingressManifest string) error`](#cli-cert-manager-func-validateingressmanifestforacme-ingressmanifest-string-error)
 - [`func WaitForCertificateReadyWithKubectl(kubectl core.KubectlRunner, name, namespace string, timeout time.Duration) error`](#cli-cert-manager-func-waitforcertificatereadywithkubectl-kubectl-core-kubectlrunner-name-namespace-string-timeout-time-duration-error)
@@ -4552,6 +4556,11 @@ func ApplyRegistryCertificateWithKubectl(kubectl core.KubectlRunner) error
 func ApplyRegistryInternalCertificate(kubectl core.KubectlRunner, dnsNames, ipAddresses []string, issuerName string) error
 ```
 
+<a id="cli-cert-manager-func-certmanagerinstallmanifesturl-string"></a>
+```text
+func CertManagerInstallManifestURL() string
+```
+
 <a id="cli-cert-manager-func-checkcasecretwithkubectl-kubectl-core-kubectlrunner-error"></a>
 ```text
 func CheckCASecretWithKubectl(kubectl core.KubectlRunner) error
@@ -4608,6 +4617,21 @@ func PreflightACMEHostnamesPort80(dnsNames []string)
 <a id="cli-cert-manager-func-removeregistryingressshimannotationwithkubectl-kubectl-core-kubectlrunner-error"></a>
 ```text
 func RemoveRegistryIngressShimAnnotationWithKubectl(kubectl core.KubectlRunner) error
+```
+
+<a id="cli-cert-manager-func-rendergeneratedcasecretmanifest-now-time-time-string-error"></a>
+```text
+func RenderGeneratedCASecretManifest(now time.Time) (string, error)
+```
+
+<a id="cli-cert-manager-func-renderletsencryptclusterissuermanifest-name-email-serverurl-string-string"></a>
+```text
+func RenderLetsEncryptClusterIssuerManifest(name, email, serverURL string) string
+```
+
+<a id="cli-cert-manager-func-renderregistrycertificate-certname-secretname-string-dnsnames-ipaddresses-string-issuername-string-string"></a>
+```text
+func RenderRegistryCertificate(certName, secretName string, dnsNames, ipAddresses []string, issuerName string) string
 ```
 
 <a id="cli-cert-manager-func-validateacmehostnameforpublicca-error"></a>

--- a/internal/cli/certmanager/letsencrypt.go
+++ b/internal/cli/certmanager/letsencrypt.go
@@ -34,6 +34,10 @@ func certManagerInstallManifestURL() string {
 	return fmt.Sprintf("https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml", certManagerRelease)
 }
 
+func CertManagerInstallManifestURL() string {
+	return certManagerInstallManifestURL()
+}
+
 // ClusterIssuerNameForACME returns the ClusterIssuer resource name for Let's Encrypt.
 func ClusterIssuerNameForACME(staging bool) string {
 	if staging {
@@ -298,6 +302,10 @@ func renderLetsEncryptClusterIssuerManifest(name, email, serverURL string) strin
 	return b.String()
 }
 
+func RenderLetsEncryptClusterIssuerManifest(name, email, serverURL string) string {
+	return renderLetsEncryptClusterIssuerManifest(name, email, serverURL)
+}
+
 func applyRegistryCertificate(kubectl core.KubectlRunner, dnsNames, ipAddresses []string, issuerName string) error {
 	return applyCertificate(kubectl, registryCertificateName, registryTLSSecretName, dnsNames, ipAddresses, issuerName)
 }
@@ -388,4 +396,8 @@ func renderRegistryCertificate(certName, secretName string, dnsNames, ipAddresse
 		}
 	}
 	return b.String()
+}
+
+func RenderRegistryCertificate(certName, secretName string, dnsNames, ipAddresses []string, issuerName string) string {
+	return renderRegistryCertificate(certName, secretName, dnsNames, ipAddresses, issuerName)
 }

--- a/internal/cli/certmanager/manager.go
+++ b/internal/cli/certmanager/manager.go
@@ -264,6 +264,10 @@ func renderGeneratedCASecretManifest(now time.Time) (string, error) {
 	return string(data), nil
 }
 
+func RenderGeneratedCASecretManifest(now time.Time) (string, error) {
+	return renderGeneratedCASecretManifest(now)
+}
+
 func generateInternalCAPEM(now time.Time) ([]byte, []byte, error) {
 	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serial, err := rand.Int(rand.Reader, serialLimit)

--- a/internal/cli/cluster/doctor/doctor_impl_test.go
+++ b/internal/cli/cluster/doctor/doctor_impl_test.go
@@ -566,7 +566,13 @@ func TestCheckRegistryReachableFromCluster(t *testing.T) {
 	t.Run("ok on HTTP 200", func(t *testing.T) {
 		mock := &core.MockExecutor{
 			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-				return &core.MockCommand{OutputData: []byte("HTTP/1.1 200 OK\nDocker-Distribution-Api-Version: registry/2.0\n")}
+				switch {
+				case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "pod"):
+					return &core.MockCommand{OutputData: []byte("Succeeded")}
+				case len(spec.Args) > 0 && spec.Args[0] == "logs":
+					return &core.MockCommand{OutputData: []byte("HTTP/1.1 200 OK\nDocker-Distribution-Api-Version: registry/2.0\n")}
+				}
+				return &core.MockCommand{}
 			},
 		}
 		kubectl := core.NewTestKubectlClient(mock)
@@ -576,10 +582,51 @@ func TestCheckRegistryReachableFromCluster(t *testing.T) {
 		}
 	})
 
+	t.Run("reads completed pod logs instead of attach output", func(t *testing.T) {
+		var runArgs []string
+		mock := &core.MockExecutor{
+			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
+				switch {
+				case len(spec.Args) > 0 && spec.Args[0] == "run":
+					runArgs = append([]string(nil), spec.Args...)
+					return &core.MockCommand{}
+				case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "pod"):
+					return &core.MockCommand{OutputData: []byte("Succeeded")}
+				case len(spec.Args) > 0 && spec.Args[0] == "logs":
+					return &core.MockCommand{OutputData: []byte("HTTP/1.1 200 OK\n")}
+				}
+				return &core.MockCommand{OutputData: []byte("HTTP/1.1 200 OK\nDocker-Distribution-Api-Version: registry/2.0\n")}
+			},
+		}
+		kubectl := core.NewTestKubectlClient(mock)
+		check := checkRegistryReachableFromCluster(kubectl)
+		if !check.OK {
+			t.Fatalf("expected OK, got detail=%q", check.Detail)
+		}
+		for _, notWant := range []string{"--attach", "--rm"} {
+			if contains(runArgs, notWant) {
+				t.Fatalf("registry reachability probe should read completed pod logs instead of using %s, got args=%v", notWant, runArgs)
+			}
+		}
+		overrides := argValueWithPrefix(runArgs, "--overrides=")
+		if overrides == "" {
+			t.Fatalf("registry reachability probe should use restricted-compliant overrides, got args=%v", runArgs)
+		}
+		if !strings.Contains(overrides, "registry.registry.svc.cluster.local:5000/v2/") {
+			t.Fatalf("registry reachability override missing registry URL: %s", overrides)
+		}
+	})
+
 	t.Run("fails on non-200", func(t *testing.T) {
 		mock := &core.MockExecutor{
 			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
+				switch {
+				case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "pod"):
+					return &core.MockCommand{OutputData: []byte("Succeeded")}
+				case len(spec.Args) > 0 && spec.Args[0] == "logs":
+					return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
+				}
+				return &core.MockCommand{}
 			},
 		}
 		kubectl := core.NewTestKubectlClient(mock)
@@ -592,7 +639,13 @@ func TestCheckRegistryReachableFromCluster(t *testing.T) {
 	t.Run("does not false-pass when body includes non-status 200", func(t *testing.T) {
 		mock := &core.MockExecutor{
 			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-				return &core.MockCommand{OutputData: []byte("diagnostic: 200 retries\nHTTP/1.1 503 Service Unavailable\n")}
+				switch {
+				case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "pod"):
+					return &core.MockCommand{OutputData: []byte("Succeeded")}
+				case len(spec.Args) > 0 && spec.Args[0] == "logs":
+					return &core.MockCommand{OutputData: []byte("diagnostic: 200 retries\nHTTP/1.1 503 Service Unavailable\n")}
+				}
+				return &core.MockCommand{}
 			},
 		}
 		kubectl := core.NewTestKubectlClient(mock)
@@ -1053,6 +1106,10 @@ func TestRunDoctorAggregates(t *testing.T) {
 				return &core.MockCommand{OutputData: []byte("docker-pullable://registry.k8s.io/pause@sha256:test")}
 			case contains(spec.Args, "get") && contains(spec.Args, "pods") && argContains(spec.Args, "spec.nodeName"):
 				return &core.MockCommand{OutputData: []byte("node-a")}
+			case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "jsonpath={.status.phase}"):
+				return &core.MockCommand{OutputData: []byte("Succeeded")}
+			case len(spec.Args) > 0 && spec.Args[0] == "logs":
+				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
 			case contains(spec.Args, "curl"):
 				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
 			}
@@ -1094,6 +1151,10 @@ func TestRunDoctorWithProgressReportsEachCheck(t *testing.T) {
 				return &core.MockCommand{OutputData: []byte("docker-pullable://registry.k8s.io/pause@sha256:test")}
 			case contains(spec.Args, "get") && contains(spec.Args, "pods") && argContains(spec.Args, "spec.nodeName"):
 				return &core.MockCommand{OutputData: []byte("node-a")}
+			case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "jsonpath={.status.phase}"):
+				return &core.MockCommand{OutputData: []byte("Succeeded")}
+			case len(spec.Args) > 0 && spec.Args[0] == "logs":
+				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
 			case contains(spec.Args, "curl"):
 				return &core.MockCommand{OutputData: []byte("HTTP/1.1 503 Service Unavailable\n")}
 			}
@@ -2078,6 +2139,10 @@ func TestRegistryReachabilityUsesHTTPSForInternalTLSRegistry(t *testing.T) {
 				return &core.MockCommand{OutputData: []byte("registry-internal-tls")}
 			case len(spec.Args) > 0 && spec.Args[0] == "run":
 				runArgs = append([]string(nil), spec.Args...)
+				return &core.MockCommand{}
+			case len(spec.Args) > 0 && spec.Args[0] == "get" && contains(spec.Args, "pod"):
+				return &core.MockCommand{OutputData: []byte("Succeeded")}
+			case len(spec.Args) > 0 && spec.Args[0] == "logs":
 				return &core.MockCommand{OutputData: []byte("HTTP/2 200\r\n")}
 			}
 			return &core.MockCommand{OutputErr: fmt.Errorf("unexpected command: %v", spec.Args)}
@@ -2089,10 +2154,10 @@ func TestRegistryReachabilityUsesHTTPSForInternalTLSRegistry(t *testing.T) {
 	if !check.OK {
 		t.Fatalf("expected registry probe to pass, got detail=%q", check.Detail)
 	}
-	if !contains(runArgs, "https://registry.registry.svc.cluster.local:5000/v2/") {
+	if !argContains(runArgs, "https://registry.registry.svc.cluster.local:5000/v2/") {
 		t.Fatalf("registry probe should use HTTPS when registry-internal-tls exists, got args=%v", runArgs)
 	}
-	if !contains(runArgs, "-skI") {
+	if !argContains(runArgs, "-skI") {
 		t.Fatalf("registry probe should allow the internal CA probe with -k, got args=%v", runArgs)
 	}
 }

--- a/internal/cli/cluster/doctor/doctor_registry.go
+++ b/internal/cli/cluster/doctor/doctor_registry.go
@@ -40,16 +40,21 @@ func checkRegistryService(kubectl core.KubectlRunner) DoctorCheck {
 // non-destructively.
 func checkRegistryReachableFromCluster(kubectl core.KubectlRunner) DoctorCheck {
 	podName := fmt.Sprintf("mcp-runtime-doctor-curl-%d", time.Now().UnixNano())
+	image := "curlimages/curl:8.7.1"
 	registryURL := doctorRegistryServiceURL(kubectl)
-	args := []string{
-		"run", "-n", "registry",
-		"--rm", "--restart=Never", "--attach",
-		"--pod-running-timeout=" + doctorProbePodRunTimeout,
-		"--quiet",
-		"--image=curlimages/curl:8.7.1",
-		podName,
-		"--command", "--", "curl", "-skI", "--connect-timeout", "5", "--max-time", "15",
+	curlArgs := []string{
+		"-skI", "--connect-timeout", "5", "--max-time", "15",
 		registryURL,
+	}
+	defer func() {
+		_ = kubectl.Run([]string{"delete", "pod", podName, "-n", "registry", "--ignore-not-found"})
+	}()
+	args := []string{
+		"run", podName,
+		"-n", "registry",
+		"--restart=Never",
+		"--image=" + image,
+		"--overrides=" + restrictedRunOverrides(podName, image, "curl", curlArgs...),
 	}
 	cmd, err := kubectl.CommandArgs(args)
 	if err != nil {
@@ -60,14 +65,39 @@ func checkRegistryReachableFromCluster(kubectl core.KubectlRunner) DoctorCheck {
 			Remedy: "check cluster connectivity and kubeconfig",
 		}
 	}
-	out, runErr := cmd.CombinedOutput()
-	body := string(out)
+	createOut, runErr := cmd.CombinedOutput()
 	if runErr != nil {
+		detail := fmt.Sprintf("helper pod failed: %v", runErr)
+		if strings.TrimSpace(string(createOut)) != "" {
+			detail += ": " + strings.TrimSpace(string(createOut))
+		}
 		return DoctorCheck{
 			Name:   "registry reachability (in-cluster)",
 			OK:     false,
-			Detail: fmt.Sprintf("helper pod failed: %v", runErr),
+			Detail: detail,
 			Remedy: "run `./bin/mcp-runtime setup` if the registry is missing; check `kubectl -n registry get pods`",
+		}
+	}
+	if err := waitForDoctorPodSucceeded(kubectl, podName, "registry", 90*time.Second); err != nil {
+		logs, _ := readKubectlOutput(kubectl, []string{"logs", podName, "-n", "registry", "--tail=50"})
+		detail := fmt.Sprintf("helper pod did not succeed: %v", err)
+		if strings.TrimSpace(logs) != "" {
+			detail += ": " + strings.TrimSpace(logs)
+		}
+		return DoctorCheck{
+			Name:   "registry reachability (in-cluster)",
+			OK:     false,
+			Detail: detail,
+			Remedy: "run `./bin/mcp-runtime setup` if the registry is missing; check `kubectl -n registry get pods`",
+		}
+	}
+	body, logsErr := readKubectlOutput(kubectl, []string{"logs", podName, "-n", "registry"})
+	if logsErr != nil {
+		return DoctorCheck{
+			Name:   "registry reachability (in-cluster)",
+			OK:     false,
+			Detail: fmt.Sprintf("failed reading helper pod logs: %v", logsErr),
+			Remedy: "inspect pod events: `kubectl -n registry describe pod " + podName + "`",
 		}
 	}
 	if !hasHTTP200Status(body) {

--- a/internal/cli/setup/platform/flow.go
+++ b/internal/cli/setup/platform/flow.go
@@ -176,7 +176,7 @@ func existingPublicAuthConfigForSetup(plan setupplan.Plan) (map[string]string, e
 	if publicBrowserLoginConfigConfigured(nil) {
 		return nil, nil
 	}
-	return existingConfigMapData(core.DefaultKubectlClient(), core.DefaultAnalyticsNamespace, "mcp-sentinel-config")
+	return existingConfigMapDataClientGo(core.DefaultAnalyticsNamespace, "mcp-sentinel-config")
 }
 
 func platformAdminEnvConfigured() bool {

--- a/internal/cli/setup/platform/helpers_test.go
+++ b/internal/cli/setup/platform/helpers_test.go
@@ -1698,6 +1698,7 @@ func TestDeployAnalyticsManifestsWithKubectl_RecreatesClickhouseInitJob(t *testi
 		core.DefaultCLIConfig = orig
 	})
 	core.DefaultCLIConfig = &core.CLIConfig{}
+	swapKubernetesClientsForTest(t, newPlatformKubernetesTestClients(nil, nil))
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -1898,6 +1899,7 @@ func TestDeployAnalyticsManifestsReturnsRolloutFailures(t *testing.T) {
 		core.DefaultCLIConfig = orig
 	})
 	core.DefaultCLIConfig = &core.CLIConfig{}
+	swapKubernetesClientsForTest(t, newPlatformKubernetesTestClients(nil, nil))
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -1990,6 +1992,7 @@ func TestDeployAnalyticsManifestsWithKubectl_HostpathUsesHostpathManifests(t *te
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() { core.DefaultCLIConfig = orig })
 	core.DefaultCLIConfig = &core.CLIConfig{}
+	swapKubernetesClientsForTest(t, newPlatformKubernetesTestClients(nil, nil))
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -2057,6 +2060,7 @@ func TestDeployAnalyticsManifestsWithKubectl_WaitsForPostgresStatefulSet(t *test
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() { core.DefaultCLIConfig = orig })
 	core.DefaultCLIConfig = &core.CLIConfig{}
+	swapKubernetesClientsForTest(t, newPlatformKubernetesTestClients(nil, nil))
 
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/cli/setup/platform/helpers_test.go
+++ b/internal/cli/setup/platform/helpers_test.go
@@ -161,8 +161,7 @@ func TestBuildOperatorImagePassesDockerPlatform(t *testing.T) {
 	orig := core.DefaultCLIConfig
 	t.Cleanup(func() { core.DefaultCLIConfig = orig })
 	core.DefaultCLIConfig = &core.CLIConfig{ImagePlatform: "linux/amd64"}
-	restoreKubectl := core.SwapDefaultKubectlClient(core.NewTestKubectlClient(&core.MockExecutor{DefaultOutput: []byte("amd64\n")}))
-	t.Cleanup(restoreKubectl)
+	swapKubernetesClientsForTest(t, platformTestClientsWithNodeArchitectures("amd64"))
 	mockExec := &core.MockExecutor{}
 	restoreExec := core.SwapExecExecutor(mockExec)
 	t.Cleanup(restoreExec)
@@ -209,15 +208,7 @@ func TestGetOperatorImage(t *testing.T) {
 
 	t.Run("uses platform registry URL when external not set", func(t *testing.T) {
 		core.DefaultCLIConfig.OperatorImage = ""
-		mock := &core.MockExecutor{
-			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-				if contains(spec.Args, "jsonpath={.spec.ports[0].port}") {
-					return &core.MockCommand{OutputData: []byte("5000")}
-				}
-				return &core.MockCommand{}
-			},
-		}
-		swapDefaultKubectlClientForTest(t, core.NewTestKubectlClient(mock))
+		swapKubernetesClientsForTest(t, platformTestClientsWithRegistryService(5000))
 		got := getOperatorImage(nil)
 		if got != "registry.registry.svc.cluster.local:5000/mcp-runtime-operator:latest" {
 			t.Fatalf("unexpected platform registry image: %q", got)
@@ -265,15 +256,7 @@ func TestGetGatewayProxyImage(t *testing.T) {
 
 	t.Run("uses platform registry URL when external not set", func(t *testing.T) {
 		core.DefaultCLIConfig.GatewayProxyImage = ""
-		mock := &core.MockExecutor{
-			CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-				if contains(spec.Args, "jsonpath={.spec.ports[0].port}") {
-					return &core.MockCommand{OutputData: []byte("5000")}
-				}
-				return &core.MockCommand{}
-			},
-		}
-		swapDefaultKubectlClientForTest(t, core.NewTestKubectlClient(mock))
+		swapKubernetesClientsForTest(t, platformTestClientsWithRegistryService(5000))
 		got := getGatewayProxyImage(nil)
 		if got != "registry.registry.svc.cluster.local:5000/mcp-sentinel-mcp-gateway:latest" {
 			t.Fatalf("unexpected platform registry image: %q", got)
@@ -311,15 +294,7 @@ func TestPlatformImageDefaultsUseInternalRegistryWithPlatformDomain(t *testing.T
 	t.Setenv("MCP_PLATFORM_DOMAIN", "mcpruntime.org")
 	setupImageTagResolver = func() string { return "deadbeef" }
 	core.DefaultCLIConfig = core.LoadCLIConfig()
-	mock := &core.MockExecutor{
-		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-			if contains(spec.Args, "jsonpath={.spec.ports[0].port}") {
-				return &core.MockCommand{OutputData: []byte("5000")}
-			}
-			return &core.MockCommand{}
-		},
-	}
-	swapDefaultKubectlClientForTest(t, core.NewTestKubectlClient(mock))
+	swapKubernetesClientsForTest(t, platformTestClientsWithRegistryService(5000))
 
 	gotOperator := getOperatorImage(nil)
 	if gotOperator != "registry.registry.svc.cluster.local:5000/mcp-runtime-operator:latest" {
@@ -340,49 +315,21 @@ func TestApplyPlatformIngressPrunesPathBasedSentinelIngresses(t *testing.T) {
 	t.Cleanup(func() { core.DefaultCLIConfig = origConfig })
 	core.DefaultCLIConfig = &core.CLIConfig{PlatformIngressHost: "platform.example.com"}
 
-	var created []*core.MockCommand
-	mock := &core.MockExecutor{
-		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
-			cmd := &core.MockCommand{Args: spec.Args}
-			created = append(created, cmd)
-			return cmd
-		},
-	}
+	clients := platformTestClientsWithIngresses(pathBasedSentinelIngressNames...)
+	swapKubernetesClientsForTest(t, clients)
+	mock := &core.MockExecutor{}
 	kubectl := core.NewTestKubectlClient(mock)
 
 	if err := applyPlatformIngressIfConfigured(kubectl); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var (
-		appliedPlatformIngress bool
-		deletedPathIngresses   bool
-	)
-	for _, cmd := range created {
-		spec := core.ExecSpec{Args: cmd.Args}
-		if commandHasArgs(spec, "apply", "-f", "-") && cmd.StdinR != nil {
-			data, err := io.ReadAll(cmd.StdinR)
-			if err != nil {
-				t.Fatalf("read stdin: %v", err)
-			}
-			body := string(data)
-			appliedPlatformIngress = strings.Contains(body, "name: mcp-sentinel-platform-ui") &&
-				strings.Contains(body, `- host: "platform.example.com"`)
-		}
-		if commandHasArgs(spec, "delete", "ingress", "-n", core.DefaultAnalyticsNamespace, "--ignore-not-found=true") {
-			deletedPathIngresses = true
-			for _, name := range pathBasedSentinelIngressNames {
-				if !contains(cmd.Args, name) {
-					t.Fatalf("delete command missing %s: %v", name, cmd.Args)
-				}
-			}
-		}
+	assertPlatformIngressAppliedForTest(t, clients, "platform.example.com")
+	for _, name := range pathBasedSentinelIngressNames {
+		assertIngressDeletedForTest(t, clients, core.DefaultAnalyticsNamespace, name)
 	}
-	if !appliedPlatformIngress {
-		t.Fatal("expected platform UI ingress apply")
-	}
-	if !deletedPathIngresses {
-		t.Fatal("expected path-based sentinel ingress delete")
+	if len(mock.Commands) != 0 {
+		t.Fatalf("expected client-go path to avoid kubectl commands, got %v", mock.Commands)
 	}
 }
 
@@ -1288,6 +1235,7 @@ data:
 }
 
 func TestRenderAnalyticsConfigManifestDetectsK3sTraefikNamespace(t *testing.T) {
+	swapKubernetesClientsForTest(t, platformTestClientsWithTraefikDeployment("kube-system"))
 	mock := &core.MockExecutor{
 		CommandFunc: func(spec core.ExecSpec) *core.MockCommand {
 			if commandHasArgs(spec, "get", "deployment", "-A", "--no-headers") {
@@ -2333,19 +2281,16 @@ func TestCheckCRDInstalledWithKubectl(t *testing.T) {
 	}
 }
 
-func TestCheckCRDInstalledUsesDefaultKubectl(t *testing.T) {
-
+func TestCheckCRDInstalledUsesDefaultKubernetesClient(t *testing.T) {
+	swapKubernetesClientsForTest(t, platformTestClientsWithCRD("example.crd.io"))
 	mock := &core.MockExecutor{}
 	swapDefaultKubectlClientForTest(t, core.NewTestKubectlClient(mock))
 
 	if err := checkCRDInstalled("example.crd.io"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(mock.Commands) != 1 {
-		t.Fatalf("expected 1 kubectl command, got %d", len(mock.Commands))
-	}
-	if !commandHasArgs(mock.Commands[0], "get", "crd", "example.crd.io") {
-		t.Fatalf("unexpected command args: %v", mock.Commands[0].Args)
+	if len(mock.Commands) != 0 {
+		t.Fatalf("expected client-go CRD check to avoid kubectl commands, got %v", mock.Commands)
 	}
 }
 

--- a/internal/cli/setup/platform/helpers_test.go
+++ b/internal/cli/setup/platform/helpers_test.go
@@ -317,19 +317,14 @@ func TestApplyPlatformIngressPrunesPathBasedSentinelIngresses(t *testing.T) {
 
 	clients := platformTestClientsWithIngresses(pathBasedSentinelIngressNames...)
 	swapKubernetesClientsForTest(t, clients)
-	mock := &core.MockExecutor{}
-	kubectl := core.NewTestKubectlClient(mock)
 
-	if err := applyPlatformIngressIfConfigured(kubectl); err != nil {
+	if err := applyPlatformIngressIfConfigured(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	assertPlatformIngressAppliedForTest(t, clients, "platform.example.com")
 	for _, name := range pathBasedSentinelIngressNames {
 		assertIngressDeletedForTest(t, clients, core.DefaultAnalyticsNamespace, name)
-	}
-	if len(mock.Commands) != 0 {
-		t.Fatalf("expected client-go path to avoid kubectl commands, got %v", mock.Commands)
 	}
 }
 
@@ -338,14 +333,8 @@ func TestApplyPlatformIngressSkipsWhenHostUnset(t *testing.T) {
 	t.Cleanup(func() { core.DefaultCLIConfig = origConfig })
 	core.DefaultCLIConfig = &core.CLIConfig{}
 
-	mock := &core.MockExecutor{}
-	kubectl := core.NewTestKubectlClient(mock)
-
-	if err := applyPlatformIngressIfConfigured(kubectl); err != nil {
+	if err := applyPlatformIngressIfConfigured(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(mock.Commands) != 0 {
-		t.Fatalf("expected no kubectl commands when platform host is unset, got %v", mock.Commands)
 	}
 }
 

--- a/internal/cli/setup/platform/kube_client.go
+++ b/internal/cli/setup/platform/kube_client.go
@@ -1,0 +1,80 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"mcp-runtime/pkg/k8sclient"
+)
+
+var newKubernetesClients = k8sclient.New
+
+func platformKubernetesClients() (*k8sclient.Clients, error) {
+	clients, err := newKubernetesClients()
+	if err != nil {
+		return nil, err
+	}
+	return clients, nil
+}
+
+func applyManifestYAML(manifest string, namespace string, stdout io.Writer) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	results, err := k8sclient.ApplyManifestYAML(context.Background(), clients, []byte(manifest), namespace)
+	if err != nil {
+		return err
+	}
+	writeApplyResults(stdout, results)
+	return nil
+}
+
+func applyManifestFile(path string, namespace string, stdout io.Writer) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	results, err := k8sclient.ApplyManifestFile(context.Background(), clients, path, namespace)
+	if err != nil {
+		return err
+	}
+	writeApplyResults(stdout, results)
+	return nil
+}
+
+func applyManifestDir(path string, namespace string, stdout io.Writer) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	results, err := k8sclient.ApplyManifestDir(context.Background(), clients, path, namespace)
+	if err != nil {
+		return err
+	}
+	writeApplyResults(stdout, results)
+	return nil
+}
+
+func ensureNamespaceWithLabels(name string, labels map[string]string) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.EnsureNamespace(context.Background(), clients, name, labels)
+}
+
+func writeApplyResults(stdout io.Writer, results []k8sclient.ApplyResult) {
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	for _, result := range results {
+		if strings.TrimSpace(result.Action) == "" {
+			continue
+		}
+		fmt.Fprintln(stdout, result.String())
+	}
+}

--- a/internal/cli/setup/platform/kube_client_test.go
+++ b/internal/cli/setup/platform/kube_client_test.go
@@ -1,0 +1,156 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+
+	"mcp-runtime/internal/cli/core"
+	"mcp-runtime/pkg/k8sclient"
+)
+
+var platformIngressGVR = schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}
+
+func swapKubernetesClientsForTest(t *testing.T, clients *k8sclient.Clients) {
+	t.Helper()
+	orig := newKubernetesClients
+	t.Cleanup(func() { newKubernetesClients = orig })
+	newKubernetesClients = func() (*k8sclient.Clients, error) {
+		return clients, nil
+	}
+}
+
+func newPlatformKubernetesTestClients(clientObjects []runtime.Object, dynamicObjects []runtime.Object) *k8sclient.Clients {
+	scheme := runtime.NewScheme()
+	resources := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: []string{"get", "create", "update"}},
+				{Name: "namespaces", Namespaced: false, Kind: "Namespace", Verbs: []string{"get", "create", "update"}},
+				{Name: "secrets", Namespaced: true, Kind: "Secret", Verbs: []string{"get", "create", "update"}},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment", Verbs: []string{"get", "list", "update", "patch"}},
+			},
+		},
+		{
+			GroupVersion: "networking.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "ingresses", Namespaced: true, Kind: "Ingress", Verbs: []string{"get", "create", "update", "delete"}},
+			},
+		},
+		{
+			GroupVersion: "apiextensions.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "customresourcedefinitions", Namespaced: false, Kind: "CustomResourceDefinition", Verbs: []string{"get", "create", "update"}},
+			},
+		},
+	}
+	return &k8sclient.Clients{
+		Clientset: kubernetesfake.NewSimpleClientset(clientObjects...),
+		Dynamic:   dynamicfake.NewSimpleDynamicClient(scheme, dynamicObjects...),
+		Discovery: &discoveryfake.FakeDiscovery{Fake: &clienttesting.Fake{Resources: resources}},
+		Namespace: metav1.NamespaceDefault,
+	}
+}
+
+func platformTestClientsWithIngresses(names ...string) *k8sclient.Clients {
+	objects := make([]runtime.Object, 0, len(names))
+	for _, name := range names {
+		objects = append(objects, &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: core.DefaultAnalyticsNamespace},
+		})
+	}
+	return newPlatformKubernetesTestClients(objects, nil)
+}
+
+func platformTestClientsWithTraefikDeployment(namespace string) *k8sclient.Clients {
+	return newPlatformKubernetesTestClients([]runtime.Object{
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "traefik", Namespace: namespace}},
+	}, nil)
+}
+
+func platformTestClientsWithNodeArchitectures(architectures ...string) *k8sclient.Clients {
+	objects := make([]runtime.Object, 0, len(architectures))
+	for i, architecture := range architectures {
+		objects = append(objects, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-%d", i)},
+			Status: corev1.NodeStatus{
+				NodeInfo: corev1.NodeSystemInfo{Architecture: architecture},
+			},
+		})
+	}
+	return newPlatformKubernetesTestClients(objects, nil)
+}
+
+func platformTestClientsWithRegistryService(port int32) *k8sclient.Clients {
+	return newPlatformKubernetesTestClients([]runtime.Object{
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: core.RegistryServiceName, Namespace: core.NamespaceRegistry},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: "10.96.201.51",
+				Ports: []corev1.ServicePort{
+					{Port: port},
+				},
+			},
+		},
+	}, nil)
+}
+
+func platformTestClientsWithCRD(name string) *k8sclient.Clients {
+	return newPlatformKubernetesTestClients(nil, []runtime.Object{
+		&unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "CustomResourceDefinition",
+			"metadata": map[string]any{
+				"name": name,
+			},
+		}},
+	})
+}
+
+func assertPlatformIngressAppliedForTest(t *testing.T, clients *k8sclient.Clients, host string) {
+	t.Helper()
+	ingress, err := clients.Dynamic.Resource(platformIngressGVR).
+		Namespace(core.DefaultAnalyticsNamespace).
+		Get(context.Background(), "mcp-sentinel-platform-ui", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected platform UI ingress apply: %v", err)
+	}
+	rules, ok, err := unstructured.NestedSlice(ingress.Object, "spec", "rules")
+	if err != nil || !ok || len(rules) == 0 {
+		t.Fatalf("expected platform UI ingress rules, ok=%v err=%v object=%v", ok, err, ingress.Object)
+	}
+	firstRule, ok := rules[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected ingress rule shape: %#v", rules[0])
+	}
+	if got := firstRule["host"]; got != host {
+		t.Fatalf("platform UI ingress host = %v, want %s", got, host)
+	}
+}
+
+func assertIngressDeletedForTest(t *testing.T, clients *k8sclient.Clients, namespace, name string) {
+	t.Helper()
+	_, err := clients.Clientset.NetworkingV1().Ingresses(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected ingress %s/%s to be deleted, got err=%v", namespace, name, err)
+	}
+}

--- a/internal/cli/setup/platform/platform.go
+++ b/internal/cli/setup/platform/platform.go
@@ -11,7 +11,6 @@ import (
 
 	"mcp-runtime/internal/cli/cluster"
 	"mcp-runtime/internal/cli/core"
-	"mcp-runtime/internal/cli/kube"
 	"mcp-runtime/internal/cli/registry"
 	"mcp-runtime/internal/cli/registry/config"
 	setupplan "mcp-runtime/internal/cli/setup/plan"
@@ -183,7 +182,7 @@ func (d SetupDeps) withDefaults(logger *zap.Logger) SetupDeps {
 		}
 	}
 	if d.DeployRegistry == nil {
-		d.DeployRegistry = registry.DeployRegistry
+		d.DeployRegistry = deployRegistryClientGo
 	}
 	if d.WaitForDeploymentAvailable == nil {
 		d.WaitForDeploymentAvailable = waitForDeploymentAvailable
@@ -193,7 +192,7 @@ func (d SetupDeps) withDefaults(logger *zap.Logger) SetupDeps {
 	}
 	if d.SetupTLS == nil {
 		d.SetupTLS = func(l *zap.Logger, p setupplan.Plan) error {
-			return setupTLSWithKubectlAndPlan(core.DefaultKubectlClient(), l, p)
+			return setupTLSWithClientGoAndPlan(l, p)
 		}
 	}
 	if d.BuildOperatorImage == nil {
@@ -216,16 +215,16 @@ func (d SetupDeps) withDefaults(logger *zap.Logger) SetupDeps {
 	}
 	if d.EnsureNamespace == nil {
 		d.EnsureNamespace = func(namespace string) error {
-			return kube.EnsureNamespace(core.DefaultKubectlClient().CommandArgs, namespace)
+			return ensureNamespaceWithLabels(namespace, nil)
 		}
 	}
 	if d.EnsureCatalogNamespace == nil {
 		d.EnsureCatalogNamespace = func(namespace string, labels map[string]string) error {
-			return kube.EnsureNamespaceWithLabels(core.DefaultKubectlClient().CommandArgs, namespace, labels)
+			return ensureNamespaceWithLabels(namespace, labels)
 		}
 	}
 	if d.ResolvePlatformRegistryURL == nil {
-		d.ResolvePlatformRegistryURL = registry.ResolveInternalPlatformRegistryURL
+		d.ResolvePlatformRegistryURL = resolveInternalPlatformRegistryURLClientGo
 	}
 	if d.PushOperatorImageToInternal == nil {
 		d.PushOperatorImageToInternal = pushOperatorImageToInternalRegistry

--- a/internal/cli/setup/platform/platform_analytics.go
+++ b/internal/cli/setup/platform/platform_analytics.go
@@ -35,7 +35,6 @@ func deployAnalyticsManifests(logger *zap.Logger, images AnalyticsImageSet, stor
 func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageSet, storageMode, platformMode string) error {
 	rolloutTimeoutDuration := analyticsRolloutTimeoutDuration()
 	rolloutTimeout := rolloutTimeoutDuration.String()
-	kubectl := core.DefaultKubectlClient()
 
 	if err := ensureRepoManagedTraefikMiddlewareResourcesClientGo(logger); err != nil {
 		return err
@@ -51,7 +50,7 @@ func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageS
 			return err
 		}
 	}
-	if err := applyCatalogNamespaceForMode(kubectl, platformMode); err != nil {
+	if err := applyCatalogNamespaceForMode(platformMode); err != nil {
 		return err
 	}
 
@@ -89,13 +88,13 @@ func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageS
 	}
 
 	if err := waitForRolloutStatusWithClientGo("statefulset", "clickhouse", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
-		return mcpSentinelDependencyRolloutFailed(kubectl, err, "statefulset", "clickhouse", core.DefaultAnalyticsNamespace, "storage (clickhouse)")
+		return mcpSentinelDependencyRolloutFailed(core.DefaultKubectlClient(), err, "statefulset", "clickhouse", core.DefaultAnalyticsNamespace, "storage (clickhouse)")
 	}
 	if err := waitForRolloutStatusWithClientGo("deployment", "zookeeper", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
-		return mcpSentinelDependencyRolloutFailed(kubectl, err, "deployment", "zookeeper", core.DefaultAnalyticsNamespace, "messaging (zookeeper)")
+		return mcpSentinelDependencyRolloutFailed(core.DefaultKubectlClient(), err, "deployment", "zookeeper", core.DefaultAnalyticsNamespace, "messaging (zookeeper)")
 	}
 	if err := waitForRolloutStatusWithClientGo("statefulset", "kafka", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
-		return mcpSentinelDependencyRolloutFailed(kubectl, err, "statefulset", "kafka", core.DefaultAnalyticsNamespace, "messaging (kafka)")
+		return mcpSentinelDependencyRolloutFailed(core.DefaultKubectlClient(), err, "statefulset", "kafka", core.DefaultAnalyticsNamespace, "messaging (kafka)")
 	}
 
 	core.Info("Initializing ClickHouse schema")
@@ -106,7 +105,7 @@ func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageS
 		return err
 	}
 	if err := waitForJobCompletionClientGo("clickhouse-init", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
-		return mcpSentinelDependencyJobFailed(kubectl, err, "clickhouse-init", core.DefaultAnalyticsNamespace, "clickhouse init schema")
+		return mcpSentinelDependencyJobFailed(core.DefaultKubectlClient(), err, "clickhouse-init", core.DefaultAnalyticsNamespace, "clickhouse init schema")
 	}
 
 	core.Info("Applying analytics services")
@@ -131,7 +130,7 @@ func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageS
 		}
 	}
 
-	if err := applyPlatformIngressIfConfigured(kubectl); err != nil {
+	if err := applyPlatformIngressIfConfigured(); err != nil {
 		return err
 	}
 
@@ -165,13 +164,13 @@ func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageS
 		return nil
 	}
 
-	printAnalyticsRolloutDiagnostics(kubectl)
+	printAnalyticsRolloutDiagnostics(core.DefaultKubectlClient())
 	summary := strings.Join(rolloutFailures, "; ")
 	cause := core.NewWithSentinel(core.ErrSetupAnalyticsRolloutFailed, summary)
 	msg := fmt.Sprintf("analytics components failed to roll out: %s", summary)
 	ctx := map[string]any{"component": "mcp-sentinel", "rollout_failures": summary}
 	if core.IsDebugMode() {
-		if diag := buildAnalyticsRolloutDebugDetail(kubectl, failedForDebug); diag != "" {
+		if diag := buildAnalyticsRolloutDebugDetail(core.DefaultKubectlClient(), failedForDebug); diag != "" {
 			ctx["diagnostics"] = trimDiagnosticsString(diag)
 		}
 	}
@@ -195,7 +194,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap
 			return err
 		}
 	}
-	if err := applyCatalogNamespaceForMode(kubectl, platformMode); err != nil {
+	if err := applyCatalogNamespaceForMode(platformMode); err != nil {
 		return err
 	}
 
@@ -275,7 +274,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap
 		}
 	}
 
-	if err := applyPlatformIngressIfConfigured(kubectl); err != nil {
+	if err := applyPlatformIngressIfConfigured(); err != nil {
 		return err
 	}
 
@@ -322,7 +321,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap
 	return core.WrapWithSentinelAndContext(core.ErrOperatorDeploymentFailed, cause, msg, ctx)
 }
 
-func applyCatalogNamespaceForMode(kubectl core.KubectlRunner, platformMode string) error {
+func applyCatalogNamespaceForMode(platformMode string) error {
 	namespace := setupplan.CatalogNamespaceForPlatformMode(platformMode)
 	if strings.TrimSpace(namespace) == "" {
 		return nil
@@ -418,7 +417,7 @@ func applyRenderedManifestClientGo(manifestPath string, images AnalyticsImageSet
 	return applyManifestYAML(rendered, "", os.Stdout)
 }
 
-func applyPlatformIngressIfConfigured(kubectl core.KubectlRunner) error {
+func applyPlatformIngressIfConfigured() error {
 	host := strings.TrimSpace(core.GetPlatformIngressHost())
 	if host == "" {
 		return nil
@@ -428,13 +427,13 @@ func applyPlatformIngressIfConfigured(kubectl core.KubectlRunner) error {
 	if err := applyManifestYAML(manifest, "", os.Stdout); err != nil {
 		return core.WrapWithSentinel(core.ErrSetupApplyPlatformUIIngressFailed, err, fmt.Sprintf("apply platform UI ingress: %v", err))
 	}
-	if err := removePathBasedSentinelIngresses(kubectl); err != nil {
+	if err := removePathBasedSentinelIngresses(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func removePathBasedSentinelIngresses(kubectl core.KubectlRunner) error {
+func removePathBasedSentinelIngresses() error {
 	clients, err := platformKubernetesClients()
 	if err != nil {
 		return err

--- a/internal/cli/setup/platform/platform_analytics.go
+++ b/internal/cli/setup/platform/platform_analytics.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
@@ -21,10 +22,160 @@ import (
 	"mcp-runtime/internal/cli/setup/assetpath"
 	"mcp-runtime/internal/cli/setup/ingressmanifest"
 	setupplan "mcp-runtime/internal/cli/setup/plan"
+	"mcp-runtime/pkg/k8sclient"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func deployAnalyticsManifests(logger *zap.Logger, images AnalyticsImageSet, storageMode, platformMode string) error {
-	return deployAnalyticsManifestsWithKubectl(core.DefaultKubectlClient(), logger, images, storageMode, platformMode)
+	return deployAnalyticsManifestsClientGo(logger, images, storageMode, platformMode)
+}
+
+func deployAnalyticsManifestsClientGo(logger *zap.Logger, images AnalyticsImageSet, storageMode, platformMode string) error {
+	rolloutTimeoutDuration := analyticsRolloutTimeoutDuration()
+	rolloutTimeout := rolloutTimeoutDuration.String()
+	kubectl := core.DefaultKubectlClient()
+
+	if err := ensureRepoManagedTraefikMiddlewareResourcesClientGo(logger); err != nil {
+		return err
+	}
+
+	core.Info("Applying mcp-sentinel namespace and config")
+	manifests := []string{
+		"k8s/00-namespace.yaml",
+		"k8s/01-config.yaml",
+	}
+	for _, manifest := range manifests {
+		if err := applyRenderedManifestClientGo(manifest, images, "", platformMode); err != nil {
+			return err
+		}
+	}
+	if err := applyCatalogNamespaceForMode(kubectl, platformMode); err != nil {
+		return err
+	}
+
+	core.Info("Applying mcp-sentinel managed secrets")
+	secretManifest, err := renderAnalyticsSecretManifestClientGo()
+	if err != nil {
+		return err
+	}
+	if err := applyManifestYAML(secretManifest, "", os.Stdout); err != nil {
+		return err
+	}
+
+	imagePullSecretName, err := ensureAnalyticsImagePullSecretClientGo()
+	if err != nil {
+		return err
+	}
+
+	clickhouseManifest := "k8s/03-clickhouse.yaml"
+	kafkaManifest := "k8s/05-kafka.yaml"
+	postgresManifest := "k8s/20-postgres.yaml"
+	if storageMode == setupplan.StorageModeHostpath {
+		clickhouseManifest = "k8s/03-clickhouse-hostpath.yaml"
+		kafkaManifest = "k8s/05-kafka-hostpath.yaml"
+		postgresManifest = "k8s/20-postgres-hostpath.yaml"
+	}
+
+	core.Info("Applying analytics storage and messaging components")
+	for _, manifest := range []string{
+		clickhouseManifest,
+		kafkaManifest,
+	} {
+		if err := applyRenderedManifestClientGo(manifest, images, imagePullSecretName, platformMode); err != nil {
+			return err
+		}
+	}
+
+	if err := waitForRolloutStatusWithClientGo("statefulset", "clickhouse", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
+		return mcpSentinelDependencyRolloutFailed(kubectl, err, "statefulset", "clickhouse", core.DefaultAnalyticsNamespace, "storage (clickhouse)")
+	}
+	if err := waitForRolloutStatusWithClientGo("deployment", "zookeeper", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
+		return mcpSentinelDependencyRolloutFailed(kubectl, err, "deployment", "zookeeper", core.DefaultAnalyticsNamespace, "messaging (zookeeper)")
+	}
+	if err := waitForRolloutStatusWithClientGo("statefulset", "kafka", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
+		return mcpSentinelDependencyRolloutFailed(kubectl, err, "statefulset", "kafka", core.DefaultAnalyticsNamespace, "messaging (kafka)")
+	}
+
+	core.Info("Initializing ClickHouse schema")
+	if err := deleteJobIfExistsClientGo("clickhouse-init", core.DefaultAnalyticsNamespace); err != nil {
+		return core.WrapWithSentinel(core.ErrSetupDeleteClickHouseInitJobFailed, err, fmt.Sprintf("delete existing clickhouse init job: %v", err))
+	}
+	if err := applyRenderedManifestClientGo("k8s/04-clickhouse-init.yaml", images, imagePullSecretName, platformMode); err != nil {
+		return err
+	}
+	if err := waitForJobCompletionClientGo("clickhouse-init", core.DefaultAnalyticsNamespace, rolloutTimeoutDuration); err != nil {
+		return mcpSentinelDependencyJobFailed(kubectl, err, "clickhouse-init", core.DefaultAnalyticsNamespace, "clickhouse init schema")
+	}
+
+	core.Info("Applying analytics services")
+	for _, manifest := range []string{
+		postgresManifest,
+		"k8s/06-ingest.yaml",
+		"k8s/07-processor.yaml",
+		"k8s/08-api.yaml",
+		"k8s/08-api-rbac.yaml",
+		"k8s/09-ui.yaml",
+		"k8s/10-gateway.yaml",
+		"k8s/11-prometheus.yaml",
+		"k8s/15-otel-collector.yaml",
+		"k8s/16-tempo.yaml",
+		"k8s/17-loki.yaml",
+		"k8s/18-promtail.yaml",
+		"k8s/19-grafana-datasources.yaml",
+		"k8s/12-grafana.yaml",
+	} {
+		if err := applyRenderedManifestClientGo(manifest, images, imagePullSecretName, platformMode); err != nil {
+			return err
+		}
+	}
+
+	if err := applyPlatformIngressIfConfigured(kubectl); err != nil {
+		return err
+	}
+
+	core.Info(fmt.Sprintf("Waiting for mcp-sentinel workload rollouts (per-resource timeout %s; override with MCP_DEPLOYMENT_TIMEOUT)", rolloutTimeout))
+	targets := []struct{ kind, name string }{
+		{kind: "statefulset", name: "mcp-sentinel-postgres"},
+		{kind: "deployment", name: "mcp-sentinel-ingest"},
+		{kind: "deployment", name: "mcp-sentinel-processor"},
+		{kind: "deployment", name: "mcp-sentinel-api"},
+		{kind: "deployment", name: "mcp-sentinel-ui"},
+		{kind: "deployment", name: "mcp-sentinel-gateway"},
+		{kind: "deployment", name: "prometheus"},
+		{kind: "deployment", name: "grafana"},
+		{kind: "deployment", name: "otel-collector"},
+		{kind: "statefulset", name: "tempo"},
+		{kind: "statefulset", name: "loki"},
+	}
+	var rolloutFailures []string
+	var failedForDebug []analyticsFailedRollout
+	for _, target := range targets {
+		rolloutLog, err := runRolloutWithOptionalDebugCaptureClientGo(target.kind, target.name, core.DefaultAnalyticsNamespace, rolloutTimeoutDuration)
+		if err != nil {
+			rolloutFailures = append(rolloutFailures, fmt.Sprintf("%s/%s: %v", target.kind, target.name, err))
+			failedForDebug = append(failedForDebug, analyticsFailedRollout{
+				kind: target.kind, name: target.name, rolloutLog: rolloutLog,
+			})
+		}
+	}
+	if len(rolloutFailures) == 0 {
+		core.Success("mcp-sentinel manifests deployed successfully")
+		return nil
+	}
+
+	printAnalyticsRolloutDiagnostics(kubectl)
+	summary := strings.Join(rolloutFailures, "; ")
+	cause := core.NewWithSentinel(core.ErrSetupAnalyticsRolloutFailed, summary)
+	msg := fmt.Sprintf("analytics components failed to roll out: %s", summary)
+	ctx := map[string]any{"component": "mcp-sentinel", "rollout_failures": summary}
+	if core.IsDebugMode() {
+		if diag := buildAnalyticsRolloutDebugDetail(kubectl, failedForDebug); diag != "" {
+			ctx["diagnostics"] = trimDiagnosticsString(diag)
+		}
+	}
+	return core.WrapWithSentinelAndContext(core.ErrOperatorDeploymentFailed, cause, msg, ctx)
 }
 
 func deployAnalyticsManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap.Logger, images AnalyticsImageSet, storageMode, platformMode string) error {
@@ -53,7 +204,7 @@ func deployAnalyticsManifestsWithKubectl(kubectl core.KubectlRunner, logger *zap
 	if err != nil {
 		return err
 	}
-	if err := kube.ApplyManifestContent(kubectl.CommandArgs, secretManifest); err != nil {
+	if err := applyManifestYAML(secretManifest, "", os.Stdout); err != nil {
 		return err
 	}
 
@@ -177,7 +328,7 @@ func applyCatalogNamespaceForMode(kubectl core.KubectlRunner, platformMode strin
 		return nil
 	}
 	core.Info(fmt.Sprintf("Applying platform catalog namespace %s", namespace))
-	return kube.EnsureNamespaceWithLabels(kubectl.CommandArgs, namespace, catalogNamespaceLabels(platformMode))
+	return ensureNamespaceWithLabels(namespace, catalogNamespaceLabels(platformMode))
 }
 
 func trimDiagnosticsString(s string) string {
@@ -242,7 +393,29 @@ func applyRenderedManifest(kubectl core.KubectlRunner, manifestPath string, imag
 	if err != nil {
 		return core.WrapWithSentinel(core.ErrSetupRenderManifestFailed, err, fmt.Sprintf("render manifest %s: %v", manifestPath, err))
 	}
-	return kube.ApplyManifestContent(kubectl.CommandArgs, rendered)
+	return applyManifestYAML(rendered, "", os.Stdout)
+}
+
+func applyRenderedManifestClientGo(manifestPath string, images AnalyticsImageSet, imagePullSecretName, platformMode string) error {
+	resolvedManifestPath, err := assetpath.ResolveRepoAssetPath(manifestPath)
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrReadManagerYAMLFailed, err, fmt.Sprintf("failed to resolve manifest %s: %v", manifestPath, err))
+	}
+
+	content, err := kube.ReadFileAtPath(resolvedManifestPath)
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrReadManagerYAMLFailed, err, fmt.Sprintf("failed to read manifest %s: %v", resolvedManifestPath, err))
+	}
+	rendered := ""
+	if manifestPath == "k8s/01-config.yaml" {
+		rendered, err = renderAnalyticsConfigManifestClientGo(string(content), platformMode, images)
+	} else {
+		rendered, err = renderAnalyticsManifest(string(content), images, imagePullSecretName, platformMode)
+	}
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrSetupRenderManifestFailed, err, fmt.Sprintf("render manifest %s: %v", manifestPath, err))
+	}
+	return applyManifestYAML(rendered, "", os.Stdout)
 }
 
 func applyPlatformIngressIfConfigured(kubectl core.KubectlRunner) error {
@@ -252,7 +425,7 @@ func applyPlatformIngressIfConfigured(kubectl core.KubectlRunner) error {
 	}
 	manifest := ingressmanifest.RenderPlatformUIIngress(host, core.GetRegistryClusterIssuerName(), core.DefaultAnalyticsNamespace)
 	core.Info(fmt.Sprintf("Applying platform UI ingress for %s", host))
-	if err := kube.ApplyManifestContent(kubectl.CommandArgs, manifest); err != nil {
+	if err := applyManifestYAML(manifest, "", os.Stdout); err != nil {
 		return core.WrapWithSentinel(core.ErrSetupApplyPlatformUIIngressFailed, err, fmt.Sprintf("apply platform UI ingress: %v", err))
 	}
 	if err := removePathBasedSentinelIngresses(kubectl); err != nil {
@@ -262,10 +435,15 @@ func applyPlatformIngressIfConfigured(kubectl core.KubectlRunner) error {
 }
 
 func removePathBasedSentinelIngresses(kubectl core.KubectlRunner) error {
-	args := append([]string{"delete", "ingress"}, pathBasedSentinelIngressNames...)
-	args = append(args, "-n", core.DefaultAnalyticsNamespace, "--ignore-not-found=true")
-	if err := kubectl.RunWithOutput(args, os.Stdout, os.Stderr); err != nil {
-		return core.WrapWithSentinel(core.ErrSetupRemovePathBasedSentinelIngressesFailed, err, fmt.Sprintf("remove path-based sentinel ingresses for public platform host: %v", err))
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	for _, name := range pathBasedSentinelIngressNames {
+		err := clients.Clientset.NetworkingV1().Ingresses(core.DefaultAnalyticsNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return core.WrapWithSentinel(core.ErrSetupRemovePathBasedSentinelIngressesFailed, err, fmt.Sprintf("remove path-based sentinel ingress %s/%s for public platform host: %v", core.DefaultAnalyticsNamespace, name, err))
+		}
 	}
 	return nil
 }
@@ -332,7 +510,34 @@ func renderAnalyticsManifest(content string, images AnalyticsImageSet, imagePull
 	return rendered, nil
 }
 
+type analyticsConfigMapReader func(namespace, name string) (map[string]string, error)
+type analyticsTraefikNamespaceResolver func() string
+
 func renderAnalyticsConfigManifest(kubectl core.KubectlRunner, content, platformMode string, images AnalyticsImageSet) (string, error) {
+	return renderAnalyticsConfigManifestWithReaders(
+		content,
+		platformMode,
+		images,
+		func(namespace, name string) (map[string]string, error) {
+			return existingConfigMapData(kubectl, namespace, name)
+		},
+		func() string {
+			return activeTraefikNamespaceForPlatform(kubectl)
+		},
+	)
+}
+
+func renderAnalyticsConfigManifestClientGo(content, platformMode string, images AnalyticsImageSet) (string, error) {
+	return renderAnalyticsConfigManifestWithReaders(
+		content,
+		platformMode,
+		images,
+		existingConfigMapDataClientGo,
+		activeTraefikNamespaceForPlatformClientGo,
+	)
+}
+
+func renderAnalyticsConfigManifestWithReaders(content, platformMode string, images AnalyticsImageSet, readConfigMap analyticsConfigMapReader, resolveTraefikNamespace analyticsTraefikNamespaceResolver) (string, error) {
 	type configMapManifest struct {
 		APIVersion string            `yaml:"apiVersion"`
 		Kind       string            `yaml:"kind"`
@@ -348,7 +553,7 @@ func renderAnalyticsConfigManifest(kubectl core.KubectlRunner, content, platform
 		manifest.Data = map[string]string{}
 	}
 
-	existingData, err := existingConfigMapData(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-config")
+	existingData, err := readConfigMap(core.DefaultAnalyticsNamespace, "mcp-sentinel-config")
 	if err != nil {
 		return "", err
 	}
@@ -384,7 +589,7 @@ func renderAnalyticsConfigManifest(kubectl core.KubectlRunner, content, platform
 		manifest.Data["PLATFORM_REGISTRY_URL"] = registryHost
 	}
 	if strings.TrimSpace(manifest.Data["PLATFORM_TRAEFIK_NAMESPACE"]) == "" {
-		if namespace := activeTraefikNamespaceForPlatform(kubectl); namespace != "" {
+		if namespace := resolveTraefikNamespace(); namespace != "" {
 			manifest.Data["PLATFORM_TRAEFIK_NAMESPACE"] = namespace
 		}
 	}
@@ -468,42 +673,66 @@ func existingConfigMapData(kubectl core.KubectlRunner, namespace, name string) (
 	return payload.Data, nil
 }
 
+func existingConfigMapDataClientGo(namespace, name string) (map[string]string, error) {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return nil, err
+	}
+	data, err := k8sclient.ConfigMapData(context.Background(), clients, namespace, name)
+	if err != nil {
+		return nil, core.WrapWithSentinel(core.ErrSetupReadConfigMapFailed, err, fmt.Sprintf("read configmap %s/%s: %v", namespace, name, err))
+	}
+	return data, nil
+}
+
 func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
-	apiKeys, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "API_KEYS", 16)
+	return renderAnalyticsSecretManifestWithReader(func(namespace, name, key string) (string, error) {
+		return existingSecretDataValue(kubectl, namespace, name, key)
+	})
+}
+
+func renderAnalyticsSecretManifestClientGo() (string, error) {
+	return renderAnalyticsSecretManifestWithReader(existingSecretDataValueClientGo)
+}
+
+type analyticsSecretValueReader func(namespace, name, key string) (string, error)
+
+func renderAnalyticsSecretManifestWithReader(readSecret analyticsSecretValueReader) (string, error) {
+	apiKeys, err := existingSecretDataValueOrRandomWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "API_KEYS", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	ingestAPIKeys, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "INGEST_API_KEYS", 16)
+	ingestAPIKeys, err := existingSecretDataValueOrRandomWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "INGEST_API_KEYS", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	uiAPIKey, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "UI_API_KEY", 16)
+	uiAPIKey, err := existingSecretDataValueOrRandomWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "UI_API_KEY", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
 	apiKeys = ensureCSVIncludes(apiKeys, uiAPIKey)
-	adminAPIKeys, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "ADMIN_API_KEYS")
+	adminAPIKeys, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "ADMIN_API_KEYS")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
 	adminAPIKeys = ensureCSVIncludes(adminAPIKeys, uiAPIKey)
-	grafanaPassword, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "GRAFANA_ADMIN_PASSWORD", 16)
+	grafanaPassword, err := existingSecretDataValueOrRandomWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "GRAFANA_ADMIN_PASSWORD", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	postgresUser, err := existingSecretDataValueOrDefault(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_USER", "mcp_runtime")
+	postgresUser, err := existingSecretDataValueOrDefaultWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_USER", "mcp_runtime")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	postgresPassword, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_PASSWORD", 16)
+	postgresPassword, err := existingSecretDataValueOrRandomWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_PASSWORD", 16)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	postgresDB, err := existingSecretDataValueOrDefault(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_DB", "mcp_runtime")
+	postgresDB, err := existingSecretDataValueOrDefaultWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_DB", "mcp_runtime")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	postgresDSN, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_DSN")
+	postgresDSN, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "POSTGRES_DSN")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
@@ -515,19 +744,19 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 			postgresDB,
 		)
 	}
-	platformJWTSecret, err := existingSecretDataValueOrRandom(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_JWT_SECRET", 32)
+	platformJWTSecret, err := existingSecretDataValueOrRandomWithReader(readSecret, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_JWT_SECRET", 32)
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	platformAdminEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_ADMIN_EMAIL")
+	platformAdminEmail, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_ADMIN_EMAIL")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	platformAdminPassword, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_ADMIN_PASSWORD")
+	platformAdminPassword, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_ADMIN_PASSWORD")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	adminUsers, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "ADMIN_USERS")
+	adminUsers, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "ADMIN_USERS")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
@@ -552,19 +781,19 @@ func renderAnalyticsSecretManifest(kubectl core.KubectlRunner) (string, error) {
 	}
 	adminUsers = ensureCSVIncludesValues(adminUsers, adminUserCandidates...)
 	platformDevLoginEnabled := ""
-	platformDevUserEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_EMAIL")
+	platformDevUserEmail, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_EMAIL")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	platformDevUserPassword, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_PASSWORD")
+	platformDevUserPassword, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_USER_PASSWORD")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	platformDevAdminEmail, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_ADMIN_EMAIL")
+	platformDevAdminEmail, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_ADMIN_EMAIL")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
-	platformDevAdminPassword, err := existingSecretDataValue(kubectl, core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_ADMIN_PASSWORD")
+	platformDevAdminPassword, err := readSecret(core.DefaultAnalyticsNamespace, "mcp-sentinel-secrets", "PLATFORM_DEV_ADMIN_PASSWORD")
 	if err != nil {
 		return "", core.WrapWithSentinel(core.ErrRenderSecretManifestFailed, err, fmt.Sprintf("failed to read analytics secrets: %v", err))
 	}
@@ -695,6 +924,27 @@ func platformImagePullSecretOverride() string {
 	return setupSecretEnvValue("MCP_PLATFORM_IMAGE_PULL_SECRET", "MCP_REGISTRY_PULL_SECRET_NAME")
 }
 
+func ensureAnalyticsImagePullSecretClientGo() (string, error) {
+	if explicit := platformImagePullSecretOverride(); explicit != "" {
+		return explicit, nil
+	}
+	extRegistry, err := registry.ResolveExternalRegistryConfig(nil)
+	if err != nil {
+		return "", err
+	}
+	if extRegistry == nil || extRegistry.URL == "" || (extRegistry.Username == "" && extRegistry.Password == "") {
+		return "", nil
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return "", err
+	}
+	if err := k8sclient.UpsertDockerConfigSecret(context.Background(), clients, core.DefaultAnalyticsNamespace, defaultRegistrySecretName, extRegistry.URL, extRegistry.Username, extRegistry.Password); err != nil {
+		return "", err
+	}
+	return defaultRegistrySecretName, nil
+}
+
 func existingSecretDataValue(kubectl core.KubectlRunner, namespace, name, key string) (string, error) {
 	cmd, err := kubectl.CommandArgs([]string{"get", "secret", name, "-n", namespace, "-o", "jsonpath={.data." + key + "}"})
 	if err != nil {
@@ -721,8 +971,20 @@ func existingSecretDataValue(kubectl core.KubectlRunner, namespace, name, key st
 	return string(decoded), nil
 }
 
-func existingSecretDataValueOrRandom(kubectl core.KubectlRunner, namespace, name, key string, size int) (string, error) {
-	value, err := existingSecretDataValue(kubectl, namespace, name, key)
+func existingSecretDataValueClientGo(namespace, name, key string) (string, error) {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return "", err
+	}
+	value, err := k8sclient.SecretStringDataValue(context.Background(), clients, namespace, name, key)
+	if err != nil {
+		return "", core.WrapWithSentinel(core.ErrSetupReadSecretKeyFailed, err, fmt.Sprintf("read secret %s/%s key %s: %v", namespace, name, key, err))
+	}
+	return value, nil
+}
+
+func existingSecretDataValueOrRandomWithReader(readSecret analyticsSecretValueReader, namespace, name, key string, size int) (string, error) {
+	value, err := readSecret(namespace, name, key)
 	if err != nil {
 		return "", err
 	}
@@ -732,8 +994,8 @@ func existingSecretDataValueOrRandom(kubectl core.KubectlRunner, namespace, name
 	return randomHex(size)
 }
 
-func existingSecretDataValueOrDefault(kubectl core.KubectlRunner, namespace, name, key, fallback string) (string, error) {
-	value, err := existingSecretDataValue(kubectl, namespace, name, key)
+func existingSecretDataValueOrDefaultWithReader(readSecret analyticsSecretValueReader, namespace, name, key, fallback string) (string, error) {
+	value, err := readSecret(namespace, name, key)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/setup/platform/platform_deploy.go
+++ b/internal/cli/setup/platform/platform_deploy.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"mcp-runtime/internal/cli/kube"
 	"mcp-runtime/internal/cli/registry/config"
 	setupplan "mcp-runtime/internal/cli/setup/plan"
+	"mcp-runtime/pkg/k8sclient"
 	"mcp-runtime/pkg/manifest"
 )
 
@@ -178,18 +180,25 @@ func verifySetup(logger *zap.Logger, usingExternalRegistry bool, deps SetupDeps)
 }
 
 func restartDeployment(name, namespace string) error {
-	// #nosec G204 -- command arguments are built from trusted inputs and fixed verbs.
-	return restartDeploymentWithKubectl(core.DefaultKubectlClient(), name, namespace)
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.RestartDeployment(context.Background(), clients, namespace, name, time.Now())
 }
 
+//lint:ignore U1000 retained as the legacy kubectl implementation for focused tests and fallback patches.
 func restartDeploymentWithKubectl(kubectl core.KubectlRunner, name, namespace string) error {
 	// #nosec G204 -- command arguments are built from trusted inputs and fixed verbs.
 	return kubectl.RunWithOutput([]string{"rollout", "restart", "deployment/" + name, "-n", namespace}, os.Stdout, os.Stderr)
 }
 
 func checkCRDInstalled(name string) error {
-	// #nosec G204 -- name is hardcoded CRD identifier from internal code.
-	return checkCRDInstalledWithKubectl(core.DefaultKubectlClient(), name)
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.CheckCRDExists(context.Background(), clients, name)
 }
 
 func checkCRDInstalledWithKubectl(kubectl core.KubectlRunner, name string) error {
@@ -199,7 +208,28 @@ func checkCRDInstalledWithKubectl(kubectl core.KubectlRunner, name string) error
 
 // waitForDeploymentAvailable polls a deployment until it has at least one available replica or times out.
 func waitForDeploymentAvailable(logger *zap.Logger, name, namespace, selector string, timeout time.Duration) error {
-	return waitForDeploymentAvailableWithKubectl(core.DefaultKubectlClient(), logger, name, namespace, selector, timeout)
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.WaitForDeploymentAvailable(context.Background(), clients, namespace, name, timeout); err != nil {
+		msg := fmt.Sprintf("timed out waiting for deployment %s in namespace %s", name, namespace)
+		cause := core.NewWithSentinel(core.ErrSetupDeploymentReadinessDeadlineExceeded, "deployment readiness deadline exceeded")
+		ctx := map[string]any{
+			"deployment": name,
+			"namespace":  namespace,
+			"selector":   selector,
+			"component":  "deployment-wait",
+		}
+		mergeDeploymentDebugDiagnosticsIfNeeded(core.DefaultKubectlClient(), ctx, name, namespace, selector)
+		wrappedErr := core.WrapWithSentinelAndContext(core.ErrDeploymentTimeout, cause, msg, ctx)
+		core.Error("Deployment timeout")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Deployment timeout")
+		}
+		return wrappedErr
+	}
+	return nil
 }
 
 // waitForDeploymentAvailableWithKubectl polls a deployment until it has at least one available replica or times out.
@@ -366,7 +396,153 @@ func mergeCRDCheckDebugDiagnosticsIfNeeded(kubectl core.KubectlRunner, m map[str
 // deployOperatorManifests deploys operator manifests without requiring kustomize or controller-gen.
 // It applies CRD, RBAC, and manager manifests directly, replacing the image name in the process.
 func deployOperatorManifests(logger *zap.Logger, operatorImage, gatewayProxyImage string, operatorArgs []string, imagePullSecretName string) error {
-	return deployOperatorManifestsWithKubectl(core.DefaultKubectlClient(), logger, operatorImage, gatewayProxyImage, operatorArgs, imagePullSecretName)
+	return deployOperatorManifestsWithClientGo(logger, operatorImage, gatewayProxyImage, operatorArgs, imagePullSecretName)
+}
+
+func deployOperatorManifestsWithClientGo(logger *zap.Logger, operatorImage, gatewayProxyImage string, operatorArgs []string, imagePullSecretName string) error {
+	if err := ensureRepoManagedTraefikMiddlewareResourcesClientGo(logger); err != nil {
+		return err
+	}
+
+	core.Info("Applying CRD manifests")
+	if err := applyManifestDir("config/crd/bases", "", os.Stdout); err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrApplyCRDFailed, err, fmt.Sprintf("failed to apply CRD: %v", err))
+		core.Error("Failed to apply CRD")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Failed to apply CRD")
+		}
+		return wrappedErr
+	}
+
+	core.Info("Applying RBAC manifests")
+	if err := ensureNamespaceWithLabels(core.NamespaceMCPRuntime, nil); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrEnsureOperatorNamespaceFailed,
+			err,
+			fmt.Sprintf("failed to ensure operator namespace: %v", err),
+			map[string]any{"namespace": core.NamespaceMCPRuntime, "component": "setup"},
+		)
+		core.Error("Failed to ensure operator namespace")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Failed to ensure operator namespace")
+		}
+		return wrappedErr
+	}
+	for _, path := range []string{
+		"config/rbac/service_account.yaml",
+		"config/rbac/role.yaml",
+		"config/rbac/role_binding.yaml",
+	} {
+		if err := applyManifestFile(path, "", os.Stdout); err != nil {
+			wrappedErr := core.WrapWithSentinel(core.ErrApplyRBACFailed, err, fmt.Sprintf("failed to apply RBAC: %v", err))
+			core.Error("Failed to apply RBAC")
+			if logger != nil {
+				core.LogStructuredError(logger, wrappedErr, "Failed to apply RBAC")
+			}
+			return wrappedErr
+		}
+	}
+	core.Info("Reapplied operator ClusterRole mcp-runtime-operator-role from config/rbac/role.yaml; run `mcp-runtime cluster doctor` if MCPServer creates ever appear unreconciled")
+
+	core.Info("Applying operator deployment")
+	managerYAML, err := renderOperatorManagerManifest(operatorImage, gatewayProxyImage, operatorArgs, existingOperatorEnvValueClientGo)
+	if err != nil {
+		if logger != nil {
+			core.LogStructuredError(logger, err, "Failed to render manager manifest")
+		}
+		return err
+	}
+	if strings.TrimSpace(imagePullSecretName) != "" {
+		rendered, err := injectImagePullSecretsIntoManifest(string(managerYAML), imagePullSecretName)
+		if err != nil {
+			wrappedErr := core.WrapWithSentinel(core.ErrRenderManagerYAMLFailed, err, fmt.Sprintf("failed to inject operator imagePullSecret: %v", err))
+			core.Error("Failed to inject operator imagePullSecret")
+			if logger != nil {
+				core.LogStructuredError(logger, wrappedErr, "Failed to inject operator imagePullSecret")
+			}
+			return wrappedErr
+		}
+		managerYAML = []byte(rendered)
+	}
+	if err := applyManifestYAML(string(managerYAML), core.NamespaceMCPRuntime, os.Stdout); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrApplyManagerDeploymentFailed,
+			err,
+			fmt.Sprintf("failed to apply manager deployment: %v", err),
+			map[string]any{"operator_image": operatorImage, "namespace": core.NamespaceMCPRuntime, "component": "setup"},
+		)
+		core.Error("Failed to apply manager deployment")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Failed to apply manager deployment")
+		}
+		return wrappedErr
+	}
+
+	core.Success("Operator manifests deployed successfully")
+	return nil
+}
+
+func renderOperatorManagerManifest(operatorImage, gatewayProxyImage string, operatorArgs []string, existingEnvValue func(string) string) ([]byte, error) {
+	managerYAML, err := os.ReadFile("config/manager/manager.yaml")
+	if err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrReadManagerYAMLFailed, err, fmt.Sprintf("failed to read manager.yaml: %v", err))
+		core.Error("Failed to read manager.yaml")
+		return nil, wrappedErr
+	}
+
+	mutator, err := manifest.NewMutator(managerYAML)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrParseManagerYAMLFailed, err, fmt.Sprintf("failed to parse manager.yaml: %v", err))
+		core.Error("Failed to parse manager.yaml")
+		return nil, wrappedErr
+	}
+
+	if err := mutator.SetDeploymentImage(core.OperatorDeploymentName, core.OperatorManagerContainerName, operatorImage); err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrSetOperatorImageFailed, err, fmt.Sprintf("failed to set operator image: %v", err))
+		core.Error("Failed to set operator image")
+		return nil, wrappedErr
+	}
+
+	pullPolicy := operatorImagePullPolicy(operatorImage)
+	if pullPolicy != "" {
+		if err := mutator.SetDeploymentImagePullPolicy(core.OperatorDeploymentName, core.OperatorManagerContainerName, pullPolicy); err != nil {
+			wrappedErr := core.WrapWithSentinel(core.ErrMutateManagerYAMLFailed, err, fmt.Sprintf("failed to set operator image pull policy: %v", err))
+			core.Error("Failed to set operator image pull policy")
+			return nil, wrappedErr
+		}
+	}
+
+	if len(operatorArgs) > 0 {
+		if err := mutator.MergeDeploymentArgs(core.OperatorDeploymentName, core.OperatorManagerContainerName, operatorArgs); err != nil {
+			wrappedErr := core.WrapWithSentinel(core.ErrMutateManagerYAMLFailed, err, fmt.Sprintf("failed to merge operator args: %v", err))
+			core.Error("Failed to merge operator args")
+			return nil, wrappedErr
+		}
+	}
+
+	existingGatewayOTLPEndpoint := ""
+	if existingEnvValue != nil {
+		existingGatewayOTLPEndpoint = existingEnvValue(gatewayOTELExporterOTLPEndpointEnv)
+	}
+	if envVars := operatorEnvOverrides(gatewayProxyImage, existingGatewayOTLPEndpoint); len(envVars) > 0 {
+		envMap := make(map[string]string, len(envVars))
+		for _, ev := range envVars {
+			envMap[ev.Name] = ev.Value
+		}
+		if err := mutator.MergeDeploymentEnv(core.OperatorDeploymentName, core.OperatorManagerContainerName, envMap); err != nil {
+			wrappedErr := core.WrapWithSentinel(core.ErrMutateManagerYAMLFailed, err, fmt.Sprintf("failed to merge operator env vars: %v", err))
+			core.Error("Failed to merge operator env vars")
+			return nil, wrappedErr
+		}
+	}
+
+	mutatedYAML, err := mutator.ToYAML()
+	if err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrRenderManagerYAMLFailed, err, fmt.Sprintf("failed to render mutated manifest: %v", err))
+		core.Error("Failed to render mutated manifest")
+		return nil, wrappedErr
+	}
+	return mutatedYAML, nil
 }
 
 // deployOperatorManifestsWithKubectl deploys operator manifests without requiring kustomize or controller-gen.
@@ -602,6 +778,10 @@ func runRolloutWithOptionalDebugCapture(kubectl core.KubectlRunner, kind, name, 
 	return buf.String(), err
 }
 
+func runRolloutWithOptionalDebugCaptureClientGo(kind, name, namespace string, timeout time.Duration) (capture string, err error) {
+	return "", waitForRolloutStatusWithClientGo(kind, name, namespace, timeout)
+}
+
 func kubectlText(kubectl core.KubectlRunner, args []string) (string, error) {
 	cmd, err := kubectl.CommandArgs(args)
 	if err != nil {
@@ -615,14 +795,26 @@ func waitForRolloutStatusWithKubectl(kubectl core.KubectlRunner, kind, name, nam
 	return kubectl.RunWithOutput([]string{"rollout", "status", fmt.Sprintf("%s/%s", kind, name), "-n", namespace, "--timeout=" + timeout}, os.Stdout, os.Stderr)
 }
 
+func waitForRolloutStatusWithClientGo(kind, name, namespace string, timeout time.Duration) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.WaitForWorkloadRollout(context.Background(), clients, namespace, kind, name, timeout)
+}
+
 // analyticsRolloutTimeoutString returns the kubectl --timeout value for mcp-sentinel rollouts.
 // Uses MCP_DEPLOYMENT_TIMEOUT (see core.GetDeploymentTimeout); if unset or non-positive, uses the default 5m.
 func analyticsRolloutTimeoutString() string {
+	return analyticsRolloutTimeoutDuration().String()
+}
+
+func analyticsRolloutTimeoutDuration() time.Duration {
 	d := core.GetDeploymentTimeout()
 	if d <= 0 {
 		d = 5 * time.Minute
 	}
-	return d.String()
+	return d
 }
 
 // printAnalyticsRolloutDiagnostics prints pods and events to help triage stuck mcp-sentinel rollouts.
@@ -638,8 +830,24 @@ func waitForJobCompletionWithKubectl(kubectl core.KubectlRunner, name, namespace
 	return kubectl.RunWithOutput([]string{"wait", "--for=condition=complete", "job/" + name, "-n", namespace, "--timeout=" + timeout}, os.Stdout, os.Stderr)
 }
 
+func waitForJobCompletionClientGo(name, namespace string, timeout time.Duration) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.WaitForJobComplete(context.Background(), clients, namespace, name, timeout)
+}
+
 func deleteJobIfExistsWithKubectl(kubectl core.KubectlRunner, name, namespace string) error {
 	return kubectl.RunWithOutput([]string{"delete", "job/" + name, "-n", namespace, "--ignore-not-found=true", "--wait=true", "--timeout=60s"}, os.Stdout, os.Stderr)
+}
+
+func deleteJobIfExistsClientGo(name, namespace string) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.DeleteJob(context.Background(), clients, namespace, name, 60*time.Second)
 }
 
 func operatorImagePullPolicy(operatorImage string) string {
@@ -716,6 +924,28 @@ func existingOperatorEnvValue(kubectl core.KubectlRunner, name string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+func existingOperatorEnvValueClientGo(name string) string {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return ""
+	}
+	deploy, err := k8sclient.GetDeployment(context.Background(), clients, core.NamespaceMCPRuntime, core.OperatorDeploymentName)
+	if err != nil {
+		return ""
+	}
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		if container.Name != core.OperatorManagerContainerName {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == name {
+				return strings.TrimSpace(env.Value)
+			}
+		}
+	}
+	return ""
 }
 
 func applySetupPlanToCLIConfig(plan setupplan.Plan) {

--- a/internal/cli/setup/platform/platform_images.go
+++ b/internal/cli/setup/platform/platform_images.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"slices"
@@ -14,6 +15,7 @@ import (
 	"mcp-runtime/internal/cli/registry/config"
 	"mcp-runtime/internal/cli/registry/ref"
 	"mcp-runtime/internal/cli/setup/assetpath"
+	"mcp-runtime/pkg/k8sclient"
 )
 
 func setupImageTag() string {
@@ -24,15 +26,9 @@ func setupImageTag() string {
 }
 
 func resolveSetupImagePlatform(kubectl core.KubectlRunner) (string, error) {
-	var explicitPlatform string
-	if core.DefaultCLIConfig != nil {
-		if platform := strings.TrimSpace(core.DefaultCLIConfig.ImagePlatform); platform != "" {
-			validated, err := validateSetupImagePlatform(platform)
-			if err != nil {
-				return "", err
-			}
-			explicitPlatform = validated
-		}
+	explicitPlatform, err := explicitSetupImagePlatform()
+	if err != nil {
+		return "", err
 	}
 
 	cacheKey := fmt.Sprintf("%T:%p:%s", kubectl, kubectl, explicitPlatform)
@@ -50,6 +46,26 @@ func resolveSetupImagePlatform(kubectl core.KubectlRunner) (string, error) {
 	return entry.platform, entry.err
 }
 
+func resolveSetupImagePlatformClientGo() (string, error) {
+	explicitPlatform, err := explicitSetupImagePlatform()
+	if err != nil {
+		return "", err
+	}
+	archs, err := clusterNodeArchitecturesClientGo()
+	return resolveSetupImagePlatformFromArchitectures(archs, explicitPlatform, err)
+}
+
+func explicitSetupImagePlatform() (string, error) {
+	if core.DefaultCLIConfig == nil {
+		return "", nil
+	}
+	platform := strings.TrimSpace(core.DefaultCLIConfig.ImagePlatform)
+	if platform == "" {
+		return "", nil
+	}
+	return validateSetupImagePlatform(platform)
+}
+
 func resetSetupImagePlatformCacheForTest() {
 	setupImagePlatformCache.Lock()
 	setupImagePlatformCache.entries = map[string]*setupImagePlatformCacheEntry{}
@@ -58,6 +74,10 @@ func resetSetupImagePlatformCacheForTest() {
 
 func resolveSetupImagePlatformUncached(kubectl core.KubectlRunner, explicitPlatform string) (string, error) {
 	archs, err := clusterNodeArchitectures(kubectl)
+	return resolveSetupImagePlatformFromArchitectures(archs, explicitPlatform, err)
+}
+
+func resolveSetupImagePlatformFromArchitectures(archs []string, explicitPlatform string, err error) (string, error) {
 	if err != nil {
 		if explicitPlatform != "" {
 			return explicitPlatform, nil
@@ -121,6 +141,18 @@ func clusterNodeArchitectures(kubectl core.KubectlRunner) ([]string, error) {
 		archs = append(archs, arch)
 	}
 	slices.Sort(archs)
+	return archs, nil
+}
+
+func clusterNodeArchitecturesClientGo() ([]string, error) {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return nil, core.WrapWithSentinel(core.ErrSetupInspectNodeArchitecturesFailed, err, fmt.Sprintf("could not create Kubernetes client to inspect node architectures: %v", err))
+	}
+	archs, err := k8sclient.NodeArchitectures(context.Background(), clients)
+	if err != nil {
+		return nil, core.WrapWithSentinel(core.ErrSetupInspectNodeArchitecturesFailed, err, fmt.Sprintf("could not inspect Kubernetes node architectures: %v", err))
+	}
 	return archs, nil
 }
 
@@ -485,7 +517,7 @@ func getOperatorImage(ext *config.ExternalRegistryConfig) string {
 	if ext != nil && ext.URL != "" {
 		return strings.TrimSuffix(ext.URL, "/") + "/mcp-runtime-operator:" + tag
 	}
-	return fmt.Sprintf("%s/mcp-runtime-operator:%s", registry.ResolveInternalPlatformRegistryURL(nil), tag)
+	return fmt.Sprintf("%s/mcp-runtime-operator:%s", resolveInternalPlatformRegistryURLClientGo(nil), tag)
 }
 
 func getGatewayProxyImage(ext *config.ExternalRegistryConfig) string {
@@ -498,7 +530,7 @@ func getGatewayProxyImage(ext *config.ExternalRegistryConfig) string {
 	if ext != nil && ext.URL != "" {
 		return strings.TrimSuffix(ext.URL, "/") + "/" + defaultGatewayProxyRepository + ":" + tag
 	}
-	return fmt.Sprintf("%s/%s:%s", registry.ResolveInternalPlatformRegistryURL(nil), defaultGatewayProxyRepository, tag)
+	return fmt.Sprintf("%s/%s:%s", resolveInternalPlatformRegistryURLClientGo(nil), defaultGatewayProxyRepository, tag)
 }
 
 func analyticsImageFor(ext *config.ExternalRegistryConfig, repository string) string {
@@ -507,11 +539,11 @@ func analyticsImageFor(ext *config.ExternalRegistryConfig, repository string) st
 	if ext != nil && ext.URL != "" {
 		return strings.TrimSuffix(ext.URL, "/") + "/" + repository + ":" + tag
 	}
-	return fmt.Sprintf("%s/%s:%s", registry.ResolveInternalPlatformRegistryURL(nil), repository, tag)
+	return fmt.Sprintf("%s/%s:%s", resolveInternalPlatformRegistryURLClientGo(nil), repository, tag)
 }
 
 func buildOperatorImage(image string) error {
-	platform, err := resolveSetupImagePlatform(core.DefaultKubectlClient())
+	platform, err := resolveSetupImagePlatformClientGo()
 	if err != nil {
 		return err
 	}
@@ -530,7 +562,7 @@ func buildOperatorImage(image string) error {
 }
 
 func buildGatewayProxyImage(image string) error {
-	platform, err := resolveSetupImagePlatform(core.DefaultKubectlClient())
+	platform, err := resolveSetupImagePlatformClientGo()
 	if err != nil {
 		return err
 	}
@@ -560,7 +592,7 @@ func buildGatewayProxyImage(image string) error {
 }
 
 func buildAnalyticsImage(image, dockerfilePath, buildContext string) error {
-	platform, err := resolveSetupImagePlatform(core.DefaultKubectlClient())
+	platform, err := resolveSetupImagePlatformClientGo()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/setup/platform/platform_registry.go
+++ b/internal/cli/setup/platform/platform_registry.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"mcp-runtime/internal/cli/registry/config"
 	"mcp-runtime/internal/cli/registry/ref"
 	setupplan "mcp-runtime/internal/cli/setup/plan"
+	"mcp-runtime/pkg/k8sclient"
 )
 
 func ValidateRegistryMode(mode string) error {
@@ -125,13 +127,22 @@ func shouldStageRegistryIngressAuth(usingExternalRegistry bool) bool {
 }
 
 func disableRegistryIngressAuth() error {
-	return disableRegistryIngressAuthWithKubectl(core.DefaultKubectlClient())
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.RemoveIngressAnnotation(context.Background(), clients, core.NamespaceRegistry, core.RegistryServiceName, "traefik.ingress.kubernetes.io/router.middlewares")
 }
 
 func enableRegistryIngressAuth() error {
-	return enableRegistryIngressAuthWithKubectl(core.DefaultKubectlClient())
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.SetIngressAnnotation(context.Background(), clients, core.NamespaceRegistry, core.RegistryServiceName, "traefik.ingress.kubernetes.io/router.middlewares", registryAdminAuthMiddleware)
 }
 
+//lint:ignore U1000 retained as the legacy kubectl implementation for focused tests and fallback patches.
 func disableRegistryIngressAuthWithKubectl(kubectl core.KubectlRunner) error {
 	// Capture kubectl output so the success path stays quiet (the annotation
 	// may already be absent, which kubectl reports loudly) but surface the
@@ -157,6 +168,7 @@ func disableRegistryIngressAuthWithKubectl(kubectl core.KubectlRunner) error {
 	return err
 }
 
+//lint:ignore U1000 retained as the legacy kubectl implementation for focused tests and fallback patches.
 func enableRegistryIngressAuthWithKubectl(kubectl core.KubectlRunner) error {
 	var stdout, stderr bytes.Buffer
 	err := kubectl.RunWithOutput([]string{
@@ -172,7 +184,49 @@ func enableRegistryIngressAuthWithKubectl(kubectl core.KubectlRunner) error {
 }
 
 func configureProvisionedRegistryEnv(ext *config.ExternalRegistryConfig, secretName string) error {
-	return configureProvisionedRegistryEnvWithKubectl(core.DefaultKubectlClient(), ext, secretName)
+	return configureProvisionedRegistryEnvWithClientGo(ext, secretName)
+}
+
+func configureProvisionedRegistryEnvWithClientGo(ext *config.ExternalRegistryConfig, secretName string) error {
+	if ext == nil || ext.URL == "" {
+		return nil
+	}
+	hasCreds := ext.Username != "" || ext.Password != ""
+	if hasCreds && secretName == "" {
+		secretName = defaultRegistrySecretName
+	}
+	literals := map[string]string{"PROVISIONED_REGISTRY_URL": ext.URL}
+	secretKeys := []string(nil)
+	if hasCreds {
+		if err := ensureProvisionedRegistrySecretWithClientGo(secretName, ext.Username, ext.Password); err != nil {
+			return err
+		}
+		platformMode := os.Getenv("MCP_PLATFORM_MODE")
+		catalogNamespace := setupplan.CatalogNamespaceForPlatformMode(platformMode)
+		if catalogNamespace != "" {
+			if err := ensureNamespaceWithLabels(catalogNamespace, catalogNamespaceLabels(platformMode)); err != nil {
+				return err
+			}
+			if err := ensureImagePullSecretWithClientGo(catalogNamespace, secretName, ext.URL, ext.Username, ext.Password); err != nil {
+				return err
+			}
+		}
+		literals["PROVISIONED_REGISTRY_SECRET_NAME"] = secretName
+		secretKeys = []string{"PROVISIONED_REGISTRY_USERNAME", "PROVISIONED_REGISTRY_PASSWORD"}
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	return k8sclient.SetDeploymentEnv(
+		context.Background(),
+		clients,
+		core.NamespaceMCPRuntime,
+		core.OperatorDeploymentName,
+		literals,
+		secretName,
+		secretKeys,
+	)
 }
 
 func configureProvisionedRegistryEnvWithKubectl(kubectl core.KubectlRunner, ext *config.ExternalRegistryConfig, secretName string) error {
@@ -277,6 +331,34 @@ func ensureProvisionedRegistrySecretWithKubectl(kubectl core.KubectlRunner, name
 	return nil
 }
 
+func ensureProvisionedRegistrySecretWithClientGo(name, username, password string) error {
+	data := map[string]string{}
+	if username != "" {
+		data["PROVISIONED_REGISTRY_USERNAME"] = username
+	}
+	if password != "" {
+		data["PROVISIONED_REGISTRY_PASSWORD"] = password
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.UpsertOpaqueSecretStringData(context.Background(), clients, core.NamespaceMCPRuntime, name, data); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrApplySecretManifestFailed,
+			err,
+			fmt.Sprintf("apply secret manifest: %v", err),
+			map[string]any{"secret_name": name, "namespace": core.NamespaceMCPRuntime, "component": "setup"},
+		)
+		core.Error("Failed to apply secret manifest")
+		return wrappedErr
+	}
+	return nil
+}
+
 func ensureImagePullSecretWithKubectl(kubectl core.KubectlRunner, namespace, name, registry, username, password string) error {
 	if username == "" && password == "" {
 		return nil
@@ -335,6 +417,27 @@ data:
 		return wrappedErr
 	}
 
+	return nil
+}
+
+func ensureImagePullSecretWithClientGo(namespace, name, registry, username, password string) error {
+	if username == "" && password == "" {
+		return nil
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.UpsertDockerConfigSecret(context.Background(), clients, namespace, name, registry, username, password); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrApplyImagePullSecretFailed,
+			err,
+			fmt.Sprintf("apply imagePullSecret: %v", err),
+			map[string]any{"secret_name": name, "namespace": namespace, "registry": registry, "component": "setup"},
+		)
+		core.Error("Failed to apply image pull secret")
+		return wrappedErr
+	}
 	return nil
 }
 

--- a/internal/cli/setup/platform/platform_registry_deploy.go
+++ b/internal/cli/setup/platform/platform_registry_deploy.go
@@ -1,0 +1,182 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"mcp-runtime/internal/cli/core"
+	"mcp-runtime/pkg/k8sclient"
+)
+
+const (
+	defaultRegistryDeploymentImage  = "registry:2.8.3"
+	registryImageOverrideEnvForPlan = "MCP_RUNTIME_REGISTRY_IMAGE_OVERRIDE"
+)
+
+func deployRegistryClientGo(logger *zap.Logger, namespace string, port int, registryType, registryStorageSize, manifestPath string) error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.EnsureNamespace(context.Background(), clients, namespace, nil); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrEnsureNamespaceFailed,
+			err,
+			fmt.Sprintf("failed to ensure namespace: %v", err),
+			map[string]any{"namespace": namespace, "component": "registry"},
+		)
+		core.Error("Failed to ensure namespace")
+		core.LogStructuredError(logger, wrappedErr, "Failed to ensure namespace")
+		return wrappedErr
+	}
+
+	if logger != nil {
+		logger.Info("Applying registry manifests")
+	}
+	manifest, err := renderRegistryKustomizeManifest(manifestPath)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrDeployRegistryFailed,
+			err,
+			fmt.Sprintf("failed to render registry manifest %q: %v", manifestPath, err),
+			map[string]any{"namespace": namespace, "manifest_path": manifestPath, "registry_type": registryType, "component": "registry"},
+		)
+		core.Error("Failed to render registry manifest")
+		core.LogStructuredError(logger, wrappedErr, "Failed to render registry manifest")
+		return wrappedErr
+	}
+	manifest = rewriteRegistryManifestHost(manifest, core.GetRegistryIngressHost())
+	manifest = stripRegistryManifestClusterIssuerAnnotation(manifest)
+	if overrideImage := strings.TrimSpace(os.Getenv(registryImageOverrideEnvForPlan)); overrideImage != "" {
+		if logger != nil {
+			logger.Info("Applying registry image override", zap.String("image", overrideImage))
+		}
+		updated := strings.Replace(manifest, "image: "+defaultRegistryDeploymentImage, "image: "+overrideImage, 1)
+		if updated == manifest {
+			err := fmt.Errorf("registry image reference %q not found in manifest", defaultRegistryDeploymentImage)
+			wrappedErr := core.WrapWithSentinelAndContext(
+				core.ErrDeployRegistryFailed,
+				err,
+				err.Error(),
+				map[string]any{"namespace": namespace, "manifest_path": manifestPath, "registry_type": registryType, "component": "registry"},
+			)
+			core.Error("Failed to rewrite registry image")
+			core.LogStructuredError(logger, wrappedErr, "Failed to rewrite registry image")
+			return wrappedErr
+		}
+		manifest = updated
+	}
+	results, err := k8sclient.ApplyManifestYAML(context.Background(), clients, []byte(manifest), namespace)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrDeployRegistryFailed,
+			err,
+			fmt.Sprintf("failed to deploy registry: %v", err),
+			map[string]any{"namespace": namespace, "manifest_path": manifestPath, "registry_type": registryType, "component": "registry"},
+		)
+		core.Error("Failed to deploy registry")
+		core.LogStructuredError(logger, wrappedErr, "Failed to deploy registry")
+		return wrappedErr
+	}
+	writeApplyResults(os.Stdout, results)
+
+	if err := ensureRegistryStorageSizeClientGo(logger, clients, namespace, registryStorageSize); err != nil {
+		return err
+	}
+
+	if logger != nil {
+		logger.Info("Waiting for registry to be ready")
+	}
+	if err := k8sclient.WaitForDeploymentAvailable(context.Background(), clients, namespace, "registry", 5*time.Minute); err != nil {
+		if logger != nil {
+			logger.Warn("Registry deployment may still be in progress", zap.Error(err))
+		}
+	}
+	if logger != nil {
+		logger.Info("Registry deployed successfully")
+	}
+	_ = port
+	return nil
+}
+
+func renderRegistryKustomizeManifest(manifestPath string) (string, error) {
+	kubectl := core.DefaultKubectlClient()
+	renderCmd, err := kubectl.CommandArgs([]string{"kustomize", manifestPath})
+	if err != nil {
+		return "", err
+	}
+	var stdout, stderr bytes.Buffer
+	renderCmd.SetStdout(&stdout)
+	renderCmd.SetStderr(&stderr)
+	if err := renderCmd.Run(); err != nil {
+		return "", fmt.Errorf("kubectl kustomize %s failed: %w (%s)", manifestPath, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+func rewriteRegistryManifestHost(manifest, host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" || host == "registry.local" {
+		return manifest
+	}
+	return strings.ReplaceAll(manifest, "registry.local", host)
+}
+
+func stripRegistryManifestClusterIssuerAnnotation(manifest string) string {
+	lines := strings.SplitAfter(manifest, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "cert-manager.io/cluster-issuer:") || strings.HasPrefix(trimmed, `"cert-manager.io/cluster-issuer":`) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "")
+}
+
+func ensureRegistryStorageSizeClientGo(logger *zap.Logger, clients *k8sclient.Clients, namespace, registryStorageSize string) error {
+	storageSize := strings.TrimSpace(registryStorageSize)
+	if storageSize == "" {
+		return nil
+	}
+	currentSize, err := k8sclient.PersistentVolumeClaimStorage(context.Background(), clients, namespace, core.RegistryPVCName)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrReadRegistryStorageFailed,
+			err,
+			fmt.Sprintf("failed to read current registry storage size: %v", err),
+			map[string]any{"namespace": namespace, "pvc": core.RegistryPVCName, "component": "registry"},
+		)
+		core.Error("Failed to read registry storage size")
+		core.LogStructuredError(logger, wrappedErr, "Failed to read registry storage size")
+		return wrappedErr
+	}
+	if currentSize == storageSize {
+		if logger != nil {
+			logger.Info("Registry storage size already matches requested value", zap.String("size", storageSize))
+		}
+		return nil
+	}
+	if logger != nil {
+		logger.Info("Updating registry storage size", zap.String("from", currentSize), zap.String("to", storageSize))
+	}
+	if err := k8sclient.UpdatePersistentVolumeClaimStorage(context.Background(), clients, namespace, core.RegistryPVCName, storageSize); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrUpdateRegistryStorageFailed,
+			err,
+			fmt.Sprintf("failed to update registry storage size to %s: %v", storageSize, err),
+			map[string]any{"namespace": namespace, "pvc": core.RegistryPVCName, "storage_size": storageSize, "component": "registry"},
+		)
+		core.Error("Failed to update registry storage size")
+		core.LogStructuredError(logger, wrappedErr, "Failed to update registry storage size")
+		return wrappedErr
+	}
+	return nil
+}

--- a/internal/cli/setup/platform/platform_registry_deploy.go
+++ b/internal/cli/setup/platform/platform_registry_deploy.go
@@ -4,14 +4,19 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
 
 	"go.uber.org/zap"
+	"sigs.k8s.io/yaml"
 
 	"mcp-runtime/internal/cli/core"
 	"mcp-runtime/pkg/k8sclient"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const (
@@ -20,6 +25,9 @@ const (
 )
 
 func deployRegistryClientGo(logger *zap.Logger, namespace string, port int, registryType, registryStorageSize, manifestPath string) error {
+	if err := validateRegistryType(registryType); err != nil {
+		return err
+	}
 	clients, err := platformKubernetesClients()
 	if err != nil {
 		return err
@@ -51,26 +59,21 @@ func deployRegistryClientGo(logger *zap.Logger, namespace string, port int, regi
 		core.LogStructuredError(logger, wrappedErr, "Failed to render registry manifest")
 		return wrappedErr
 	}
-	manifest = rewriteRegistryManifestHost(manifest, core.GetRegistryIngressHost())
-	manifest = stripRegistryManifestClusterIssuerAnnotation(manifest)
-	if overrideImage := strings.TrimSpace(os.Getenv(registryImageOverrideEnvForPlan)); overrideImage != "" {
-		if logger != nil {
-			logger.Info("Applying registry image override", zap.String("image", overrideImage))
-		}
-		updated := strings.Replace(manifest, "image: "+defaultRegistryDeploymentImage, "image: "+overrideImage, 1)
-		if updated == manifest {
-			err := fmt.Errorf("registry image reference %q not found in manifest", defaultRegistryDeploymentImage)
-			wrappedErr := core.WrapWithSentinelAndContext(
-				core.ErrDeployRegistryFailed,
-				err,
-				err.Error(),
-				map[string]any{"namespace": namespace, "manifest_path": manifestPath, "registry_type": registryType, "component": "registry"},
-			)
-			core.Error("Failed to rewrite registry image")
-			core.LogStructuredError(logger, wrappedErr, "Failed to rewrite registry image")
-			return wrappedErr
-		}
-		manifest = updated
+	overrideImage := strings.TrimSpace(os.Getenv(registryImageOverrideEnvForPlan))
+	if overrideImage != "" && logger != nil {
+		logger.Info("Applying registry image override", zap.String("image", overrideImage))
+	}
+	manifest, err = mutateRegistryManifest(manifest, core.GetRegistryIngressHost(), overrideImage)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrDeployRegistryFailed,
+			err,
+			err.Error(),
+			map[string]any{"namespace": namespace, "manifest_path": manifestPath, "registry_type": registryType, "component": "registry"},
+		)
+		core.Error("Failed to rewrite registry manifest")
+		core.LogStructuredError(logger, wrappedErr, "Failed to rewrite registry manifest")
+		return wrappedErr
 	}
 	results, err := k8sclient.ApplyManifestYAML(context.Background(), clients, []byte(manifest), namespace)
 	if err != nil {
@@ -120,25 +123,112 @@ func renderRegistryKustomizeManifest(manifestPath string) (string, error) {
 	return stdout.String(), nil
 }
 
-func rewriteRegistryManifestHost(manifest, host string) string {
-	host = strings.TrimSpace(host)
-	if host == "" || host == "registry.local" {
-		return manifest
+func validateRegistryType(registryType string) error {
+	switch strings.ToLower(strings.TrimSpace(registryType)) {
+	case "", "docker":
+		return nil
+	default:
+		return core.NewWithSentinel(core.ErrUnsupportedRegistryType, fmt.Sprintf("unsupported registry type %q; only docker is supported today", registryType))
 	}
-	return strings.ReplaceAll(manifest, "registry.local", host)
 }
 
-func stripRegistryManifestClusterIssuerAnnotation(manifest string) string {
-	lines := strings.SplitAfter(manifest, "\n")
-	out := make([]string, 0, len(lines))
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "cert-manager.io/cluster-issuer:") || strings.HasPrefix(trimmed, `"cert-manager.io/cluster-issuer":`) {
+func mutateRegistryManifest(manifest, host, overrideImage string) (string, error) {
+	host = strings.TrimSpace(host)
+	overrideImage = strings.TrimSpace(overrideImage)
+	replaceHost := host != "" && host != "registry.local"
+	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(manifest), 4096)
+	var out strings.Builder
+	imageReplaced := false
+	wroteObject := false
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", fmt.Errorf("decode registry manifest: %w", err)
+		}
+		if len(obj.Object) == 0 {
 			continue
 		}
-		out = append(out, line)
+		if replaceHost {
+			obj.Object = replaceStringValues(obj.Object, "registry.local", host).(map[string]any)
+		}
+		removeRegistryClusterIssuerAnnotation(obj)
+		if overrideImage != "" && setRegistryDeploymentImage(obj, overrideImage) {
+			imageReplaced = true
+		}
+		rendered, err := yaml.Marshal(obj.Object)
+		if err != nil {
+			return "", fmt.Errorf("encode registry manifest: %w", err)
+		}
+		if wroteObject {
+			out.WriteString("---\n")
+		}
+		out.Write(rendered)
+		if !strings.HasSuffix(string(rendered), "\n") {
+			out.WriteByte('\n')
+		}
+		wroteObject = true
 	}
-	return strings.Join(out, "")
+	if overrideImage != "" && !imageReplaced {
+		return "", fmt.Errorf("registry image reference %q not found in manifest", defaultRegistryDeploymentImage)
+	}
+	return out.String(), nil
+}
+
+func replaceStringValues(value any, oldValue, newValue string) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			typed[key] = replaceStringValues(nested, oldValue, newValue)
+		}
+		return typed
+	case []any:
+		for i, nested := range typed {
+			typed[i] = replaceStringValues(nested, oldValue, newValue)
+		}
+		return typed
+	case string:
+		return strings.ReplaceAll(typed, oldValue, newValue)
+	default:
+		return typed
+	}
+}
+
+func removeRegistryClusterIssuerAnnotation(obj *unstructured.Unstructured) {
+	annotations := obj.GetAnnotations()
+	if len(annotations) == 0 {
+		return
+	}
+	delete(annotations, "cert-manager.io/cluster-issuer")
+	obj.SetAnnotations(annotations)
+}
+
+func setRegistryDeploymentImage(obj *unstructured.Unstructured, image string) bool {
+	if obj.GetKind() != "Deployment" || obj.GetName() != "registry" {
+		return false
+	}
+	containers, found, err := unstructured.NestedSlice(obj.Object, "spec", "template", "spec", "containers")
+	if err != nil || !found {
+		return false
+	}
+	replaced := false
+	for i, raw := range containers {
+		container, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if currentImage, _ := container["image"].(string); currentImage == defaultRegistryDeploymentImage {
+			container["image"] = image
+			containers[i] = container
+			replaced = true
+		}
+	}
+	if replaced {
+		_ = unstructured.SetNestedSlice(obj.Object, containers, "spec", "template", "spec", "containers")
+	}
+	return replaced
 }
 
 func ensureRegistryStorageSizeClientGo(logger *zap.Logger, clients *k8sclient.Clients, namespace, registryStorageSize string) error {

--- a/internal/cli/setup/platform/platform_registry_deploy_test.go
+++ b/internal/cli/setup/platform/platform_registry_deploy_test.go
@@ -1,0 +1,59 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateRegistryTypeRejectsUnsupportedValues(t *testing.T) {
+	if err := validateRegistryType("docker"); err != nil {
+		t.Fatalf("validateRegistryType(docker) error = %v", err)
+	}
+	if err := validateRegistryType("harbor"); err == nil {
+		t.Fatal("validateRegistryType(harbor) error = nil, want unsupported registry type")
+	}
+}
+
+func TestMutateRegistryManifestUsesStructuredRegistryUpdates(t *testing.T) {
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: registry
+spec:
+  template:
+    spec:
+      containers:
+      - name: registry
+        # image: registry:2.8.3 in a comment should not be rewritten
+        image: registry:2.8.3
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: registry
+  namespace: registry
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  rules:
+  - host: registry.local
+`
+
+	rendered, err := mutateRegistryManifest(manifest, "registry.example.com", "registry.example.com/registry:2.8.3")
+	if err != nil {
+		t.Fatalf("mutateRegistryManifest() error = %v", err)
+	}
+	if strings.Contains(rendered, "cert-manager.io/cluster-issuer") {
+		t.Fatalf("expected cluster issuer annotation to be removed, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "registry.example.com") {
+		t.Fatalf("expected registry host rewrite, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "image: registry.example.com/registry:2.8.3") {
+		t.Fatalf("expected registry image override, got:\n%s", rendered)
+	}
+	if strings.Count(rendered, "registry.example.com/registry:2.8.3") != 1 {
+		t.Fatalf("expected only the container image to be rewritten, got:\n%s", rendered)
+	}
+}

--- a/internal/cli/setup/platform/platform_registry_resolve.go
+++ b/internal/cli/setup/platform/platform_registry_resolve.go
@@ -1,0 +1,92 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"mcp-runtime/internal/cli/core"
+)
+
+const registryServiceDNS = "registry.registry.svc.cluster.local"
+
+func resolveInternalPlatformRegistryURLClientGo(logger *zap.Logger) string {
+	cfg := core.DefaultCLIConfig
+	registryEndpoint := ""
+	registryIngressHost := ""
+	registryPort := 5000
+	if cfg != nil {
+		registryEndpoint = cfg.RegistryEndpoint
+		registryIngressHost = cfg.RegistryIngressHost
+		registryPort = cfg.RegistryPort
+	}
+	if endpoint := strings.TrimSpace(registryEndpoint); endpoint != "" &&
+		(registryEndpointExplicitlyConfiguredForPlatform() ||
+			(endpoint != core.DefaultRegistryEndpoint && endpoint != strings.TrimSpace(registryIngressHost))) {
+		return endpoint
+	}
+
+	portValue, portErr := registryServicePortClientGo()
+	if os.Getenv("MCP_RUNTIME_TEST_MODE") == "1" {
+		if portErr == nil && portValue != "" {
+			return fmt.Sprintf("%s:%s", registryServiceDNS, portValue)
+		}
+		if logger != nil {
+			logger.Warn("Could not detect registry service port in test mode, using default service DNS:port")
+		}
+		return fmt.Sprintf("%s:%d", registryServiceDNS, registryPort)
+	}
+
+	ip, ipErr := registryServiceClusterIPClientGo()
+	if ipErr == nil && ip != "" && portErr == nil && portValue != "" {
+		return fmt.Sprintf("%s:%s", ip, portValue)
+	}
+	if portErr == nil && portValue != "" {
+		return fmt.Sprintf("%s:%s", registryServiceDNS, portValue)
+	}
+
+	if logger != nil {
+		logger.Warn("Could not detect internal registry service port, using default service DNS:port")
+	}
+	return fmt.Sprintf("%s:%d", registryServiceDNS, registryPort)
+}
+
+func registryServiceClusterIPClientGo() (string, error) {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return "", err
+	}
+	service, err := clients.Clientset.CoreV1().Services(core.NamespaceRegistry).Get(context.Background(), core.RegistryServiceName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(service.Spec.ClusterIP), nil
+}
+
+func registryServicePortClientGo() (string, error) {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return "", err
+	}
+	service, err := clients.Clientset.CoreV1().Services(core.NamespaceRegistry).Get(context.Background(), core.RegistryServiceName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if len(service.Spec.Ports) == 0 {
+		return "", fmt.Errorf("registry service has no ports")
+	}
+	return fmt.Sprint(service.Spec.Ports[0].Port), nil
+}
+
+func registryEndpointExplicitlyConfiguredForPlatform() bool {
+	for _, key := range []string{"MCP_REGISTRY_ENDPOINT", "MCP_REGISTRY_HOST"} {
+		if value, ok := os.LookupEnv(key); ok && strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/setup/platform/platform_tls.go
+++ b/internal/cli/setup/platform/platform_tls.go
@@ -1,9 +1,13 @@
 package platform
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -13,6 +17,10 @@ import (
 	"mcp-runtime/internal/cli/core"
 	"mcp-runtime/internal/cli/kube"
 	setupplan "mcp-runtime/internal/cli/setup/plan"
+	"mcp-runtime/pkg/k8sclient"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // validateTLSSetupCLIFlags enforces ACME / internal-issuer mutual exclusion and
@@ -50,6 +58,8 @@ func setupTLSStep(logger *zap.Logger, plan setupplan.Plan, deps SetupDeps) error
 
 // setupTLSWithKubectlAndPlan provisions TLS: Let's Encrypt when plan.ACMEmail is set, an existing
 // ClusterIssuer when plan.TLSClusterIssuer is set, otherwise the bundled private CA (mcp-runtime-ca).
+//
+//lint:ignore U1000 retained as the legacy kubectl implementation for focused tests and fallback patches.
 func setupTLSWithKubectlAndPlan(kubectl core.KubectlRunner, logger *zap.Logger, plan setupplan.Plan) error {
 	if strings.TrimSpace(plan.ACMEmail) != "" {
 		return setupTLSLetsEncrypt(kubectl, logger, plan)
@@ -58,6 +68,542 @@ func setupTLSWithKubectlAndPlan(kubectl core.KubectlRunner, logger *zap.Logger, 
 		return setupTLSWithExistingClusterIssuer(kubectl, logger, plan)
 	}
 	return setupTLSPrivateCA(kubectl, logger, plan)
+}
+
+func setupTLSWithClientGoAndPlan(logger *zap.Logger, plan setupplan.Plan) error {
+	if strings.TrimSpace(plan.ACMEmail) != "" {
+		return setupTLSLetsEncryptClientGo(logger, plan)
+	}
+	if strings.TrimSpace(plan.TLSClusterIssuer) != "" {
+		return setupTLSWithExistingClusterIssuerClientGo(logger, plan)
+	}
+	return setupTLSPrivateCAClientGo(logger, plan)
+}
+
+func setupTLSLetsEncryptClientGo(logger *zap.Logger, plan setupplan.Plan) error {
+	core.Info("Configuring TLS with Let's Encrypt (cert-manager HTTP-01)")
+	if err := certmanager.ValidateACMEHostnameForPublicCA(); err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrTLSSetupFailed, err, err.Error())
+		core.Error("Invalid configuration for Let's Encrypt")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Invalid configuration for Let's Encrypt")
+		}
+		return wrappedErr
+	}
+	if err := certmanager.ValidateIngressManifestForACME(plan.Ingress.Manifest); err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrTLSSetupFailed, err, err.Error())
+		core.Error("Ingress configuration blocks Let's Encrypt")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Ingress configuration blocks Let's Encrypt")
+		}
+		return wrappedErr
+	}
+	if plan.InstallCertManager {
+		if err := ensureCertManagerInstalledClientGo(logger); err != nil {
+			return err
+		}
+	} else if err := checkCertManagerInstalledClientGo(); err != nil {
+		err := core.WrapWithSentinel(core.ErrCertManagerNotInstalled, err, "cert-manager not installed. Install it, or omit --skip-cert-manager-install to let setup apply it from upstream")
+		core.Error("Cert-manager not installed")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "Cert-manager not installed")
+		}
+		return err
+	}
+	if err := waitForTraefikDeploymentForACMEClientGo(); err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrTLSSetupFailed, err, err.Error())
+		core.Error("Traefik is not ready for HTTP-01")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Traefik is not ready for HTTP-01")
+		}
+		return wrappedErr
+	}
+	core.Info("Checking TCP connectivity to your ACME hostnames on port 80 (best effort from this machine)")
+	certmanager.PreflightACMEHostnamesPort80(certmanager.ACMETLSDNSNames())
+
+	name := certmanager.ClusterIssuerNameForACME(plan.ACMEStaging)
+	manifest := certmanager.RenderLetsEncryptClusterIssuerManifest(name, plan.ACMEmail, acmeServerURLForClientGo(plan.ACMEStaging))
+	core.Info("Applying Let's Encrypt ClusterIssuer")
+	if err := applyManifestYAML(manifest, "", os.Stdout); err != nil {
+		return err
+	}
+
+	if err := ensureNamespaceWithLabels(core.NamespaceRegistry, nil); err != nil {
+		return wrapRegistryNamespaceError(err, logger)
+	}
+	if err := ensureRegistryCertificateOwnershipClientGo(logger); err != nil {
+		return err
+	}
+
+	dnsNames := certmanager.ACMETLSDNSNames()
+	core.Info("Applying Certificate for registry (Let's Encrypt SANs)")
+	if err := applyRegistryCertificateClientGo(certmanager.RegistryCertificateName, certmanager.RegistryTLSSecretName, dnsNames, nil, name); err != nil {
+		return wrapApplyCertificateError(err, logger, certmanager.RegistryCertificateName)
+	}
+	certTimeout := core.GetCertTimeout()
+	if certTimeout < 5*time.Minute {
+		certTimeout = 5 * time.Minute
+	}
+	if err := waitForCertificateReadyClientGo(certmanager.RegistryCertificateName, core.NamespaceRegistry, certTimeout, logger, "certificate"); err != nil {
+		return err
+	}
+	core.Success("Certificate issued successfully")
+	return setupBundledRegistryInternalTLSClientGo(logger, plan)
+}
+
+func setupTLSWithExistingClusterIssuerClientGo(logger *zap.Logger, plan setupplan.Plan) error {
+	issuerName := strings.TrimSpace(plan.TLSClusterIssuer)
+	core.Info("Configuring TLS with existing ClusterIssuer: " + issuerName)
+	if plan.InstallCertManager {
+		if err := ensureCertManagerInstalledClientGo(logger); err != nil {
+			return err
+		}
+	} else if err := checkCertManagerInstalledClientGo(); err != nil {
+		err := core.WrapWithSentinel(core.ErrCertManagerNotInstalled, err, "cert-manager not installed. Install it, or omit --skip-cert-manager-install to let setup apply it from upstream")
+		core.Error("Cert-manager not installed")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "Cert-manager not installed")
+		}
+		return err
+	}
+	if err := checkNamedClusterIssuerClientGo(issuerName); err != nil {
+		core.Error("Cluster issuer not found")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "Cluster issuer not found")
+		}
+		return err
+	}
+	if err := ensureNamespaceWithLabels(core.NamespaceRegistry, nil); err != nil {
+		return wrapRegistryNamespaceError(err, logger)
+	}
+	if err := ensureRegistryCertificateOwnershipClientGo(logger); err != nil {
+		return err
+	}
+	dnsNames, ipAddresses := registryCertificateSANs(plan)
+	if len(dnsNames) == 0 && len(ipAddresses) == 0 {
+		err := core.NewWithSentinel(core.ErrSetupTLSCertificateSANsEmpty, "no DNS names or IP addresses resolved for the Certificate; set MCP_PLATFORM_DOMAIN, MCP_REGISTRY_HOST, or MCP_REGISTRY_INGRESS_HOST (and optional MCP_MCP_INGRESS_HOST)")
+		wrappedErr := core.WrapWithSentinel(core.ErrTLSSetupFailed, err, err.Error())
+		core.Error("Invalid TLS host configuration")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Invalid TLS host configuration")
+		}
+		return wrappedErr
+	}
+	core.Info("Applying Certificate for registry (custom ClusterIssuer)")
+	if err := applyRegistryCertificateClientGo(certmanager.RegistryCertificateName, certmanager.RegistryTLSSecretName, dnsNames, ipAddresses, issuerName); err != nil {
+		return wrapApplyCertificateError(err, logger, certmanager.RegistryCertificateName)
+	}
+	certTimeout := core.GetCertTimeout()
+	if certTimeout < 5*time.Minute {
+		certTimeout = 5 * time.Minute
+	}
+	if err := waitForCertificateReadyClientGo(certmanager.RegistryCertificateName, core.NamespaceRegistry, certTimeout, logger, "certificate"); err != nil {
+		return err
+	}
+	core.Success("Certificate issued successfully")
+	return setupBundledRegistryInternalTLSClientGo(logger, plan)
+}
+
+func setupTLSPrivateCAClientGo(logger *zap.Logger, plan setupplan.Plan) error {
+	core.Info("Checking cert-manager installation")
+	if err := checkCertManagerInstalledClientGo(); err != nil {
+		err := core.WrapWithSentinel(core.ErrCertManagerNotInstalled, err, "cert-manager not installed. Install it first:\n  helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set crds.enabled=true\n  or run setup with --with-tls --acme-email <addr> to install cert-manager automatically")
+		core.Error("Cert-manager not installed")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "Cert-manager not installed")
+		}
+		return err
+	}
+	core.Info("cert-manager CRDs found")
+
+	core.Info("Checking CA secret")
+	if plan.RegistryMode == setupplan.RegistryModeBundledHTTPS {
+		created, err := ensureCASecretClientGo()
+		if err != nil {
+			err := core.WrapWithSentinel(core.ErrCASecretNotFound, err, "CA secret 'mcp-runtime-ca' could not be generated in cert-manager namespace. Create a private CA manually:\n  kubectl create secret tls mcp-runtime-ca --cert=ca.crt --key=ca.key -n cert-manager")
+			core.Error("CA secret unavailable")
+			if logger != nil {
+				core.LogStructuredError(logger, err, "CA secret unavailable")
+			}
+			return err
+		}
+		if created {
+			core.Info("Generated cert-manager/mcp-runtime-ca for bundled HTTPS registry TLS; configure every Kubernetes node to trust its tls.crt before pulling from the bundled HTTPS registry")
+		}
+	} else if err := checkCASecretClientGo(); err != nil {
+		err := core.WrapWithSentinel(core.ErrCASecretNotFound, err, "CA secret 'mcp-runtime-ca' not found in cert-manager namespace. For Let's Encrypt use --acme-email, or create a private CA:\n  kubectl create secret tls mcp-runtime-ca --cert=ca.crt --key=ca.key -n cert-manager")
+		core.Error("CA secret not found")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "CA secret not found")
+		}
+		return err
+	}
+	core.Info("CA secret found")
+
+	core.Info("Applying ClusterIssuer")
+	if err := applyManifestFile("config/cert-manager/cluster-issuer.yaml", "", os.Stdout); err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrClusterIssuerApplyFailed, err, fmt.Sprintf("failed to apply ClusterIssuer: %v", err))
+		core.Error("Failed to apply ClusterIssuer")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Failed to apply ClusterIssuer")
+		}
+		return wrappedErr
+	}
+	if err := ensureNamespaceWithLabels(core.NamespaceRegistry, nil); err != nil {
+		return wrapRegistryNamespaceError(err, logger)
+	}
+	if err := ensureRegistryCertificateOwnershipClientGo(logger); err != nil {
+		return err
+	}
+	core.Info("Applying Certificate for registry")
+	var certErr error
+	if plan.RegistryMode == setupplan.RegistryModeBundledHTTPS {
+		dnsNames, ipAddresses := registryCertificateSANs(plan)
+		certErr = applyRegistryCertificateClientGo(certmanager.RegistryCertificateName, certmanager.RegistryTLSSecretName, dnsNames, ipAddresses, certmanager.CertClusterIssuerName)
+	} else {
+		certErr = applyRegistryCertificateFromTemplateClientGo()
+	}
+	if certErr != nil {
+		return wrapApplyCertificateError(certErr, logger, certmanager.RegistryCertificateName)
+	}
+	certTimeout := core.GetCertTimeout()
+	if err := waitForCertificateReadyClientGo(certmanager.RegistryCertificateName, core.NamespaceRegistry, certTimeout, logger, "certificate"); err != nil {
+		return err
+	}
+	core.Success("Certificate issued successfully")
+	return setupBundledRegistryInternalTLSClientGo(logger, plan)
+}
+
+func acmeServerURLForClientGo(staging bool) string {
+	if staging {
+		return "https://acme-staging-v02.api.letsencrypt.org/directory"
+	}
+	return "https://acme-v02.api.letsencrypt.org/directory"
+}
+
+func ensureCertManagerInstalledClientGo(logger *zap.Logger) error {
+	if err := checkCertManagerInstalledClientGo(); err == nil {
+		core.Info("cert-manager already installed")
+		return nil
+	}
+	core.Info("Installing cert-manager v1.16.2")
+	warnMsg := "If this fails (no network), install cert-manager manually, then re-run setup with --skip-cert-manager-install"
+	core.Warn(warnMsg)
+	resp, err := http.Get(certmanager.CertManagerInstallManifestURL()) // #nosec G107 -- fixed cert-manager release URL.
+	if err != nil {
+		wrapped := core.WrapWithSentinel(core.ErrCertManagerInstallFailed, err, fmt.Sprintf("cert-manager install failed: %v. %s", err, warnMsg))
+		core.Error("cert-manager install failed")
+		if logger != nil {
+			core.LogStructuredError(logger, wrapped, "cert-manager install failed")
+		}
+		return wrapped
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		err := core.NewWithSentinel(core.ErrCertManagerInstallFailed, fmt.Sprintf("cert-manager install manifest download failed: HTTP %d. %s", resp.StatusCode, warnMsg))
+		core.Error("cert-manager install failed")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "cert-manager install failed")
+		}
+		return err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrCertManagerInstallFailed, err, fmt.Sprintf("read cert-manager install manifest: %v", err))
+	}
+	if err := applyManifestYAML(string(body), "", os.Stdout); err != nil {
+		wrapped := core.WrapWithSentinel(core.ErrCertManagerInstallFailed, err, fmt.Sprintf("cert-manager install failed: %v. %s", err, warnMsg))
+		core.Error("cert-manager install failed")
+		if logger != nil {
+			core.LogStructuredError(logger, wrapped, "cert-manager install failed")
+		}
+		return wrapped
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	overall := 5 * time.Minute
+	start := time.Now()
+	core.Info(fmt.Sprintf("Waiting for cert-manager deployments (combined timeout %s across three deployments)", overall))
+	for _, dep := range []string{"cert-manager", "cert-manager-cainjector", "cert-manager-webhook"} {
+		remaining := time.Until(start.Add(overall))
+		if remaining <= 0 {
+			err := core.NewWithSentinel(core.ErrCertManagerInstallFailed, fmt.Sprintf("timed out waiting for cert-manager before deployment/%s", dep))
+			core.Error("cert-manager did not become ready")
+			if logger != nil {
+				core.LogStructuredError(logger, err, "cert-manager did not become ready")
+			}
+			return err
+		}
+		if err := k8sclient.WaitForDeploymentAvailable(context.Background(), clients, "cert-manager", dep, remaining.Round(time.Second)); err != nil {
+			wrapped := core.WrapWithSentinel(core.ErrCertManagerInstallFailed, err, fmt.Sprintf("cert-manager component %s not ready: %v", dep, err))
+			core.Error("cert-manager did not become ready")
+			if logger != nil {
+				core.LogStructuredError(logger, wrapped, "cert-manager did not become ready")
+			}
+			return wrapped
+		}
+	}
+	core.Info("cert-manager is ready")
+	return nil
+}
+
+func checkCertManagerInstalledClientGo() error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.CheckCRDExists(context.Background(), clients, core.CertManagerCRDName); err != nil {
+		return core.ErrCertManagerNotInstalled
+	}
+	return nil
+}
+
+func waitForTraefikDeploymentForACMEClientGo() error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if _, err := k8sclient.GetDeployment(context.Background(), clients, "traefik", "traefik"); err != nil {
+		if apierrors.IsNotFound(err) {
+			core.Warn("No traefik/traefik deployment found; skipping Traefik wait. cert-manager still needs the Traefik ingress class to serve HTTP-01, with port 80 on your public hostnames")
+			return nil
+		}
+		return err
+	}
+	core.Info("Waiting for traefik/traefik (ingress must be up before the ACME request)")
+	if err := k8sclient.WaitForDeploymentAvailable(context.Background(), clients, "traefik", "traefik", 3*time.Minute); err != nil {
+		return core.WrapWithSentinel(core.ErrCertTraefikNotReady, err, fmt.Sprintf("traefik not ready: %v", err))
+	}
+	core.Info("traefik/traefik is available")
+	return nil
+}
+
+func checkNamedClusterIssuerClientGo(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return core.NewWithSentinel(core.ErrClusterIssuerNotFound, "ClusterIssuer name is empty (set --tls-cluster-issuer or MCP_TLS_CLUSTER_ISSUER)")
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.CheckClusterIssuer(context.Background(), clients, name); err != nil {
+		return core.WrapWithSentinel(core.ErrClusterIssuerNotFound, err, fmt.Sprintf("ClusterIssuer %q not found. Install your org issuer first (cert-manager) or fix --tls-cluster-issuer / MCP_TLS_CLUSTER_ISSUER: %v", name, err))
+	}
+	return nil
+}
+
+func checkCASecretClientGo() error {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if _, err := clients.Clientset.CoreV1().Secrets("cert-manager").Get(context.Background(), "mcp-runtime-ca", metav1.GetOptions{}); err != nil {
+		return core.ErrCASecretNotFound
+	}
+	return nil
+}
+
+func ensureCASecretClientGo() (bool, error) {
+	if err := checkCASecretClientGo(); err == nil {
+		return false, nil
+	}
+	manifest, err := certmanager.RenderGeneratedCASecretManifest(time.Now())
+	if err != nil {
+		return false, err
+	}
+	if err := applyManifestYAML(manifest, "", os.Stdout); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func applyRegistryCertificateClientGo(certName, secretName string, dnsNames, ipAddresses []string, issuerName string) error {
+	if len(dnsNames) == 0 && len(ipAddresses) == 0 {
+		return core.NewWithSentinel(core.ErrCertCertificateSANsEmpty, fmt.Sprintf("%s TLS has no DNS names or IP addresses to request", certName))
+	}
+	manifest := certmanager.RenderRegistryCertificate(certName, secretName, dnsNames, ipAddresses, issuerName)
+	return applyManifestYAML(manifest, "", os.Stdout)
+}
+
+func applyRegistryCertificateFromTemplateClientGo() error {
+	content, err := os.ReadFile("config/cert-manager/example-registry-certificate.yaml")
+	if err != nil {
+		return err
+	}
+	manifest := string(content)
+	if host := strings.TrimSpace(core.GetRegistryIngressHost()); host != "" && host != "registry.local" {
+		manifest = strings.ReplaceAll(manifest, "registry.local", host)
+	}
+	return applyManifestYAML(manifest, core.NamespaceRegistry, os.Stdout)
+}
+
+func waitForCertificateReadyClientGo(name, namespace string, timeout time.Duration, logger *zap.Logger, label string) error {
+	core.Info(fmt.Sprintf("Waiting for %s to be issued (timeout: %s)", label, timeout))
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.WaitForCertificateReady(context.Background(), clients, namespace, name, timeout); err != nil {
+		err := core.NewWithSentinel(core.ErrCertificateNotReady, fmt.Sprintf("%s not ready after %s. Check cert-manager logs: kubectl logs -n cert-manager deployment/cert-manager", label, timeout))
+		core.Error("Certificate not ready")
+		if logger != nil {
+			core.LogStructuredError(logger, err, "Certificate not ready")
+		}
+		return err
+	}
+	return nil
+}
+
+func wrapRegistryNamespaceError(err error, logger *zap.Logger) error {
+	wrappedErr := core.WrapWithSentinelAndContext(
+		core.ErrCreateRegistryNamespaceFailed,
+		err,
+		fmt.Sprintf("failed to create registry namespace: %v", err),
+		map[string]any{"namespace": core.NamespaceRegistry, "component": "setup"},
+	)
+	core.Error("Failed to create registry namespace")
+	if logger != nil {
+		core.LogStructuredError(logger, wrappedErr, "Failed to create registry namespace")
+	}
+	return wrappedErr
+}
+
+func wrapApplyCertificateError(err error, logger *zap.Logger, name string) error {
+	wrappedErr := core.WrapWithSentinelAndContext(
+		core.ErrApplyCertificateFailed,
+		err,
+		fmt.Sprintf("failed to apply Certificate: %v", err),
+		map[string]any{"certificate": name, "namespace": core.NamespaceRegistry, "component": "setup"},
+	)
+	core.Error("Failed to apply Certificate")
+	if logger != nil {
+		core.LogStructuredError(logger, wrappedErr, "Failed to apply Certificate")
+	}
+	return wrappedErr
+}
+
+func ensureRegistryCertificateOwnershipClientGo(logger *zap.Logger) error {
+	core.Info("Checking registry TLS Certificate ownership")
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.RemoveIngressAnnotation(context.Background(), clients, core.NamespaceRegistry, core.RegistryServiceName, "cert-manager.io/cluster-issuer"); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(core.ErrTLSSetupFailed, err, err.Error(), map[string]any{"ingress": core.RegistryServiceName, "namespace": core.NamespaceRegistry, "component": "setup"})
+		core.Error("Failed to remove registry ingress-shim annotation")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Failed to remove registry ingress-shim annotation")
+		}
+		return wrappedErr
+	}
+	owners, err := k8sclient.CertificateOwnersForSecret(context.Background(), clients, core.NamespaceRegistry, certmanager.RegistryTLSSecretName)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(core.ErrTLSSetupFailed, err, err.Error(), map[string]any{"resource_name": certmanager.RegistryTLSSecretName, "namespace": core.NamespaceRegistry, "component": "setup"})
+		core.Error("Registry TLS Certificate conflict")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Registry TLS Certificate conflict")
+		}
+		return wrappedErr
+	}
+	if len(owners) == 0 || (len(owners) == 1 && owners[0] == certmanager.RegistryCertificateName) {
+		return nil
+	}
+	msg := fmt.Sprintf("registry TLS secret %q in namespace %q is already referenced by Certificate(s) %s; setup owns this secret with Certificate %q. Delete or rename the extra Certificate resource before re-running setup (old ingress-shim drift is usually fixed with: kubectl delete certificate registry-tls -n registry)", certmanager.RegistryTLSSecretName, core.NamespaceRegistry, strings.Join(owners, ", "), certmanager.RegistryCertificateName)
+	err = core.NewWithSentinel(core.ErrCertRegistryTLSSecretConflict, msg)
+	wrappedErr := core.WrapWithSentinelAndContext(core.ErrTLSSetupFailed, err, err.Error(), map[string]any{"resource_name": certmanager.RegistryTLSSecretName, "namespace": core.NamespaceRegistry, "component": "setup"})
+	core.Error("Registry TLS Certificate conflict")
+	if logger != nil {
+		core.LogStructuredError(logger, wrappedErr, "Registry TLS Certificate conflict")
+	}
+	return wrappedErr
+}
+
+func setupBundledRegistryInternalTLSClientGo(logger *zap.Logger, plan setupplan.Plan) error {
+	if plan.RegistryMode != setupplan.RegistryModeBundledHTTPS {
+		return nil
+	}
+	issuerName, err := bundledRegistryInternalIssuerNameClientGo(plan)
+	if err != nil {
+		wrappedErr := core.WrapWithSentinel(core.ErrClusterIssuerNotFound, err, fmt.Sprintf("failed to inspect internal registry ClusterIssuer: %v", err))
+		core.Error("Internal registry issuer unavailable")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Internal registry issuer unavailable")
+		}
+		return wrappedErr
+	}
+	if issuerName == certmanager.CertClusterIssuerName {
+		core.Info("Ensuring internal registry CA secret")
+		created, err := ensureCASecretClientGo()
+		if err != nil {
+			err := core.WrapWithSentinel(core.ErrCASecretNotFound, err, "bundled HTTPS registry pulls need an internal CA for registry-internal-tls. Setup could not create cert-manager/mcp-runtime-ca; pass --tls-cluster-issuer for an existing internal issuer or create the CA secret manually")
+			core.Error("Internal registry CA secret unavailable")
+			if logger != nil {
+				core.LogStructuredError(logger, err, "Internal registry CA secret unavailable")
+			}
+			return err
+		}
+		if created {
+			core.Info("Generated cert-manager/mcp-runtime-ca for internal registry TLS; configure every Kubernetes node to trust its tls.crt before pulling from the bundled HTTPS registry")
+		}
+		core.Info("Applying internal registry ClusterIssuer")
+		if err := applyManifestFile("config/cert-manager/cluster-issuer.yaml", "", os.Stdout); err != nil {
+			wrappedErr := core.WrapWithSentinel(core.ErrClusterIssuerApplyFailed, err, fmt.Sprintf("failed to apply internal registry ClusterIssuer: %v", err))
+			core.Error("Failed to apply internal registry ClusterIssuer")
+			if logger != nil {
+				core.LogStructuredError(logger, wrappedErr, "Failed to apply internal registry ClusterIssuer")
+			}
+			return wrappedErr
+		}
+	}
+
+	dnsNames, ipAddresses := registryInternalCertificateSANs(plan)
+	core.Info("Applying Certificate for internal registry pod TLS")
+	if err := applyRegistryCertificateClientGo(certmanager.RegistryInternalCertificateName, certmanager.RegistryInternalTLSSecretName, dnsNames, ipAddresses, issuerName); err != nil {
+		wrappedErr := core.WrapWithSentinelAndContext(
+			core.ErrApplyCertificateFailed,
+			err,
+			fmt.Sprintf("failed to apply internal registry Certificate: %v", err),
+			map[string]any{"certificate": certmanager.RegistryInternalCertificateName, "namespace": core.NamespaceRegistry, "component": "setup"},
+		)
+		core.Error("Failed to apply internal registry Certificate")
+		if logger != nil {
+			core.LogStructuredError(logger, wrappedErr, "Failed to apply internal registry Certificate")
+		}
+		return wrappedErr
+	}
+
+	certTimeout := core.GetCertTimeout()
+	if certTimeout < 2*time.Minute {
+		certTimeout = 2 * time.Minute
+	}
+	if err := waitForCertificateReadyClientGo(certmanager.RegistryInternalCertificateName, core.NamespaceRegistry, certTimeout, logger, "internal registry certificate"); err != nil {
+		return err
+	}
+	core.Success("Internal registry certificate issued successfully")
+	return nil
+}
+
+func bundledRegistryInternalIssuerNameClientGo(plan setupplan.Plan) (string, error) {
+	issuerName := strings.TrimSpace(plan.TLSClusterIssuer)
+	if issuerName == "" {
+		return certmanager.CertClusterIssuerName, nil
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return "", err
+	}
+	usesACME, err := k8sclient.ClusterIssuerUsesACME(context.Background(), clients, issuerName)
+	if err != nil {
+		return "", err
+	}
+	if usesACME {
+		core.Warn(fmt.Sprintf("ClusterIssuer %q uses ACME and cannot issue internal registry DNS names; using %s for registry-internal-tls", issuerName, certmanager.CertClusterIssuerName))
+		return certmanager.CertClusterIssuerName, nil
+	}
+	return issuerName, nil
 }
 
 func registryCertificateSANs(plan setupplan.Plan) ([]string, []string) {
@@ -164,6 +710,7 @@ func dedupeStrings(values []string) []string {
 	return out
 }
 
+//lint:ignore U1000 retained as the legacy kubectl implementation for focused tests and fallback patches.
 func setupTLSLetsEncrypt(kubectl core.KubectlRunner, logger *zap.Logger, plan setupplan.Plan) error {
 	core.Info("Configuring TLS with Let's Encrypt (cert-manager HTTP-01)")
 	if err := certmanager.ValidateACMEHostnameForPublicCA(); err != nil {
@@ -270,6 +817,8 @@ func setupTLSLetsEncrypt(kubectl core.KubectlRunner, logger *zap.Logger, plan se
 
 // setupTLSWithExistingClusterIssuer issues the registry (and optional mcp SAN) Certificate using a
 // ClusterIssuer that already exists in the cluster (internal / enterprise CA).
+//
+//lint:ignore U1000 retained as the legacy kubectl implementation for focused tests and fallback patches.
 func setupTLSWithExistingClusterIssuer(kubectl core.KubectlRunner, logger *zap.Logger, plan setupplan.Plan) error {
 	issuerName := strings.TrimSpace(plan.TLSClusterIssuer)
 	core.Info("Configuring TLS with existing ClusterIssuer: " + issuerName)

--- a/internal/cli/setup/platform/platform_tls.go
+++ b/internal/cli/setup/platform/platform_tls.go
@@ -289,7 +289,8 @@ func ensureCertManagerInstalledClientGo(logger *zap.Logger) error {
 	core.Info("Installing cert-manager v1.16.2")
 	warnMsg := "If this fails (no network), install cert-manager manually, then re-run setup with --skip-cert-manager-install"
 	core.Warn(warnMsg)
-	resp, err := http.Get(certmanager.CertManagerInstallManifestURL()) // #nosec G107 -- fixed cert-manager release URL.
+	httpClient := &http.Client{Timeout: 30 * time.Second}
+	resp, err := httpClient.Get(certmanager.CertManagerInstallManifestURL()) // #nosec G107 -- fixed cert-manager release URL.
 	if err != nil {
 		wrapped := core.WrapWithSentinel(core.ErrCertManagerInstallFailed, err, fmt.Sprintf("cert-manager install failed: %v. %s", err, warnMsg))
 		core.Error("cert-manager install failed")

--- a/internal/cli/setup/platform/platform_traefik.go
+++ b/internal/cli/setup/platform/platform_traefik.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"mcp-runtime/internal/cli/core"
 	"mcp-runtime/internal/cli/kube"
 	"mcp-runtime/internal/cli/setup/assetpath"
+	"mcp-runtime/pkg/k8sclient"
 )
 
 func ensureRepoManagedTraefikMiddlewareResources(kubectl core.KubectlRunner, logger *zap.Logger) error {
@@ -34,6 +36,40 @@ func ensureRepoManagedTraefikMiddlewareResources(kubectl core.KubectlRunner, log
 		}
 	}
 	return nil
+}
+
+func ensureRepoManagedTraefikMiddlewareResourcesClientGo(logger *zap.Logger) error {
+	namespaces, err := activeNamedTraefikDeploymentNamespacesClientGo()
+	if err != nil {
+		return err
+	}
+	for _, namespace := range namespaces {
+		if logger != nil {
+			logger.Info("Reconciling Traefik file-provider resources", zap.String("namespace", namespace))
+		}
+		if err := applyTraefikSupportManifestClientGo("config/ingress/overlays/http/dynamic-config.yaml", namespace); err != nil {
+			return err
+		}
+		if err := applyTraefikSupportManifestClientGo("config/ingress/overlays/http/plugin-source.yaml", namespace); err != nil {
+			return err
+		}
+		if err := patchTraefikDeploymentForFileMiddlewareSupportClientGo(namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func activeNamedTraefikDeploymentNamespacesClientGo() ([]string, error) {
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return nil, err
+	}
+	namespaces, err := k8sclient.ListDeploymentNamespacesByName(context.Background(), clients, "traefik")
+	if err != nil {
+		return nil, core.WrapWithSentinel(core.ErrSetupListTraefikDeploymentsFailed, err, fmt.Sprintf("list traefik deployments: %v", err))
+	}
+	return namespaces, nil
 }
 
 func activeNamedTraefikDeploymentNamespacesWithKubectl(kubectl core.KubectlRunner) ([]string, error) {
@@ -80,6 +116,26 @@ func applyTraefikSupportManifest(kubectl core.KubectlRunner, relPath, namespace 
 	}
 	manifestContent := strings.ReplaceAll(string(manifestBytes), "namespace: traefik", "namespace: "+namespace)
 	if err := kube.ApplyManifestContent(kubectl.CommandArgs, manifestContent); err != nil {
+		return core.WrapWithSentinel(
+			core.ErrInstallIngressControllerFailed,
+			err,
+			fmt.Sprintf("failed to reconcile Traefik manifest %s in namespace %s: %v", relPath, namespace, err),
+		)
+	}
+	return nil
+}
+
+func applyTraefikSupportManifestClientGo(relPath, namespace string) error {
+	resolvedPath, err := assetpath.ResolveRepoAssetPath(relPath)
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrReadIngressManifestFailed, err, fmt.Sprintf("failed to resolve Traefik manifest %s: %v", relPath, err))
+	}
+	manifestBytes, err := kube.ReadFileAtPath(resolvedPath)
+	if err != nil {
+		return core.WrapWithSentinel(core.ErrReadIngressManifestFailed, err, fmt.Sprintf("failed to read Traefik manifest %s: %v", relPath, err))
+	}
+	manifestContent := strings.ReplaceAll(string(manifestBytes), "namespace: traefik", "namespace: "+namespace)
+	if err := applyManifestYAML(manifestContent, "", os.Stdout); err != nil {
 		return core.WrapWithSentinel(
 			core.ErrInstallIngressControllerFailed,
 			err,
@@ -201,6 +257,86 @@ func patchTraefikDeploymentForFileMiddlewareSupport(kubectl core.KubectlRunner, 
 	return nil
 }
 
+func patchTraefikDeploymentForFileMiddlewareSupportClientGo(namespace string) error {
+	spec, err := readTraefikDeploymentSpecClientGo(namespace)
+	if err != nil {
+		return err
+	}
+	patchBytes, err := traefikMiddlewarePatch(spec, namespace)
+	if err != nil || len(patchBytes) == 0 {
+		return err
+	}
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return err
+	}
+	if err := k8sclient.PatchDeploymentJSON(context.Background(), clients, namespace, "traefik", patchBytes); err != nil {
+		return core.WrapWithSentinel(
+			core.ErrInstallIngressControllerFailed,
+			err,
+			fmt.Sprintf("failed to patch traefik deployment in namespace %s for file-provider middleware support: %v", namespace, err),
+		)
+	}
+	return nil
+}
+
+func traefikMiddlewarePatch(spec traefikDeploymentSpec, namespace string) ([]byte, error) {
+	if len(spec.Spec.Template.Spec.Containers) == 0 {
+		return nil, core.NewWithSentinel(core.ErrInstallIngressControllerFailed, fmt.Sprintf("traefik deployment in namespace %s has no containers", namespace))
+	}
+	containerIndex := -1
+	for i, candidate := range spec.Spec.Template.Spec.Containers {
+		if candidate.Name == "traefik" {
+			containerIndex = i
+			break
+		}
+	}
+	if containerIndex == -1 {
+		return nil, core.NewWithSentinel(core.ErrInstallIngressControllerFailed, fmt.Sprintf("traefik deployment in namespace %s has no container named traefik", namespace))
+	}
+	container := spec.Spec.Template.Spec.Containers[containerIndex]
+
+	var ops []jsonPatchOperation
+	if !containsString(container.Args, "--providers.file.filename=/etc/traefik/dynamic/dynamic.yml") {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: fmt.Sprintf("/spec/template/spec/containers/%d/args/-", containerIndex), Value: "--providers.file.filename=/etc/traefik/dynamic/dynamic.yml"})
+	}
+	if !containsString(container.Args, "--providers.file.watch=true") {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: fmt.Sprintf("/spec/template/spec/containers/%d/args/-", containerIndex), Value: "--providers.file.watch=true"})
+	}
+	if !containsString(container.Args, "--experimental.localplugins.pii-redactor.modulename=github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor") {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: fmt.Sprintf("/spec/template/spec/containers/%d/args/-", containerIndex), Value: "--experimental.localplugins.pii-redactor.modulename=github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor"})
+	}
+	addDynamicMount := !hasVolumeMountPath(container.VolumeMounts, "/etc/traefik/dynamic")
+	if addDynamicMount {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: fmt.Sprintf("/spec/template/spec/containers/%d/volumeMounts/-", containerIndex), Value: map[string]any{"name": "traefik-dynamic", "mountPath": "/etc/traefik/dynamic", "readOnly": true}})
+	}
+	addPluginSourceMount := !hasVolumeMountPath(container.VolumeMounts, "/plugins-local/src/github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor")
+	if addPluginSourceMount {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: fmt.Sprintf("/spec/template/spec/containers/%d/volumeMounts/-", containerIndex), Value: map[string]any{"name": "traefik-plugin-source", "mountPath": "/plugins-local/src/github.com/Agent-Hellboy/mcp-runtime/traefik-plugins/pii-redactor", "readOnly": true}})
+	}
+	addPluginStorageMount := !hasVolumeMountPath(container.VolumeMounts, "/plugins-storage")
+	if addPluginStorageMount {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: fmt.Sprintf("/spec/template/spec/containers/%d/volumeMounts/-", containerIndex), Value: map[string]any{"name": "traefik-plugins", "mountPath": "/plugins-storage"}})
+	}
+	if addDynamicMount && !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-dynamic") {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: "/spec/template/spec/volumes/-", Value: map[string]any{"name": "traefik-dynamic", "configMap": map[string]any{"name": "traefik-dynamic", "items": []map[string]any{{"key": "dynamic.yml", "path": "dynamic.yml"}}}}})
+	}
+	if addPluginSourceMount && !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-plugin-source") {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: "/spec/template/spec/volumes/-", Value: map[string]any{"name": "traefik-plugin-source", "configMap": map[string]any{"name": "traefik-plugin-pii-redactor"}}})
+	}
+	if addPluginStorageMount && !hasVolume(spec.Spec.Template.Spec.Volumes, "traefik-plugins") {
+		ops = append(ops, jsonPatchOperation{Op: "add", Path: "/spec/template/spec/volumes/-", Value: map[string]any{"name": "traefik-plugins", "emptyDir": map[string]any{}}})
+	}
+	if len(ops) == 0 {
+		return nil, nil
+	}
+	patchBytes, err := json.Marshal(ops)
+	if err != nil {
+		return nil, core.WrapWithSentinel(core.ErrSetupMarshalTraefikDeploymentPatchFailed, err, fmt.Sprintf("marshal traefik deployment patch: %v", err))
+	}
+	return patchBytes, nil
+}
+
 func readTraefikDeploymentSpec(kubectl core.KubectlRunner, namespace string) (traefikDeploymentSpec, error) {
 	var spec traefikDeploymentSpec
 	cmd, err := kubectl.CommandArgs([]string{"get", "deployment", "traefik", "-n", namespace, "-o", "json"})
@@ -210,6 +346,26 @@ func readTraefikDeploymentSpec(kubectl core.KubectlRunner, namespace string) (tr
 	out, err := cmd.Output()
 	if err != nil {
 		return spec, core.WrapWithSentinel(core.ErrSetupReadTraefikDeploymentFailed, err, fmt.Sprintf("read traefik deployment %s/traefik: %v", namespace, err))
+	}
+	if err := json.Unmarshal(out, &spec); err != nil {
+		return spec, core.WrapWithSentinel(core.ErrSetupDecodeTraefikDeploymentFailed, err, fmt.Sprintf("decode traefik deployment %s/traefik: %v", namespace, err))
+	}
+	return spec, nil
+}
+
+func readTraefikDeploymentSpecClientGo(namespace string) (traefikDeploymentSpec, error) {
+	var spec traefikDeploymentSpec
+	clients, err := platformKubernetesClients()
+	if err != nil {
+		return spec, err
+	}
+	deploy, err := k8sclient.GetDeployment(context.Background(), clients, namespace, "traefik")
+	if err != nil {
+		return spec, core.WrapWithSentinel(core.ErrSetupReadTraefikDeploymentFailed, err, fmt.Sprintf("read traefik deployment %s/traefik: %v", namespace, err))
+	}
+	out, err := json.Marshal(deploy)
+	if err != nil {
+		return spec, core.WrapWithSentinel(core.ErrSetupDecodeTraefikDeploymentFailed, err, fmt.Sprintf("decode traefik deployment %s/traefik: %v", namespace, err))
 	}
 	if err := json.Unmarshal(out, &spec); err != nil {
 		return spec, core.WrapWithSentinel(core.ErrSetupDecodeTraefikDeploymentFailed, err, fmt.Sprintf("decode traefik deployment %s/traefik: %v", namespace, err))
@@ -250,7 +406,11 @@ func hasVolume(volumes []struct {
 }
 
 func activeTraefikNamespaceForPlatform(kubectl core.KubectlRunner) string {
-	namespaces, err := activeNamedTraefikDeploymentNamespacesWithKubectl(kubectl)
+	return activeTraefikNamespaceForPlatformClientGo()
+}
+
+func activeTraefikNamespaceForPlatformClientGo() string {
+	namespaces, err := activeNamedTraefikDeploymentNamespacesClientGo()
 	if err != nil || len(namespaces) == 0 {
 		return ""
 	}

--- a/pkg/k8sclient/apply.go
+++ b/pkg/k8sclient/apply.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/util/retry"
 )
 
 const defaultFieldManager = "mcp-runtime"
@@ -96,25 +97,33 @@ func applyObject(ctx context.Context, clients *Clients, mapper meta.RESTMapper, 
 		objectClient = resourceClient.Namespace(objectNamespace)
 	}
 
-	current, err := objectClient.Get(ctx, name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		if _, createErr := objectClient.Create(ctx, obj, metav1.CreateOptions{FieldManager: defaultFieldManager}); createErr != nil {
-			return ApplyResult{}, fmt.Errorf("create %s %s/%s: %w", gvk.String(), objectNamespace, name, createErr)
+	result := ApplyResult{GroupVersionKind: gvk, Namespace: objectNamespace, Name: name}
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := objectClient.Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			if _, createErr := objectClient.Create(ctx, obj.DeepCopy(), metav1.CreateOptions{FieldManager: defaultFieldManager}); createErr != nil {
+				return fmt.Errorf("create %s %s/%s: %w", gvk.String(), objectNamespace, name, createErr)
+			}
+			result.Action = "created"
+			return nil
 		}
-		return ApplyResult{GroupVersionKind: gvk, Namespace: objectNamespace, Name: name, Action: "created"}, nil
-	}
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("get %s %s/%s: %w", gvk.String(), objectNamespace, name, err)
-	}
+		if err != nil {
+			return fmt.Errorf("get %s %s/%s: %w", gvk.String(), objectNamespace, name, err)
+		}
 
-	merged := current.DeepCopy()
-	mergeObject(merged.Object, obj.Object)
-	unstructured.RemoveNestedField(merged.Object, "metadata", "managedFields")
-	unstructured.RemoveNestedField(merged.Object, "status")
-	if _, updateErr := objectClient.Update(ctx, merged, metav1.UpdateOptions{FieldManager: defaultFieldManager}); updateErr != nil {
-		return ApplyResult{}, fmt.Errorf("update %s %s/%s: %w", gvk.String(), objectNamespace, name, updateErr)
+		merged := current.DeepCopy()
+		mergeObject(merged.Object, obj.Object)
+		unstructured.RemoveNestedField(merged.Object, "metadata", "managedFields")
+		unstructured.RemoveNestedField(merged.Object, "status")
+		if _, updateErr := objectClient.Update(ctx, merged, metav1.UpdateOptions{FieldManager: defaultFieldManager}); updateErr != nil {
+			return updateErr
+		}
+		result.Action = "configured"
+		return nil
+	}); err != nil {
+		return ApplyResult{}, fmt.Errorf("apply %s %s/%s: %w", gvk.String(), objectNamespace, name, err)
 	}
-	return ApplyResult{GroupVersionKind: gvk, Namespace: objectNamespace, Name: name, Action: "configured"}, nil
+	return result, nil
 }
 
 func isEmptyObject(obj *unstructured.Unstructured) bool {

--- a/pkg/k8sclient/apply.go
+++ b/pkg/k8sclient/apply.go
@@ -1,0 +1,164 @@
+package k8sclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+)
+
+const defaultFieldManager = "mcp-runtime"
+
+// ApplyResult describes one object applied through the Kubernetes API.
+type ApplyResult struct {
+	GroupVersionKind schema.GroupVersionKind
+	Namespace        string
+	Name             string
+	Action           string
+}
+
+// String returns kubectl-like output for CLI callers.
+func (r ApplyResult) String() string {
+	kind := strings.ToLower(r.GroupVersionKind.Kind)
+	return fmt.Sprintf("%s/%s %s", kind, r.Name, r.Action)
+}
+
+// ApplyManifestYAML applies a multi-document Kubernetes manifest through
+// client-go instead of shelling out to kubectl.
+func ApplyManifestYAML(ctx context.Context, clients *Clients, manifest []byte, namespace string) ([]ApplyResult, error) {
+	if clients == nil {
+		return nil, fmt.Errorf("kubernetes clients cannot be nil")
+	}
+	if clients.Dynamic == nil {
+		return nil, fmt.Errorf("dynamic Kubernetes client cannot be nil")
+	}
+	if clients.Discovery == nil {
+		return nil, fmt.Errorf("kubernetes discovery client cannot be nil")
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(clients.Discovery))
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(manifest), 4096)
+	results := []ApplyResult{}
+
+	for {
+		obj := &unstructured.Unstructured{}
+		if err := decoder.Decode(obj); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return results, fmt.Errorf("decode Kubernetes manifest: %w", err)
+		}
+		if isEmptyObject(obj) {
+			continue
+		}
+		result, err := applyObject(ctx, clients, mapper, obj, namespace)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+func applyObject(ctx context.Context, clients *Clients, mapper meta.RESTMapper, obj *unstructured.Unstructured, namespace string) (ApplyResult, error) {
+	gvk := obj.GroupVersionKind()
+	if gvk.Empty() {
+		return ApplyResult{}, fmt.Errorf("manifest object is missing apiVersion or kind")
+	}
+	name := strings.TrimSpace(obj.GetName())
+	if name == "" {
+		return ApplyResult{}, fmt.Errorf("%s is missing metadata.name", gvk.String())
+	}
+
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("map %s to Kubernetes resource: %w", gvk.String(), err)
+	}
+
+	resourceClient := clients.Dynamic.Resource(mapping.Resource)
+	var objectClient dynamic.ResourceInterface = resourceClient
+	objectNamespace := ""
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		objectNamespace = firstNonEmpty(strings.TrimSpace(namespace), strings.TrimSpace(obj.GetNamespace()), strings.TrimSpace(clients.Namespace), metav1.NamespaceDefault)
+		obj.SetNamespace(objectNamespace)
+		objectClient = resourceClient.Namespace(objectNamespace)
+	}
+
+	current, err := objectClient.Get(ctx, name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		if _, createErr := objectClient.Create(ctx, obj, metav1.CreateOptions{FieldManager: defaultFieldManager}); createErr != nil {
+			return ApplyResult{}, fmt.Errorf("create %s %s/%s: %w", gvk.String(), objectNamespace, name, createErr)
+		}
+		return ApplyResult{GroupVersionKind: gvk, Namespace: objectNamespace, Name: name, Action: "created"}, nil
+	}
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("get %s %s/%s: %w", gvk.String(), objectNamespace, name, err)
+	}
+
+	merged := current.DeepCopy()
+	mergeObject(merged.Object, obj.Object)
+	unstructured.RemoveNestedField(merged.Object, "metadata", "managedFields")
+	unstructured.RemoveNestedField(merged.Object, "status")
+	if _, updateErr := objectClient.Update(ctx, merged, metav1.UpdateOptions{FieldManager: defaultFieldManager}); updateErr != nil {
+		return ApplyResult{}, fmt.Errorf("update %s %s/%s: %w", gvk.String(), objectNamespace, name, updateErr)
+	}
+	return ApplyResult{GroupVersionKind: gvk, Namespace: objectNamespace, Name: name, Action: "configured"}, nil
+}
+
+func isEmptyObject(obj *unstructured.Unstructured) bool {
+	return len(obj.Object) == 0 || (obj.GetAPIVersion() == "" && obj.GetKind() == "" && obj.GetName() == "")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func mergeObject(dst, src map[string]any) {
+	for key, srcValue := range src {
+		srcMap, srcMapOK := srcValue.(map[string]any)
+		dstMap, dstMapOK := dst[key].(map[string]any)
+		if srcMapOK && dstMapOK {
+			mergeObject(dstMap, srcMap)
+			continue
+		}
+		dst[key] = sanitizeObjectValue(srcValue)
+	}
+}
+
+func sanitizeObjectValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		copied := make(map[string]any, len(typed))
+		for key, nested := range typed {
+			copied[key] = sanitizeObjectValue(nested)
+		}
+		return copied
+	case []any:
+		copied := make([]any, len(typed))
+		for i, nested := range typed {
+			copied[i] = sanitizeObjectValue(nested)
+		}
+		return copied
+	case resource.Quantity:
+		return typed.DeepCopy()
+	default:
+		return typed
+	}
+}

--- a/pkg/k8sclient/apply_test.go
+++ b/pkg/k8sclient/apply_test.go
@@ -1,0 +1,120 @@
+package k8sclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryfake "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestApplyManifestYAMLCreatesNamespacedObject(t *testing.T) {
+	clients := newApplyTestClients()
+
+	results, err := ApplyManifestYAML(context.Background(), clients, []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo
+data:
+  key: value
+`), "mcp-servers")
+	if err != nil {
+		t.Fatalf("ApplyManifestYAML() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if got, want := results[0].String(), "configmap/demo created"; got != want {
+		t.Fatalf("result = %q, want %q", got, want)
+	}
+
+	got, err := clients.Dynamic.Resource(schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}).
+		Namespace("mcp-servers").
+		Get(context.Background(), "demo", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get(ConfigMap) error = %v", err)
+	}
+	if got.GetNamespace() != "mcp-servers" {
+		t.Fatalf("namespace = %q, want mcp-servers", got.GetNamespace())
+	}
+	if value, _, _ := unstructured.NestedString(got.Object, "data", "key"); value != "value" {
+		t.Fatalf("data.key = %q, want value", value)
+	}
+}
+
+func TestApplyManifestYAMLUpdatesAndPreservesExistingLabels(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":            "mcp-servers",
+			"resourceVersion": "1",
+			"labels": map[string]any{
+				"keep":      "true",
+				"overwrite": "old",
+			},
+		},
+	}}
+	clients := newApplyTestClients(existing)
+
+	results, err := ApplyManifestYAML(context.Background(), clients, []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-servers
+  labels:
+    overwrite: new
+`), "")
+	if err != nil {
+		t.Fatalf("ApplyManifestYAML() error = %v", err)
+	}
+	if len(results) != 1 || results[0].Action != "configured" {
+		t.Fatalf("results = %#v, want one configured result", results)
+	}
+
+	got, err := clients.Dynamic.Resource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}).
+		Get(context.Background(), "mcp-servers", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get(Namespace) error = %v", err)
+	}
+	labels := got.GetLabels()
+	if labels["keep"] != "true" {
+		t.Fatalf("keep label = %q, want true", labels["keep"])
+	}
+	if labels["overwrite"] != "new" {
+		t.Fatalf("overwrite label = %q, want new", labels["overwrite"])
+	}
+}
+
+func TestApplyManifestYAMLRejectsInvalidManifest(t *testing.T) {
+	clients := newApplyTestClients()
+
+	_, err := ApplyManifestYAML(context.Background(), clients, []byte("apiVersion: [\n"), "")
+	if err == nil {
+		t.Fatal("ApplyManifestYAML() error = nil, want decode error")
+	}
+	if !strings.Contains(err.Error(), "decode Kubernetes manifest") {
+		t.Fatalf("ApplyManifestYAML() error = %v, want decode context", err)
+	}
+}
+
+func newApplyTestClients(objects ...runtime.Object) *Clients {
+	resources := []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Name: "configmaps", Namespaced: true, Kind: "ConfigMap", Verbs: []string{"get", "create", "update"}},
+			{Name: "namespaces", Namespaced: false, Kind: "Namespace", Verbs: []string{"get", "create", "update"}},
+		},
+	}}
+
+	return &Clients{
+		Dynamic:   dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), objects...),
+		Discovery: &discoveryfake.FakeDiscovery{Fake: &clienttesting.Fake{Resources: resources}},
+		Namespace: metav1.NamespaceDefault,
+	}
+}

--- a/pkg/k8sclient/apply_test.go
+++ b/pkg/k8sclient/apply_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,6 +89,44 @@ metadata:
 	}
 	if labels["overwrite"] != "new" {
 		t.Fatalf("overwrite label = %q, want new", labels["overwrite"])
+	}
+}
+
+func TestApplyManifestYAMLRetriesUpdateConflict(t *testing.T) {
+	existing := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name":            "mcp-servers",
+			"resourceVersion": "1",
+		},
+	}}
+	clients := newApplyTestClients(existing)
+	dynamicClient := clients.Dynamic.(*dynamicfake.FakeDynamicClient)
+	conflicts := 0
+	dynamicClient.PrependReactor("update", "namespaces", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if conflicts == 0 {
+			conflicts++
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "namespaces"}, "mcp-servers", nil)
+		}
+		return false, nil, nil
+	})
+
+	results, err := ApplyManifestYAML(context.Background(), clients, []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-servers
+  labels:
+    retry: ok
+`), "")
+	if err != nil {
+		t.Fatalf("ApplyManifestYAML() error = %v", err)
+	}
+	if conflicts != 1 {
+		t.Fatalf("conflicts = %d, want 1", conflicts)
+	}
+	if len(results) != 1 || results[0].Action != "configured" {
+		t.Fatalf("results = %#v, want one configured result", results)
 	}
 }
 

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -21,7 +22,9 @@ type Config struct {
 type Clients struct {
 	Clientset kubernetes.Interface
 	Dynamic   dynamic.Interface
+	Discovery discovery.DiscoveryInterface
 	Config    *rest.Config
+	Namespace string
 }
 
 // New creates Kubernetes clients with in-cluster config or kubeconfig fallback.
@@ -33,15 +36,18 @@ func New() (*Clients, error) {
 func NewWithConfig(cfg Config) (*Clients, error) {
 	var restConfig *rest.Config
 	var err error
+	namespace := "default"
 
 	// Try in-cluster config first
 	restConfig, err = rest.InClusterConfig()
 	if err != nil {
 		// Fall back to kubeconfig
-		restConfig, err = buildKubeconfig(cfg.KubeconfigPath)
+		restConfig, namespace, err = buildKubeconfig(cfg.KubeconfigPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Kubernetes config: %w", err)
 		}
+	} else {
+		namespace = GetNamespace()
 	}
 
 	// Create clientset
@@ -59,7 +65,9 @@ func NewWithConfig(cfg Config) (*Clients, error) {
 	return &Clients{
 		Clientset: clientset,
 		Dynamic:   dynamicClient,
+		Discovery: clientset.Discovery(),
 		Config:    restConfig,
+		Namespace: namespace,
 	}, nil
 }
 
@@ -82,11 +90,13 @@ func NewFromConfig(restConfig *rest.Config) (*Clients, error) {
 	return &Clients{
 		Clientset: clientset,
 		Dynamic:   dynamicClient,
+		Discovery: clientset.Discovery(),
 		Config:    restConfig,
+		Namespace: "default",
 	}, nil
 }
 
-func buildKubeconfig(kubeconfigPath string) (*rest.Config, error) {
+func buildKubeconfig(kubeconfigPath string) (*rest.Config, string, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if paths := splitKubeconfigPaths(kubeconfigPath); len(paths) == 1 {
 		loadingRules.ExplicitPath = paths[0]
@@ -95,15 +105,20 @@ func buildKubeconfig(kubeconfigPath string) (*rest.Config, error) {
 	}
 
 	// Build from kubeconfig
-	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loadingRules,
 		&clientcmd.ConfigOverrides{},
-	).ClientConfig()
+	)
+	config, err := clientConfig.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig (searched: %v): %w", loadingRules.GetLoadingPrecedence(), err)
+		return nil, "", fmt.Errorf("failed to load kubeconfig (searched: %v): %w", loadingRules.GetLoadingPrecedence(), err)
+	}
+	namespace, _, err := clientConfig.Namespace()
+	if err != nil || strings.TrimSpace(namespace) == "" {
+		namespace = "default"
 	}
 
-	return config, nil
+	return config, namespace, nil
 }
 
 func splitKubeconfigPaths(raw string) []string {

--- a/pkg/k8sclient/client_test.go
+++ b/pkg/k8sclient/client_test.go
@@ -13,12 +13,15 @@ func TestBuildKubeconfigAcceptsExplicitPathList(t *testing.T) {
 	first := writeTestKubeconfig(t, dir, "first.yaml", "https://explicit.example.com")
 	second := writeTestKubeconfig(t, dir, "second.yaml", "https://explicit.example.com")
 
-	cfg, err := buildKubeconfig(first + string(os.PathListSeparator) + second)
+	cfg, namespace, err := buildKubeconfig(first + string(os.PathListSeparator) + second)
 	if err != nil {
 		t.Fatalf("buildKubeconfig() error = %v", err)
 	}
 	if cfg.Host != "https://explicit.example.com" {
 		t.Fatalf("config.Host = %q, want %q", cfg.Host, "https://explicit.example.com")
+	}
+	if namespace != "default" {
+		t.Fatalf("namespace = %q, want default", namespace)
 	}
 }
 
@@ -28,12 +31,28 @@ func TestBuildKubeconfigUsesKubeconfigEnvPathList(t *testing.T) {
 	second := writeTestKubeconfig(t, dir, "second.yaml", "https://env.example.com")
 	t.Setenv("KUBECONFIG", first+string(os.PathListSeparator)+second)
 
-	cfg, err := buildKubeconfig("")
+	cfg, namespace, err := buildKubeconfig("")
 	if err != nil {
 		t.Fatalf("buildKubeconfig() error = %v", err)
 	}
 	if cfg.Host != "https://env.example.com" {
 		t.Fatalf("config.Host = %q, want %q", cfg.Host, "https://env.example.com")
+	}
+	if namespace != "default" {
+		t.Fatalf("namespace = %q, want default", namespace)
+	}
+}
+
+func TestBuildKubeconfigReturnsCurrentContextNamespace(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestKubeconfigWithNamespace(t, dir, "namespaced.yaml", "https://ns.example.com", "mcp-servers")
+
+	_, namespace, err := buildKubeconfig(path)
+	if err != nil {
+		t.Fatalf("buildKubeconfig() error = %v", err)
+	}
+	if namespace != "mcp-servers" {
+		t.Fatalf("namespace = %q, want mcp-servers", namespace)
 	}
 }
 
@@ -65,8 +84,16 @@ func TestEnvNamespaceWhitespaceFallsBackToDefault(t *testing.T) {
 }
 
 func writeTestKubeconfig(t *testing.T, dir, name, server string) string {
+	return writeTestKubeconfigWithNamespace(t, dir, name, server, "")
+}
+
+func writeTestKubeconfigWithNamespace(t *testing.T, dir, name, server, namespace string) string {
 	t.Helper()
 
+	var namespaceLine string
+	if namespace != "" {
+		namespaceLine = fmt.Sprintf("    namespace: %s\n", namespace)
+	}
 	path := filepath.Join(dir, name)
 	data := fmt.Sprintf(`apiVersion: v1
 kind: Config
@@ -79,12 +106,13 @@ contexts:
   context:
     cluster: test
     user: test
+%s
 current-context: test
 users:
 - name: test
   user:
     token: test-token
-`, server)
+`, server, namespaceLine)
 	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}

--- a/pkg/k8sclient/operations.go
+++ b/pkg/k8sclient/operations.go
@@ -1,0 +1,536 @@
+package k8sclient
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+)
+
+var (
+	crdGVR           = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
+	certificateGVR   = schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1", Resource: "certificates"}
+	clusterIssuerGVR = schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1", Resource: "clusterissuers"}
+)
+
+// ApplyManifestFile applies a single manifest file through the Kubernetes API.
+func ApplyManifestFile(ctx context.Context, clients *Clients, path, namespace string) ([]ApplyResult, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- callers pass repo-controlled setup paths or already-validated CLI paths.
+	if err != nil {
+		return nil, fmt.Errorf("read Kubernetes manifest %s: %w", path, err)
+	}
+	return ApplyManifestYAML(ctx, clients, data, namespace)
+}
+
+// ApplyManifestDir applies all .yaml/.yml files in a directory in lexical order.
+func ApplyManifestDir(ctx context.Context, clients *Clients, dir, namespace string) ([]ApplyResult, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read Kubernetes manifest directory %s: %w", dir, err)
+	}
+	var paths []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			paths = append(paths, filepath.Join(dir, name))
+		}
+	}
+	sort.Strings(paths)
+	var all []ApplyResult
+	for _, path := range paths {
+		results, err := ApplyManifestFile(ctx, clients, path, namespace)
+		if err != nil {
+			return all, err
+		}
+		all = append(all, results...)
+	}
+	return all, nil
+}
+
+// EnsureNamespace creates or updates a namespace, preserving existing labels
+// unless the same label key is supplied.
+func EnsureNamespace(ctx context.Context, clients *Clients, name string, labels map[string]string) error {
+	if clients == nil || clients.Clientset == nil {
+		return fmt.Errorf("kubernetes clientset cannot be nil")
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("namespace name cannot be empty")
+	}
+	nsClient := clients.Clientset.CoreV1().Namespaces()
+	_, err := nsClient.Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = nsClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create namespace %s: %w", name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get namespace %s: %w", name, err)
+	}
+	if len(labels) == 0 {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := nsClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if current.Labels == nil {
+			current.Labels = map[string]string{}
+		}
+		for key, value := range labels {
+			current.Labels[key] = value
+		}
+		_, err = nsClient.Update(ctx, current, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// ConfigMapData returns a ConfigMap's data, or an empty map when it does not exist.
+func ConfigMapData(ctx context.Context, clients *Clients, namespace, name string) (map[string]string, error) {
+	cm, err := clients.Clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return map[string]string{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get configmap %s/%s: %w", namespace, name, err)
+	}
+	if cm.Data == nil {
+		return map[string]string{}, nil
+	}
+	return cloneStringMap(cm.Data), nil
+}
+
+// SecretStringDataValue returns one decoded Secret data value, or empty string
+// when either the Secret or key does not exist.
+func SecretStringDataValue(ctx context.Context, clients *Clients, namespace, name, key string) (string, error) {
+	secret, err := clients.Clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get secret %s/%s: %w", namespace, name, err)
+	}
+	value := secret.Data[key]
+	if len(value) == 0 {
+		return "", nil
+	}
+	return string(value), nil
+}
+
+// UpsertOpaqueSecretStringData creates or updates an Opaque Secret from string data.
+func UpsertOpaqueSecretStringData(ctx context.Context, clients *Clients, namespace, name string, data map[string]string) error {
+	byteData := make(map[string][]byte, len(data))
+	for key, value := range data {
+		byteData[key] = []byte(value)
+	}
+	return upsertSecret(ctx, clients, namespace, name, corev1.SecretTypeOpaque, byteData)
+}
+
+// UpsertDockerConfigSecret creates or updates a dockerconfigjson image pull Secret.
+func UpsertDockerConfigSecret(ctx context.Context, clients *Clients, namespace, name, registry, username, password string) error {
+	dockerCfg := map[string]any{
+		"auths": map[string]any{
+			registry: map[string]string{
+				"username": username,
+				"password": password,
+				"auth":     base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password))),
+			},
+		},
+	}
+	dockerCfgJSON, err := json.Marshal(dockerCfg)
+	if err != nil {
+		return fmt.Errorf("marshal docker config: %w", err)
+	}
+	return upsertSecret(ctx, clients, namespace, name, corev1.SecretTypeDockerConfigJson, map[string][]byte{
+		corev1.DockerConfigJsonKey: dockerCfgJSON,
+	})
+}
+
+func upsertSecret(ctx context.Context, clients *Clients, namespace, name string, secretType corev1.SecretType, data map[string][]byte) error {
+	secretClient := clients.Clientset.CoreV1().Secrets(namespace)
+	_, err := secretClient.Get(ctx, name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = secretClient.Create(ctx, &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Type:       secretType,
+			Data:       data,
+		}, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("create secret %s/%s: %w", namespace, name, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get secret %s/%s: %w", namespace, name, err)
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current, err := secretClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		current.Type = secretType
+		if current.Data == nil {
+			current.Data = map[string][]byte{}
+		}
+		for key, value := range data {
+			current.Data[key] = value
+		}
+		_, err = secretClient.Update(ctx, current, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// NodeArchitectures returns sorted unique node CPU architectures.
+func NodeArchitectures(ctx context.Context, clients *Clients) ([]string, error) {
+	nodes, err := clients.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, node := range nodes.Items {
+		arch := strings.TrimSpace(node.Status.NodeInfo.Architecture)
+		if arch != "" {
+			seen[arch] = struct{}{}
+		}
+	}
+	archs := make([]string, 0, len(seen))
+	for arch := range seen {
+		archs = append(archs, arch)
+	}
+	sort.Strings(archs)
+	return archs, nil
+}
+
+// PersistentVolumeClaimStorage returns the requested storage size for a PVC.
+func PersistentVolumeClaimStorage(ctx context.Context, clients *Clients, namespace, name string) (string, error) {
+	pvc, err := clients.Clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get pvc %s/%s: %w", namespace, name, err)
+	}
+	if pvc.Spec.Resources.Requests == nil {
+		return "", nil
+	}
+	return pvc.Spec.Resources.Requests.Storage().String(), nil
+}
+
+// UpdatePersistentVolumeClaimStorage updates the requested storage size on a PVC.
+func UpdatePersistentVolumeClaimStorage(ctx context.Context, clients *Clients, namespace, name, storageSize string) error {
+	quantity, err := resource.ParseQuantity(storageSize)
+	if err != nil {
+		return fmt.Errorf("parse pvc storage size %q: %w", storageSize, err)
+	}
+	pvcClient := clients.Clientset.CoreV1().PersistentVolumeClaims(namespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pvc, err := pvcClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if pvc.Spec.Resources.Requests == nil {
+			pvc.Spec.Resources.Requests = corev1.ResourceList{}
+		}
+		pvc.Spec.Resources.Requests[corev1.ResourceStorage] = quantity
+		_, err = pvcClient.Update(ctx, pvc, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// CheckCRDExists verifies that a CRD exists.
+func CheckCRDExists(ctx context.Context, clients *Clients, name string) error {
+	if _, err := clients.Dynamic.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{}); err != nil {
+		return fmt.Errorf("get crd %s: %w", name, err)
+	}
+	return nil
+}
+
+// SetDeploymentEnv updates env vars on the first container in a Deployment.
+func SetDeploymentEnv(ctx context.Context, clients *Clients, namespace, name string, literals map[string]string, secretName string, secretKeys []string) error {
+	deployClient := clients.Clientset.AppsV1().Deployments(namespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deploy, err := deployClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if len(deploy.Spec.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("deployment %s/%s has no containers", namespace, name)
+		}
+		env := deploy.Spec.Template.Spec.Containers[0].Env
+		for key, value := range literals {
+			env = upsertEnvVar(env, corev1.EnvVar{Name: key, Value: value})
+		}
+		for _, key := range secretKeys {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			env = upsertEnvVar(env, corev1.EnvVar{
+				Name: key,
+				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+					Key:                  key,
+				}},
+			})
+		}
+		deploy.Spec.Template.Spec.Containers[0].Env = env
+		_, err = deployClient.Update(ctx, deploy, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func upsertEnvVar(env []corev1.EnvVar, next corev1.EnvVar) []corev1.EnvVar {
+	for i := range env {
+		if env[i].Name == next.Name {
+			env[i] = next
+			return env
+		}
+	}
+	return append(env, next)
+}
+
+// RestartDeployment triggers a Deployment rollout by updating the standard restart annotation.
+func RestartDeployment(ctx context.Context, clients *Clients, namespace, name string, now time.Time) error {
+	deployClient := clients.Clientset.AppsV1().Deployments(namespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		deploy, err := deployClient.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if deploy.Spec.Template.Annotations == nil {
+			deploy.Spec.Template.Annotations = map[string]string{}
+		}
+		deploy.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = now.Format(time.RFC3339)
+		_, err = deployClient.Update(ctx, deploy, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// WaitForDeploymentAvailable waits until a Deployment reports at least one available replica.
+func WaitForDeploymentAvailable(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		deploy, err := clients.Clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return deploy.Status.AvailableReplicas > 0, nil
+	})
+}
+
+// WaitForStatefulSetReady waits until a StatefulSet reports all desired replicas ready.
+func WaitForStatefulSetReady(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		statefulSet, err := clients.Clientset.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		desired := int32(1)
+		if statefulSet.Spec.Replicas != nil {
+			desired = *statefulSet.Spec.Replicas
+		}
+		return statefulSet.Status.ReadyReplicas >= desired &&
+			statefulSet.Status.UpdatedReplicas >= desired &&
+			statefulSet.Status.ObservedGeneration >= statefulSet.Generation, nil
+	})
+}
+
+// WaitForWorkloadRollout waits until a supported workload kind is ready.
+func WaitForWorkloadRollout(ctx context.Context, clients *Clients, namespace, kind, name string, timeout time.Duration) error {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "deployment", "deploy", "deployments":
+		return WaitForDeploymentAvailable(ctx, clients, namespace, name, timeout)
+	case "statefulset", "statefulsets", "sts":
+		return WaitForStatefulSetReady(ctx, clients, namespace, name, timeout)
+	default:
+		return fmt.Errorf("unsupported workload kind %q", kind)
+	}
+}
+
+// DeleteJob deletes a Job and waits briefly for it to disappear.
+func DeleteJob(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
+	jobs := clients.Clientset.BatchV1().Jobs(namespace)
+	err := jobs.Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("delete job %s/%s: %w", namespace, name, err)
+	}
+	return wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := jobs.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+}
+
+// WaitForJobComplete waits until a Job completes or fails.
+func WaitForJobComplete(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		job, err := clients.Clientset.BatchV1().Jobs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		for _, condition := range job.Status.Conditions {
+			if condition.Type == "Complete" && condition.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+			if condition.Type == "Failed" && condition.Status == corev1.ConditionTrue {
+				return false, fmt.Errorf("job %s/%s failed", namespace, name)
+			}
+		}
+		return false, nil
+	})
+}
+
+// ListDeploymentNamespacesByName returns namespaces containing a Deployment with the given name.
+func ListDeploymentNamespacesByName(ctx context.Context, clients *Clients, name string) ([]string, error) {
+	deployments, err := clients.Clientset.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, deploy := range deployments.Items {
+		if deploy.Name == name {
+			seen[deploy.Namespace] = struct{}{}
+		}
+	}
+	namespaces := make([]string, 0, len(seen))
+	for namespace := range seen {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	return namespaces, nil
+}
+
+func GetDeployment(ctx context.Context, clients *Clients, namespace, name string) (*appsv1.Deployment, error) {
+	return clients.Clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func PatchDeploymentJSON(ctx context.Context, clients *Clients, namespace, name string, patch []byte) error {
+	_, err := clients.Clientset.AppsV1().Deployments(namespace).Patch(ctx, name, types.JSONPatchType, patch, metav1.PatchOptions{})
+	return err
+}
+
+func RemoveIngressAnnotation(ctx context.Context, clients *Clients, namespace, name, key string) error {
+	return updateIngress(ctx, clients, namespace, name, func(ing *networkingv1.Ingress) {
+		delete(ing.Annotations, key)
+	})
+}
+
+func SetIngressAnnotation(ctx context.Context, clients *Clients, namespace, name, key, value string) error {
+	return updateIngress(ctx, clients, namespace, name, func(ing *networkingv1.Ingress) {
+		if ing.Annotations == nil {
+			ing.Annotations = map[string]string{}
+		}
+		ing.Annotations[key] = value
+	})
+}
+
+func updateIngress(ctx context.Context, clients *Clients, namespace, name string, mutate func(*networkingv1.Ingress)) error {
+	ingClient := clients.Clientset.NetworkingV1().Ingresses(namespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ing, err := ingClient.Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		mutate(ing)
+		_, err = ingClient.Update(ctx, ing, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func ClusterIssuerUsesACME(ctx context.Context, clients *Clients, name string) (bool, error) {
+	issuer, err := clients.Dynamic.Resource(clusterIssuerGVR).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("get clusterissuer %s: %w", name, err)
+	}
+	server, _, _ := unstructured.NestedString(issuer.Object, "spec", "acme", "server")
+	return strings.TrimSpace(server) != "", nil
+}
+
+func CheckClusterIssuer(ctx context.Context, clients *Clients, name string) error {
+	_, err := clients.Dynamic.Resource(clusterIssuerGVR).Get(ctx, name, metav1.GetOptions{})
+	return err
+}
+
+func CheckCertificate(ctx context.Context, clients *Clients, namespace, name string) error {
+	_, err := clients.Dynamic.Resource(certificateGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	return err
+}
+
+func CertificateOwnersForSecret(ctx context.Context, clients *Clients, namespace, secretName string) ([]string, error) {
+	list, err := clients.Dynamic.Resource(certificateGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var owners []string
+	for _, item := range list.Items {
+		gotSecret, _, _ := unstructured.NestedString(item.Object, "spec", "secretName")
+		if gotSecret == secretName {
+			owners = append(owners, item.GetName())
+		}
+	}
+	sort.Strings(owners)
+	return owners, nil
+}
+
+func WaitForCertificateReady(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		cert, err := clients.Dynamic.Resource(certificateGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		conditions, _, _ := unstructured.NestedSlice(cert.Object, "status", "conditions")
+		for _, raw := range conditions {
+			condition, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if condition["type"] == "Ready" && condition["status"] == "True" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/pkg/k8sclient/operations.go
+++ b/pkg/k8sclient/operations.go
@@ -342,6 +342,44 @@ func WaitForDeploymentAvailable(ctx context.Context, clients *Clients, namespace
 	})
 }
 
+// WaitForDeploymentRolledOut waits until the Deployment's current generation
+// has fully rolled out.
+func WaitForDeploymentRolledOut(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		deploy, err := clients.Clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		for _, condition := range deploy.Status.Conditions {
+			if condition.Type == appsv1.DeploymentProgressing &&
+				condition.Status == corev1.ConditionFalse &&
+				condition.Reason == "ProgressDeadlineExceeded" {
+				return false, fmt.Errorf("deployment %s/%s rollout exceeded progress deadline", namespace, name)
+			}
+		}
+		desired := int32(1)
+		if deploy.Spec.Replicas != nil {
+			desired = *deploy.Spec.Replicas
+		}
+		if deploy.Status.ObservedGeneration < deploy.Generation {
+			return false, nil
+		}
+		if deploy.Status.UpdatedReplicas < desired {
+			return false, nil
+		}
+		if deploy.Status.Replicas > deploy.Status.UpdatedReplicas {
+			return false, nil
+		}
+		if deploy.Status.AvailableReplicas < desired {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 // WaitForStatefulSetReady waits until a StatefulSet reports all desired replicas ready.
 func WaitForStatefulSetReady(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
@@ -366,7 +404,7 @@ func WaitForStatefulSetReady(ctx context.Context, clients *Clients, namespace, n
 func WaitForWorkloadRollout(ctx context.Context, clients *Clients, namespace, kind, name string, timeout time.Duration) error {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "deployment", "deploy", "deployments":
-		return WaitForDeploymentAvailable(ctx, clients, namespace, name, timeout)
+		return WaitForDeploymentRolledOut(ctx, clients, namespace, name, timeout)
 	case "statefulset", "statefulsets", "sts":
 		return WaitForStatefulSetReady(ctx, clients, namespace, name, timeout)
 	default:
@@ -377,7 +415,8 @@ func WaitForWorkloadRollout(ctx context.Context, clients *Clients, namespace, ki
 // DeleteJob deletes a Job and waits briefly for it to disappear.
 func DeleteJob(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
 	jobs := clients.Clientset.BatchV1().Jobs(namespace)
-	err := jobs.Delete(ctx, name, metav1.DeleteOptions{})
+	deletePolicy := metav1.DeletePropagationBackground
+	err := jobs.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
 	if apierrors.IsNotFound(err) {
 		return nil
 	}
@@ -510,8 +549,11 @@ func CertificateOwnersForSecret(ctx context.Context, clients *Clients, namespace
 func WaitForCertificateReady(ctx context.Context, clients *Clients, namespace, name string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		cert, err := clients.Dynamic.Resource(certificateGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
-		if err != nil {
+		if apierrors.IsNotFound(err) {
 			return false, nil
+		}
+		if err != nil {
+			return false, err
 		}
 		conditions, _, _ := unstructured.NestedSlice(cert.Object, "status", "conditions")
 		for _, raw := range conditions {

--- a/pkg/k8sclient/operations_test.go
+++ b/pkg/k8sclient/operations_test.go
@@ -1,0 +1,112 @@
+package k8sclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestWaitForWorkloadRolloutWaitsForDeploymentCurrentRevision(t *testing.T) {
+	replicas := int32(2)
+	clients := &Clients{Clientset: kubernetesfake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "mcp-sentinel", Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           2,
+			UpdatedReplicas:    1,
+			AvailableReplicas:  1,
+		},
+	})}
+
+	err := WaitForWorkloadRollout(context.Background(), clients, "mcp-sentinel", "deployment", "api", time.Millisecond)
+	if err == nil {
+		t.Fatal("expected rollout wait to fail while only an old replica is available")
+	}
+}
+
+func TestWaitForWorkloadRolloutAcceptsRolledOutDeployment(t *testing.T) {
+	replicas := int32(2)
+	clients := &Clients{Clientset: kubernetesfake.NewSimpleClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "mcp-sentinel", Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			Replicas:           2,
+			UpdatedReplicas:    2,
+			AvailableReplicas:  2,
+		},
+	})}
+
+	if err := WaitForWorkloadRollout(context.Background(), clients, "mcp-sentinel", "deployment", "api", time.Second); err != nil {
+		t.Fatalf("WaitForWorkloadRollout() error = %v", err)
+	}
+}
+
+func TestDeleteJobUsesBackgroundPropagation(t *testing.T) {
+	clientset := kubernetesfake.NewSimpleClientset(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "clickhouse-init", Namespace: "mcp-sentinel"},
+	})
+	clients := &Clients{Clientset: clientset}
+	clientset.PrependReactor("delete", "jobs", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		deleteAction := action.(clienttesting.DeleteAction)
+		options := deleteAction.GetDeleteOptions()
+		if options.PropagationPolicy == nil || *options.PropagationPolicy != metav1.DeletePropagationBackground {
+			t.Fatalf("PropagationPolicy = %#v, want Background", options)
+		}
+		return false, nil, nil
+	})
+
+	if err := DeleteJob(context.Background(), clients, "mcp-sentinel", "clickhouse-init", time.Second); err != nil {
+		t.Fatalf("DeleteJob() error = %v", err)
+	}
+}
+
+func TestWaitForCertificateReadyPropagatesAPIError(t *testing.T) {
+	clients := &Clients{Dynamic: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())}
+	clients.Dynamic.(*dynamicfake.FakeDynamicClient).PrependReactor("get", "certificates", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "cert-manager.io", Resource: "certificates"}, "registry-cert", errors.New("denied"))
+	})
+
+	err := WaitForCertificateReady(context.Background(), clients, "registry", "registry-cert", time.Second)
+	if err == nil {
+		t.Fatal("expected certificate wait to propagate API error")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("WaitForCertificateReady() error = %v, want forbidden", err)
+	}
+}
+
+func TestWaitForCertificateReadyAcceptsReadyCertificate(t *testing.T) {
+	clients := &Clients{Dynamic: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]any{
+				"name":      "registry-cert",
+				"namespace": "registry",
+			},
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{"type": "Ready", "status": "True"},
+				},
+			},
+		},
+	})}
+
+	if err := WaitForCertificateReady(context.Background(), clients, "registry", "registry-cert", time.Second); err != nil {
+		t.Fatalf("WaitForCertificateReady() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds shared client-go helpers for dynamic manifest apply, namespace/secret/configmap/PVC/workload/cert-manager operations, and kubeconfig namespace discovery.
- Moves the default platform setup path to client-go for registry, operator, analytics, TLS, Traefik, image platform detection, registry URL resolution, rollout/job waits, and config/secret reads.
- Keeps kubectl-specific helpers only for legacy focused tests/fallbacks, kustomize rendering, and human diagnostic output.

Closes #16

## Test plan
- [x] gofmt -s -l .
- [x] go vet ./pkg/k8sclient ./internal/cli/setup/platform
- [x] staticcheck ./pkg/k8sclient ./internal/cli/setup/platform
- [x] go test ./pkg/k8sclient ./internal/cli/setup/platform -race -count=1
- [x] go test ./internal/cli/... ./pkg/k8sclient/... -count=1