### PR TITLE
doc: align README license with Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ The repo keeps Claude-specific local configuration in [`.claude/`](.claude/READM
 
 ## License
 
-MIT
+Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Update the README **License** section to match the repository `LICENSE` file (Apache License 2.0).
- The README previously listed MIT, which was out of date after the license change.

## Test plan
- [x] Verified `LICENSE` is Apache 2.0
- [x] README license section now references `LICENSE`


Made with [Cursor](https://cursor.com)