### PR TITLE
feat(ci): add release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,120 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  BINARY_NAME: mcp-runtime
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set release metadata
+        shell: bash
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            version="${GITHUB_REF_NAME}"
+          else
+            version="dev"
+          fi
+
+          {
+            echo "VERSION=${version}"
+            echo "COMMIT=${GITHUB_SHA}"
+            echo "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "${GITHUB_ENV}"
+
+      - name: Build release archive
+        shell: bash
+        env:
+          CGO_ENABLED: 0
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+
+          package_dir="dist/${BINARY_NAME}-${GOOS}-${GOARCH}"
+          archive="dist/${BINARY_NAME}-${GOOS}-${GOARCH}.tar.gz"
+
+          mkdir -p "${package_dir}"
+
+          go build \
+            -trimpath \
+            -buildvcs=false \
+            -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+            -o "${package_dir}/${BINARY_NAME}" \
+            ./cmd/mcp-runtime
+
+          cp README.md LICENSE "${package_dir}/"
+          tar -C "${package_dir}" -czf "${archive}" .
+          sha256sum "${archive}" > "${archive}.sha256"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-runtime-${{ matrix.os }}-${{ matrix.arch }}
+          path: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-24.04
+    needs: [build]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List release assets
+        shell: bash
+        run: |
+          find dist -maxdepth 1 -type f | sort
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: MCP Runtime ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            dist/*.tar.gz
+            dist/*.tar.gz.sha256

--- a/hack/multitenancytest.sh
+++ b/hack/multitenancytest.sh
@@ -22,9 +22,12 @@ MCP_URL="${MCP_URL%/}"
 MCP_HOST="${MCP_URL#https://}"
 MCP_HOST="${MCP_HOST#http://}"
 MCP_HOST="${MCP_HOST%%/*}"
-KUBECONFIG="${KUBECONFIG:-/private/tmp/mcpruntime-k3s.yaml}"
-CREDS="${CREDS:-$HOME/Library/Application Support/mcp-runtime/credentials.json}"
-WORK_DIR="${WORK_DIR:-/private/tmp/mcp-runtime-multitenancy}"
+MCP_RUNTIME_CONFIG_DIR="${MCP_RUNTIME_CONFIG_DIR:-$HOME/.mcpruntime}"
+KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}"
+CREDS="${MCP_RUNTIME_CONFIG_DIR}/config.json"
+TMP_ROOT="${TMPDIR:-/tmp}"
+TMP_ROOT="${TMP_ROOT%/}"
+WORK_DIR="${WORK_DIR:-$TMP_ROOT/mcp-runtime-multitenancy}"
 TAG="${TAG:-v0.1.0}"
 ADAPTER_LISTEN="${ADAPTER_LISTEN:-127.0.0.1:8299}"
 
@@ -51,6 +54,7 @@ GLOBEX_SERVER="${GLOBEX_SERVER:-globex-tools}"
 AGENT_ID="${AGENT_ID:-cursor}"
 
 export KUBECONFIG
+export MCP_RUNTIME_CONFIG_DIR
 
 need() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -396,7 +400,7 @@ if [[ ! -x "$BIN" ]]; then
   exit 1
 fi
 
-mkdir -p "$WORK_DIR"
+mkdir -p "$MCP_RUNTIME_CONFIG_DIR" "$WORK_DIR"
 
 if [[ "${SKIP_SETUP:-0}" != "1" ]]; then
   setup_demo

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -66,7 +66,7 @@ Optional environment:
   ` + authfile.EnvAPIURL + `      default API base for login, e.g. https://platform.example.com
   ` + authfile.EnvAPIToken + `    use this token for API calls; overrides a saved file
   ` + authfile.EnvAPIProfile + `  select a saved credentials profile
-  MCP_RUNTIME_CONFIG_DIR    override the config directory (mainly for tests)`,
+  MCP_RUNTIME_CONFIG_DIR    override the config directory (default ~/.mcpruntime)`,
 	}
 
 	cmd.AddCommand(m.NewLoginCmd())

--- a/internal/cli/auth/auth_test.go
+++ b/internal/cli/auth/auth_test.go
@@ -75,7 +75,7 @@ func TestAuthLoginSavesAndVerifies(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute: %v stderr=%s", err, errb.String())
 	}
-	b, rerr := os.ReadFile(filepath.Join(d, "credentials.json"))
+	b, rerr := os.ReadFile(filepath.Join(d, "config.json"))
 	if rerr != nil {
 		t.Fatal(rerr)
 	}
@@ -114,7 +114,7 @@ func TestAuthLoginNormalizesTrailingAPIPath(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	b, err := os.ReadFile(filepath.Join(d, "credentials.json"))
+	b, err := os.ReadFile(filepath.Join(d, "config.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestAuthLoginStoresMultipleProfilesAndUseSwitchesCurrent(t *testing.T) {
 		t.Fatalf("acme login: %v", err)
 	}
 
-	creds, err := authfile.Load(filepath.Join(d, "credentials.json"))
+	creds, err := authfile.Load(filepath.Join(d, "config.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +166,7 @@ func TestAuthLoginStoresMultipleProfilesAndUseSwitchesCurrent(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("use admin: %v", err)
 	}
-	creds, err = authfile.Load(filepath.Join(d, "credentials.json"))
+	creds, err = authfile.Load(filepath.Join(d, "config.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/authfile/authfile.go
+++ b/pkg/authfile/authfile.go
@@ -12,9 +12,9 @@ import (
 	"sort"
 	"strings"
 	"time"
-)
 
-const subDir = "mcp-runtime"
+	"mcp-runtime/pkg/runtimeconfig"
+)
 
 // ErrNotFound is returned when no credentials file exists or it is empty.
 var ErrNotFound = errors.New("not logged in: no saved credentials")
@@ -22,26 +22,14 @@ var ErrNotFound = errors.New("not logged in: no saved credentials")
 // ErrInvalid is returned when a credentials file exists but is malformed.
 var ErrInvalid = errors.New("saved credentials are invalid")
 
-// ConfigDir is the per-user mcp-runtime configuration directory. If the environment
-// variable MCP_RUNTIME_CONFIG_DIR is set, that path is used (useful in tests).
+// ConfigDir is the per-user MCP Runtime configuration directory.
 func ConfigDir() (string, error) {
-	if d := os.Getenv("MCP_RUNTIME_CONFIG_DIR"); d != "" {
-		return d, nil
-	}
-	base, err := os.UserConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(base, subDir), nil
+	return runtimeconfig.Dir()
 }
 
-// FilePath returns the default path to credentials.json.
+// FilePath returns the default path to the MCP Runtime config file.
 func FilePath() (string, error) {
-	dir, err := ConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "credentials.json"), nil
+	return runtimeconfig.DefaultFile()
 }
 
 // Credentials holds platform API identities saved after `mcp-runtime auth login`.
@@ -321,7 +309,7 @@ const EnvAPIToken = "MCP_PLATFORM_API_TOKEN"
 // EnvAPIURL is the default platform API base URL (e.g. https://platform.example.com).
 const EnvAPIURL = "MCP_PLATFORM_API_URL"
 
-// EnvAPIProfile selects a saved platform API profile from credentials.json.
+// EnvAPIProfile selects a saved platform API profile from the MCP Runtime config file.
 const EnvAPIProfile = "MCP_PLATFORM_API_PROFILE"
 
 // ResolveToken returns a token and API base URL: first from the environment, then the default credentials file.

--- a/pkg/authfile/authfile_test.go
+++ b/pkg/authfile/authfile_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestResolveToken_PrefersEnv(t *testing.T) {
 	d := t.TempDir()
-	p := filepath.Join(d, "credentials.json")
+	p := filepath.Join(d, "config.json")
 	_ = os.MkdirAll(d, 0o700)
 	_ = os.WriteFile(p, []byte(`{"api_url":"https://file.example","token":"filetok"}`), 0o600)
 	t.Setenv("MCP_RUNTIME_CONFIG_DIR", d)
@@ -42,7 +42,7 @@ func TestConfigDir_RespectsEnv(t *testing.T) {
 func TestSaveLoadRoundTrip(t *testing.T) {
 	t.Parallel()
 	d := t.TempDir()
-	p := filepath.Join(d, "credentials.json")
+	p := filepath.Join(d, "config.json")
 	orig := &Credentials{
 		APIBaseURL:   "https://platform.example.com",
 		Token:        "secret-token-value",
@@ -89,7 +89,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 
 func TestSaveProfilePreservesMultipleAccounts(t *testing.T) {
 	d := t.TempDir()
-	p := filepath.Join(d, "credentials.json")
+	p := filepath.Join(d, "config.json")
 	if err := SaveProfile(p, "admin", CredentialAccount{APIBaseURL: "https://platform.example.com", Token: "admin-token", Role: "admin"}); err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestResolveToken_UsesSelectedProfile(t *testing.T) {
 	d := t.TempDir()
 	t.Setenv("MCP_RUNTIME_CONFIG_DIR", d)
 	t.Setenv(EnvAPIProfile, "admin")
-	p := filepath.Join(d, "credentials.json")
+	p := filepath.Join(d, "config.json")
 	if err := SaveProfile(p, "admin", CredentialAccount{APIBaseURL: "https://platform.example.com", Token: "admin-token"}); err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestLoad_Missing(t *testing.T) {
 func TestLoad_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	d := t.TempDir()
-	p := filepath.Join(d, "credentials.json")
+	p := filepath.Join(d, "config.json")
 	if err := os.WriteFile(p, []byte(`{"api_url"`), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestLoad_InvalidJSON(t *testing.T) {
 func TestLoad_IncompleteCredentials(t *testing.T) {
 	t.Parallel()
 	d := t.TempDir()
-	p := filepath.Join(d, "credentials.json")
+	p := filepath.Join(d, "config.json")
 	if err := os.WriteFile(p, []byte(`{"api_url":"https://platform.example.com"}`), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/runtimeconfig/runtimeconfig.go
+++ b/pkg/runtimeconfig/runtimeconfig.go
@@ -1,0 +1,44 @@
+// Package runtimeconfig centralizes per-user MCP Runtime configuration paths.
+package runtimeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// EnvDir overrides the per-user MCP Runtime config directory.
+const EnvDir = "MCP_RUNTIME_CONFIG_DIR"
+
+// DirName is the default config directory name under the user's home directory.
+const DirName = ".mcpruntime"
+
+// DefaultFileName is the default MCP Runtime config file name.
+const DefaultFileName = "config.json"
+
+// Dir returns the per-user MCP Runtime config directory.
+func Dir() (string, error) {
+	if d := strings.TrimSpace(os.Getenv(EnvDir)); d != "" {
+		return filepath.Clean(d), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, DirName), nil
+}
+
+// Path joins path elements under the MCP Runtime config directory.
+func Path(elem ...string) (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	parts := append([]string{dir}, elem...)
+	return filepath.Join(parts...), nil
+}
+
+// DefaultFile returns the default MCP Runtime config file path.
+func DefaultFile() (string, error) {
+	return Path(DefaultFileName)
+}

--- a/pkg/runtimeconfig/runtimeconfig_test.go
+++ b/pkg/runtimeconfig/runtimeconfig_test.go
@@ -1,0 +1,48 @@
+package runtimeconfig
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDirDefaultsToHomeDotMCPRuntime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvDir, "")
+
+	got, err := Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, DirName)
+	if got != want {
+		t.Fatalf("Dir() = %q, want %q", got, want)
+	}
+}
+
+func TestDirRespectsEnv(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "custom")
+	t.Setenv(EnvDir, dir)
+
+	got, err := Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != dir {
+		t.Fatalf("Dir() = %q, want %q", got, dir)
+	}
+}
+
+func TestDefaultFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvDir, dir)
+
+	got, err := DefaultFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, DefaultFileName)
+	if got != want {
+		t.Fatalf("DefaultFile() = %q, want %q", got, want)
+	}
+}

--- a/test/golden/cli/testdata/mcp-runtime_auth_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_auth_help.golden
@@ -9,7 +9,7 @@ Optional environment:
   MCP_PLATFORM_API_URL      default API base for login, e.g. https://platform.example.com
   MCP_PLATFORM_API_TOKEN    use this token for API calls; overrides a saved file
   MCP_PLATFORM_API_PROFILE  select a saved credentials profile
-  MCP_RUNTIME_CONFIG_DIR    override the config directory (mainly for tests)
+  MCP_RUNTIME_CONFIG_DIR    override the config directory (default ~/.mcpruntime)
 
 Usage:
   mcp-runtime auth [command]


### PR DESCRIPTION
Adds a GitHub Actions release workflow that builds `mcp-runtime` for macOS and Linux (`amd64` and `arm64`), packages release tarballs with `README.md` and `LICENSE`, emits SHA256 checksums, and publishes tagged GitHub Releases with generated notes.