### PR TITLE
fix(config): harden kubernetes workload defaults

### DIFF
--- a/config/ingress/base/kustomization.yaml
+++ b/config/ingress/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - traefik.yaml
   - dynamic-config.yaml
+  - networkpolicy.yaml

--- a/config/ingress/base/networkpolicy.yaml
+++ b/config/ingress/base/networkpolicy.yaml
@@ -1,0 +1,89 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-default-deny
+  namespace: traefik
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-ingress
+  namespace: traefik
+spec:
+  podSelector:
+    matchLabels:
+      app: traefik
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8000
+        - protocol: TCP
+          port: 8443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: traefik-allow-egress
+  namespace: traefik
+spec:
+  podSelector:
+    matchLabels:
+      app: traefik
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: registry
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-sentinel
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-servers
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-servers-org
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-servers-public
+        - namespaceSelector:
+            matchLabels:
+              platform.mcpruntime.org/managed: "true"
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 3000
+        - protocol: TCP
+          port: 5000
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8081
+        - protocol: TCP
+          port: 8082
+    # Traefik watches Ingress and TLS Secret objects through the Kubernetes API.
+    - ports:
+        - protocol: TCP
+          port: 443

--- a/config/ingress/base/traefik.yaml
+++ b/config/ingress/base/traefik.yaml
@@ -2,16 +2,30 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: traefik
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: registry
+  labels:
+    # hostpath overlays use a root chown initContainer; keep that exception
+    # visible while enforcing the strongest compatible default.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: mcp-sentinel
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: Namespace
@@ -214,11 +228,11 @@ spec:
   ports:
     - name: web
       port: 80
-      targetPort: 80
+      targetPort: 8000
       protocol: TCP
     - name: websecure
       port: 443
-      targetPort: 443
+      targetPort: 8443
       protocol: TCP
   selector:
     app: traefik
@@ -239,34 +253,40 @@ spec:
         app: traefik
     spec:
       serviceAccountName: traefik
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: traefik
         image: traefik:v2.10
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
           capabilities:
             drop:
               - ALL
-            add:
-              - NET_BIND_SERVICE
         args:
           - --providers.kubernetesingress=true
           - --providers.kubernetesingress.namespaces=registry,mcp-sentinel,mcp-servers,mcp-servers-org,mcp-servers-public
-          - --entrypoints.web.address=:80
+          - --entrypoints.web.address=:8000
+          - --entrypoints.web.forwardedHeaders.insecure=false
           - --entrypoints.web.http.redirections.entryPoint.to=websecure
           - --entrypoints.web.http.redirections.entryPoint.scheme=https
-          - --entrypoints.websecure.address=:443
+          - --entrypoints.websecure.address=:8443
+          - --entrypoints.websecure.forwardedHeaders.insecure=false
           - --entrypoints.websecure.http.tls=true
+          - --entrypoints.traefik.address=:8080
+          - --ping=true
+          - --ping.entryPoint=traefik
           - --providers.file.filename=/etc/traefik/dynamic/dynamic.yml
           - --providers.file.watch=true
         ports:
           - name: web
-            containerPort: 80
+            containerPort: 8000
           - name: websecure
-            containerPort: 443
+            containerPort: 8443
           - name: admin
             containerPort: 8080
         volumeMounts:
@@ -280,6 +300,18 @@ spec:
           limits:
             cpu: 500m
             memory: 256Mi
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: admin
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: admin
+          initialDelaySeconds: 15
+          periodSeconds: 20
       volumes:
         - name: traefik-dynamic
           configMap:

--- a/config/ingress/overlays/http/deployment-args.patch.yaml
+++ b/config/ingress/overlays/http/deployment-args.patch.yaml
@@ -4,7 +4,12 @@
     - --providers.kubernetesingress=true
     - --providers.kubernetesingress.namespaces=registry,mcp-sentinel,mcp-servers,mcp-servers-org,mcp-servers-public
     - --entrypoints.web.address=:8000
+    - --entrypoints.web.forwardedHeaders.insecure=false
     - --entrypoints.websecure.address=:8443
+    - --entrypoints.websecure.forwardedHeaders.insecure=false
+    - --entrypoints.traefik.address=:8080
+    - --ping=true
+    - --ping.entryPoint=traefik
     - --providers.file.filename=/etc/traefik/dynamic/dynamic.yml
     - --providers.file.watch=true
 - op: replace

--- a/config/ingress/overlays/prod/traefik-no-redirect.yaml
+++ b/config/ingress/overlays/prod/traefik-no-redirect.yaml
@@ -1,5 +1,5 @@
-# Traefik base enables HTTP to HTTPS on :80, which breaks HTTP-01 ACME challenges
-# (Let's Encrypt). Use plain HTTP on :80; HTTPS on :443 remains.
+# Traefik base enables HTTP to HTTPS, which breaks HTTP-01 ACME challenges
+# (Let's Encrypt). Use plain HTTP; HTTPS remains on the secure entrypoint.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,8 +13,9 @@ spec:
           args:
             - --providers.kubernetesingress=true
             - --providers.kubernetesingress.namespaces=registry,mcp-sentinel,mcp-servers,mcp-servers-org,mcp-servers-public
-            - --entrypoints.web.address=:80
-            - --entrypoints.websecure.address=:443
+            - --entrypoints.web.address=:8000
+            - --entrypoints.websecure.address=:8443
             - --entrypoints.websecure.http.tls=true
+            - --ping=true
             - --providers.file.filename=/etc/traefik/dynamic/dynamic.yml
             - --providers.file.watch=true

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - manager.yaml
+  - networkpolicy.yaml
   - pdb.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mcp-runtime
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -19,6 +23,7 @@ spec:
         control-plane: controller-manager
     spec:
       serviceAccountName: mcp-runtime-operator-controller-manager
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/config/manager/networkpolicy.yaml
+++ b/config/manager/networkpolicy.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-runtime-default-deny
+  namespace: mcp-runtime
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-runtime-allow-egress
+  namespace: mcp-runtime
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # The operator reconciles cluster resources through the Kubernetes API.
+    - ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: registry
+      ports:
+        - protocol: TCP
+          port: 5000

--- a/config/registry/base/deployment.yaml
+++ b/config/registry/base/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: registry
         image: registry:2.8.3
@@ -30,7 +32,10 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          readOnlyRootFilesystem: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         env:
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: /var/lib/registry
@@ -39,6 +44,8 @@ spec:
         volumeMounts:
         - name: registry-storage
           mountPath: /var/lib/registry
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             cpu: 100m
@@ -62,3 +69,5 @@ spec:
       - name: registry-storage
         persistentVolumeClaim:
           claimName: registry-storage
+      - name: tmp
+        emptyDir: {}

--- a/config/registry/base/kustomization.yaml
+++ b/config/registry/base/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - deployment.yaml
 - service.yaml
 - ingress.yaml
+- networkpolicy.yaml
 - pdb.yaml

--- a/config/registry/base/namespace.yaml
+++ b/config/registry/base/namespace.yaml
@@ -2,4 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: registry
-
+  labels:
+    # hostpath overlays use a root chown initContainer; keep that exception
+    # visible while enforcing the strongest compatible default.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/config/registry/base/networkpolicy.yaml
+++ b/config/registry/base/networkpolicy.yaml
@@ -1,0 +1,79 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: registry-default-deny
+  namespace: registry
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: registry-allow-ingress
+  namespace: registry
+spec:
+  podSelector:
+    matchLabels:
+      app: registry
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-sentinel
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-runtime
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-servers
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-servers-org
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: mcp-servers-public
+        - namespaceSelector:
+            matchLabels:
+              platform.mcpruntime.org/managed: "true"
+      ports:
+        - protocol: TCP
+          port: 5000
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: registry-allow-egress
+  namespace: registry
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              app: registry
+      ports:
+        - protocol: TCP
+          port: 5000

--- a/k8s/00-namespace.yaml
+++ b/k8s/00-namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: mcp-sentinel
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/services/api/internal/runtimeapi/actions.go
+++ b/services/api/internal/runtimeapi/actions.go
@@ -10,6 +10,8 @@ import (
 	"mcp-runtime/pkg/sentinel"
 )
 
+const actionRestartMaxBytes = 4 * 1024
+
 // HandleActionRestart restarts one or all Sentinel runtime components.
 func (s *RuntimeServer) HandleActionRestart(w http.ResponseWriter, r *http.Request) {
 	if s.sentinelMgr == nil {
@@ -22,8 +24,9 @@ func (s *RuntimeServer) HandleActionRestart(w http.ResponseWriter, r *http.Reque
 		All       bool   `json:"all"`
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, actionRestartMaxBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeAPIError(w, http.StatusBadRequest, "invalid request body")
+		writeBodyDecodeError(w, err)
 		return
 	}
 

--- a/services/api/internal/runtimeapi/deployments.go
+++ b/services/api/internal/runtimeapi/deployments.go
@@ -42,6 +42,11 @@ const (
 	platformNamespaceOwnerRoleName = "platform-namespace-owner"
 	sentinelIngestPort             = 8081
 	sentinelOTLPPort               = 4318
+	registryNamespace              = "registry"
+	registryPort                   = 5000
+	podSecurityEnforceLabel        = "pod-security.kubernetes.io/enforce"
+	podSecurityAuditLabel          = "pod-security.kubernetes.io/audit"
+	podSecurityWarnLabel           = "pod-security.kubernetes.io/warn"
 )
 
 var (
@@ -316,8 +321,10 @@ func (s *RuntimeServer) handleDeploymentApply(w http.ResponseWriter, r *http.Req
 		}
 	} else if p.Role == roleAdmin {
 		labels := map[string]string{
-			platformManagedLabel:                 "true",
-			"pod-security.kubernetes.io/enforce": "restricted",
+			platformManagedLabel:    "true",
+			podSecurityEnforceLabel: "restricted",
+			podSecurityAuditLabel:   "restricted",
+			podSecurityWarnLabel:    "restricted",
 		}
 		if err := s.ensureManagedNamespace(ctx, namespace, labels, managedNamespaceOptions{}); err != nil {
 			s.writeAudit(r.Context(), deploymentAuditEvent(r, p, "deployment_apply", "error", req.Name, namespace, image, err.Error()))
@@ -379,9 +386,11 @@ func (s *RuntimeServer) EnsureCatalogNamespace(ctx context.Context, namespace st
 		return nil
 	}
 	labels := map[string]string{
-		platformManagedLabel:                 "true",
-		platformScopeLabel:                   PlatformMode(),
-		"pod-security.kubernetes.io/enforce": "restricted",
+		platformManagedLabel:    "true",
+		platformScopeLabel:      PlatformMode(),
+		podSecurityEnforceLabel: "restricted",
+		podSecurityAuditLabel:   "restricted",
+		podSecurityWarnLabel:    "restricted",
 	}
 	cfg := platformTeamTraefikWatchConfig()
 	opts := managedNamespaceOptions{}
@@ -404,11 +413,13 @@ func (s *RuntimeServer) ensureTeamNamespace(ctx context.Context, team teamRecord
 		return errors.New("team namespace required")
 	}
 	labels := map[string]string{
-		platformManagedLabel:                 "true",
-		platformTeamIDLabel:                  strings.TrimSpace(team.ID),
-		platformTeamSlugLabel:                strings.TrimSpace(team.Slug),
-		platformScopeLabel:                   namespaceScopeTeam,
-		"pod-security.kubernetes.io/enforce": "restricted",
+		platformManagedLabel:    "true",
+		platformTeamIDLabel:     strings.TrimSpace(team.ID),
+		platformTeamSlugLabel:   strings.TrimSpace(team.Slug),
+		platformScopeLabel:      namespaceScopeTeam,
+		podSecurityEnforceLabel: "restricted",
+		podSecurityAuditLabel:   "restricted",
+		podSecurityWarnLabel:    "restricted",
 	}
 	cfg := platformTeamTraefikWatchConfig()
 	opts := managedNamespaceOptions{}
@@ -558,13 +569,11 @@ func desiredDefaultDenyNetworkPolicy(ns string, ingressFromNamespaces ...string)
 	udpProtocol := corev1.ProtocolUDP
 	tcpProtocol := corev1.ProtocolTCP
 	ingress := make([]networkingv1.NetworkPolicyIngressRule, 0, 2)
-	if len(ingressFromNamespaces) > 0 {
-		ingress = append(ingress, networkingv1.NetworkPolicyIngressRule{
-			From: []networkingv1.NetworkPolicyPeer{
-				{PodSelector: &metav1.LabelSelector{}},
-			},
-		})
-	}
+	ingress = append(ingress, networkingv1.NetworkPolicyIngressRule{
+		From: []networkingv1.NetworkPolicyPeer{
+			{PodSelector: &metav1.LabelSelector{}},
+		},
+	})
 	for _, namespace := range ingressFromNamespaces {
 		namespace = strings.TrimSpace(namespace)
 		if namespace == "" {
@@ -614,17 +623,6 @@ func desiredDefaultDenyNetworkPolicy(ns string, ingressFromNamespaces ...string)
 				},
 				{
 					To: []networkingv1.NetworkPolicyPeer{
-						{PodSelector: &metav1.LabelSelector{}},
-					},
-				},
-				{
-					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &tcpProtocol, Port: intstrPtr(80)},
-						{Protocol: &tcpProtocol, Port: intstrPtr(443)},
-					},
-				},
-				{
-					To: []networkingv1.NetworkPolicyPeer{
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{"kubernetes.io/metadata.name": sentinel.DefaultNamespace},
@@ -634,6 +632,18 @@ func desiredDefaultDenyNetworkPolicy(ns string, ingressFromNamespaces ...string)
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Protocol: &tcpProtocol, Port: intstrPtr(sentinelIngestPort)},
 						{Protocol: &tcpProtocol, Port: intstrPtr(sentinelOTLPPort)},
+					},
+				},
+				{
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"kubernetes.io/metadata.name": registryNamespace},
+							},
+						},
+					},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcpProtocol, Port: intstrPtr(registryPort)},
 					},
 				},
 			},
@@ -869,6 +879,30 @@ func desiredDeployment(name, namespace, image string, port, replicas int32, labe
 					Image:           image,
 					Ports:           []corev1.ContainerPort{{ContainerPort: port}},
 					SecurityContext: kubeworkload.RestrictedContainerSecurityContext(),
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{Port: intstrFromInt32(port)},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       10,
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							TCPSocket: &corev1.TCPSocketAction{Port: intstrFromInt32(port)},
+						},
+						InitialDelaySeconds: 30,
+						PeriodSeconds:       20,
+					},
 				}},
 			},
 		},

--- a/services/api/internal/runtimeapi/deployments_test.go
+++ b/services/api/internal/runtimeapi/deployments_test.go
@@ -178,6 +178,59 @@ func TestEnsureDefaultDenyNetworkPolicyAllowsSentinelEgress(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultDenyNetworkPolicyAllowsRegistryEgress(t *testing.T) {
+	client := kubernetesfake.NewSimpleClientset()
+	if err := ensureDefaultDenyNetworkPolicy(context.Background(), client, "mcp-servers"); err != nil {
+		t.Fatalf("ensureDefaultDenyNetworkPolicy() error = %v", err)
+	}
+	policy, err := client.NetworkingV1().NetworkPolicies("mcp-servers").Get(context.Background(), "platform-default-deny", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get networkpolicy: %v", err)
+	}
+	if !networkPolicyAllowsEgressToNamespacePort(policy, registryNamespace, registryPort) {
+		t.Fatalf("expected registry egress rule, got %#v", policy.Spec.Egress)
+	}
+}
+
+func TestEnsureDefaultDenyNetworkPolicyAllowsSameNamespaceIngress(t *testing.T) {
+	client := kubernetesfake.NewSimpleClientset()
+	if err := ensureDefaultDenyNetworkPolicy(context.Background(), client, "user-1"); err != nil {
+		t.Fatalf("ensureDefaultDenyNetworkPolicy() error = %v", err)
+	}
+	policy, err := client.NetworkingV1().NetworkPolicies("user-1").Get(context.Background(), "platform-default-deny", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get networkpolicy: %v", err)
+	}
+	if !networkPolicyAllowsSameNamespace(policy) {
+		t.Fatalf("network policy does not allow same-namespace ingress: %#v", policy.Spec.Ingress)
+	}
+}
+
+func TestEnsureDefaultDenyNetworkPolicyDoesNotAllowBroadHTTPEgress(t *testing.T) {
+	client := kubernetesfake.NewSimpleClientset()
+	if err := ensureDefaultDenyNetworkPolicy(context.Background(), client, "user-1"); err != nil {
+		t.Fatalf("ensureDefaultDenyNetworkPolicy() error = %v", err)
+	}
+	policy, err := client.NetworkingV1().NetworkPolicies("user-1").Get(context.Background(), "platform-default-deny", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get networkpolicy: %v", err)
+	}
+	for _, rule := range policy.Spec.Egress {
+		if len(rule.To) != 0 {
+			continue
+		}
+		seen := map[int32]bool{}
+		for _, port := range rule.Ports {
+			if port.Port != nil && port.Port.Type == intstr.Int {
+				seen[port.Port.IntVal] = true
+			}
+		}
+		if seen[80] || seen[443] {
+			t.Fatalf("found broad HTTP egress rule: %#v", rule)
+		}
+	}
+}
+
 func TestEnsureDefaultDenyNetworkPolicyAllowsConfiguredIngressNamespace(t *testing.T) {
 	client := kubernetesfake.NewSimpleClientset()
 	if err := ensureDefaultDenyNetworkPolicy(context.Background(), client, "mcp-servers-public", "kube-system"); err != nil {
@@ -228,8 +281,18 @@ func TestHandleDeploymentApplyAdminUsesRequestedNamespace(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
 	}
-	if _, err := client.CoreV1().Namespaces().Get(context.Background(), "tenant-a", metav1.GetOptions{}); err != nil {
+	ns, err := client.CoreV1().Namespaces().Get(context.Background(), "tenant-a", metav1.GetOptions{})
+	if err != nil {
 		t.Fatalf("target namespace not ensured: %v", err)
+	}
+	for _, key := range []string{
+		"pod-security.kubernetes.io/enforce",
+		"pod-security.kubernetes.io/audit",
+		"pod-security.kubernetes.io/warn",
+	} {
+		if ns.Labels[key] != "restricted" {
+			t.Fatalf("namespace label %s = %q, want restricted", key, ns.Labels[key])
+		}
 	}
 }
 
@@ -595,6 +658,18 @@ func TestDesiredDeploymentUsesRestrictedPodDefaults(t *testing.T) {
 	if container.SecurityContext.Capabilities == nil || len(container.SecurityContext.Capabilities.Drop) != 1 || container.SecurityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
 		t.Fatalf("expected user workload container to drop all capabilities, got %#v", container.SecurityContext.Capabilities)
 	}
+	if container.Resources.Requests.Cpu().IsZero() || container.Resources.Requests.Memory().IsZero() {
+		t.Fatalf("expected user workload resource requests, got %#v", container.Resources)
+	}
+	if container.Resources.Limits.Cpu().IsZero() || container.Resources.Limits.Memory().IsZero() {
+		t.Fatalf("expected user workload resource limits, got %#v", container.Resources)
+	}
+	if container.ReadinessProbe == nil || container.ReadinessProbe.TCPSocket == nil {
+		t.Fatalf("expected TCP readiness probe, got %#v", container.ReadinessProbe)
+	}
+	if container.LivenessProbe == nil || container.LivenessProbe.TCPSocket == nil {
+		t.Fatalf("expected TCP liveness probe, got %#v", container.LivenessProbe)
+	}
 }
 
 func TestHandleDeploymentItemRejectsServiceUserWithoutIdentity(t *testing.T) {
@@ -621,6 +696,37 @@ func hasString(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
 			return true
+		}
+	}
+	return false
+}
+
+func networkPolicyAllowsSameNamespace(policy *networkingv1.NetworkPolicy) bool {
+	for _, rule := range policy.Spec.Ingress {
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil && peer.NamespaceSelector == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func networkPolicyAllowsEgressToNamespacePort(policy *networkingv1.NetworkPolicy, namespace string, port int) bool {
+	for _, rule := range policy.Spec.Egress {
+		portAllowed := false
+		for _, candidate := range rule.Ports {
+			if candidate.Port != nil && candidate.Port.Type == intstr.Int && candidate.Port.IntVal == int32(port) {
+				portAllowed = true
+			}
+		}
+		if !portAllowed {
+			continue
+		}
+		for _, peer := range rule.To {
+			if peer.NamespaceSelector != nil && peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+				return true
+			}
 		}
 	}
 	return false

--- a/test/manifest/registry_networkpolicy_test.go
+++ b/test/manifest/registry_networkpolicy_test.go
@@ -1,0 +1,189 @@
+package manifest_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type networkPolicyDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name      string `yaml:"name"`
+		Namespace string `yaml:"namespace"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Ingress []networkPolicyIngressRule `yaml:"ingress"`
+		Egress  []networkPolicyEgressRule  `yaml:"egress"`
+	} `yaml:"spec"`
+}
+
+type networkPolicyIngressRule struct {
+	From  []networkPolicyPeer `yaml:"from"`
+	Ports []networkPolicyPort `yaml:"ports"`
+}
+
+type networkPolicyEgressRule struct {
+	To    []networkPolicyPeer `yaml:"to"`
+	Ports []networkPolicyPort `yaml:"ports"`
+}
+
+type networkPolicyPeer struct {
+	PodSelector       *networkPolicySelector `yaml:"podSelector"`
+	NamespaceSelector *networkPolicySelector `yaml:"namespaceSelector"`
+}
+
+type networkPolicySelector struct {
+	MatchLabels map[string]string `yaml:"matchLabels"`
+}
+
+type networkPolicyPort struct {
+	Protocol string `yaml:"protocol"`
+	Port     int    `yaml:"port"`
+}
+
+func TestRegistryNetworkPolicyAllowsHelperPushOnlyToRegistry(t *testing.T) {
+	policies := loadRegistryNetworkPolicies(t)
+
+	ingress, ok := policies["registry-allow-ingress"]
+	if !ok {
+		t.Fatal("registry-allow-ingress policy not found")
+	}
+	if !hasSameNamespaceIngressToPort(ingress, 5000) {
+		t.Fatal("registry ingress policy must allow same-namespace helper pods to reach registry:5000")
+	}
+	if !hasNamespaceIngressToPort(ingress, "mcp-servers", 5000) {
+		t.Fatal("registry ingress policy must allow catalog namespace probes to reach registry:5000")
+	}
+	if !hasManagedNamespaceIngressToPort(ingress, 5000) {
+		t.Fatal("registry ingress policy must allow managed namespace probes to reach registry:5000")
+	}
+
+	egress, ok := policies["registry-allow-egress"]
+	if !ok {
+		t.Fatal("registry-allow-egress policy not found")
+	}
+	if !hasDNSEgress(egress) {
+		t.Fatal("registry egress policy must allow helper pods to resolve cluster DNS")
+	}
+	if !hasRegistryEgressToPort(egress, 5000) {
+		t.Fatal("registry egress policy must allow helper pods to reach only registry pods on port 5000")
+	}
+}
+
+func loadRegistryNetworkPolicies(t *testing.T) map[string]networkPolicyDoc {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Join("..", "..", "config", "registry", "base", "networkpolicy.yaml"))
+	if err != nil {
+		t.Fatalf("read registry network policy manifest: %v", err)
+	}
+
+	policies := map[string]networkPolicyDoc{}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc networkPolicyDoc
+		err := decoder.Decode(&doc)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode registry network policy manifest: %v", err)
+		}
+		if doc.Kind == "NetworkPolicy" && doc.Metadata.Namespace == "registry" {
+			policies[doc.Metadata.Name] = doc
+		}
+	}
+	return policies
+}
+
+func hasSameNamespaceIngressToPort(policy networkPolicyDoc, port int) bool {
+	for _, rule := range policy.Spec.Ingress {
+		if !networkPolicyPortsInclude(rule.Ports, "TCP", port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.PodSelector != nil && peer.NamespaceSelector == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasNamespaceIngressToPort(policy networkPolicyDoc, namespace string, port int) bool {
+	for _, rule := range policy.Spec.Ingress {
+		if !networkPolicyPortsInclude(rule.Ports, "TCP", port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil &&
+				peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasManagedNamespaceIngressToPort(policy networkPolicyDoc, port int) bool {
+	for _, rule := range policy.Spec.Ingress {
+		if !networkPolicyPortsInclude(rule.Ports, "TCP", port) {
+			continue
+		}
+		for _, peer := range rule.From {
+			if peer.NamespaceSelector != nil &&
+				peer.NamespaceSelector.MatchLabels["platform.mcpruntime.org/managed"] == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasDNSEgress(policy networkPolicyDoc) bool {
+	for _, rule := range policy.Spec.Egress {
+		if !networkPolicyPortsInclude(rule.Ports, "UDP", 53) || !networkPolicyPortsInclude(rule.Ports, "TCP", 53) {
+			continue
+		}
+		for _, peer := range rule.To {
+			if peer.NamespaceSelector == nil || peer.PodSelector == nil {
+				continue
+			}
+			if peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == "kube-system" &&
+				peer.PodSelector.MatchLabels["k8s-app"] == "kube-dns" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasRegistryEgressToPort(policy networkPolicyDoc, port int) bool {
+	for _, rule := range policy.Spec.Egress {
+		if !networkPolicyPortsInclude(rule.Ports, "TCP", port) {
+			continue
+		}
+		for _, peer := range rule.To {
+			if peer.PodSelector != nil &&
+				peer.PodSelector.MatchLabels["app"] == "registry" &&
+				peer.NamespaceSelector == nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func networkPolicyPortsInclude(ports []networkPolicyPort, protocol string, port int) bool {
+	for _, candidate := range ports {
+		if candidate.Protocol == protocol && candidate.Port == port {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add default-deny NetworkPolicies for Sentinel, Traefik, registry, and operator namespaces with scoped allow rules.
- Tighten PSS labels and document baseline enforcement where checked-in hostPath/root-init exceptions remain.
- Harden Traefik and observability workloads with non-root/securityContext defaults, resources, probes, and read-only config mounts.
- Tighten generated runtime namespace defaults by adding restricted audit/warn labels, resource/probe defaults, and removing broad HTTP/HTTPS egress.

## Validation

- `go test ./internal/runtimeapi -count=1` from `services/api`
- `kubectl apply --dry-run=client` for changed raw k8s manifests
- `kubectl apply --dry-run=client -k` for ingress base/http/prod/dev, registry base, and manager
- `git diff --check`
- pre-commit hooks during commit: gitleaks, go fmt, staticcheck, go vet, go unit tests, generated file drift

## Notes

`kube-linter` was not installed in the local environment, so that optional lint pass was not run.