### PR TITLE
doc: document server init and access grant/session init CLI flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,7 @@ POD="$(kubectl get pods -n mcp-servers -l app="$SERVER" -o jsonpath='{.items[0].
 kubectl describe pod -n mcp-servers "$POD"
 kubectl logs -n mcp-servers "$POD" -c "$CONTAINER"
 kubectl logs -n mcp-servers "$POD" -c mcp-gateway
+./bin/mcp-runtime auth login --api-url <platform-url>   # platform API default
 ./bin/mcp-runtime server policy inspect "$SERVER" --namespace mcp-servers
 kubectl get mcpaccessgrant,mcpagentsession -n mcp-servers -o wide
 ```
@@ -352,7 +353,13 @@ For production with `MCP_PLATFORM_DOMAIN=example.com`, setup derives hostnames `
 ## Governance (grants and sessions)
 
 - **UI** can create/apply grants and sessions and toggle grant enablement and session state.
-- **CLI:** `mcp-runtime access grant apply --file <file.yaml>` and `mcp-runtime access session apply --file <file.yaml>`. `kubectl apply -f` is still a valid fallback.
+- **CLI (platform API default):** run `mcp-runtime auth login --api-url <platform-url>`,
+  then scaffold with `access grant init` / `access session init` when helpful, and
+  apply with `mcp-runtime access grant apply --file <file.yaml>` and
+  `mcp-runtime access session apply --file <file.yaml>`. Adapter flows usually
+  skip manual session apply; use `adapter stdio|proxy --server ... --agent ... --auto-refresh`.
+- **Admin fallback:** `kubectl apply -f` or the same apply commands with
+  `--use-kube` require admin/operator kubeconfig/RBAC and bypass platform auth.
 - **Team isolation:** use one namespace per team plus first-class team identity. `MCPServer.spec.teamID` marks the server owner, `SubjectRef.teamID` constrains grants/sessions to callers from that team, and the gateway matches all non-empty `humanID` / `agentID` / `teamID` fields exactly. Keep single-team examples in `mcp-servers`.
 - **Platform access hardening:** platform API server/grant/session writes reject shared-catalog writes by non-admin callers and reject cross-namespace `serverRef.namespace`. Server writes default/validate `spec.teamID` against the authenticated principal namespace. Grant/session writes default missing `subject.teamID` from the referenced server team, but preserve explicit foreign `subject.teamID` values for delegated cross-team access.
 - **Advisory identity checks:** access apply commands warn, but do not block, when `subject.humanID` looks malformed, case-ambiguous, whitespace-padded, or namespace-encoded.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,11 +355,12 @@ For production with `MCP_PLATFORM_DOMAIN=example.com`, setup derives hostnames `
 - **UI** can create/apply grants and sessions and toggle grant enablement and session state.
 - **CLI (platform API default):** run `mcp-runtime auth login --api-url <platform-url>`,
   then scaffold with `access grant init` / `access session init` when helpful, and
-  apply with `mcp-runtime access grant apply --file <file.yaml>` and
-  `mcp-runtime access session apply --file <file.yaml>`. Adapter flows usually
-  skip manual session apply; use `adapter stdio|proxy --server ... --agent ... --auto-refresh`.
-- **Admin fallback:** `kubectl apply -f` or the same apply commands with
-  `--use-kube` require admin/operator kubeconfig/RBAC and bypass platform auth.
+  apply grants with `mcp-runtime access grant apply --file <file.yaml>`.
+  **Session apply via platform API is admin-only.** Adapter flows usually skip
+  manual session apply; use `adapter stdio|proxy --server ... --agent ...
+  --auto-refresh`.
+- **Admin fallback:** `kubectl apply -f` or apply commands with `--use-kube`
+  require admin/operator kubeconfig/RBAC and bypass platform auth.
 - **Team isolation:** use one namespace per team plus first-class team identity. `MCPServer.spec.teamID` marks the server owner, `SubjectRef.teamID` constrains grants/sessions to callers from that team, and the gateway matches all non-empty `humanID` / `agentID` / `teamID` fields exactly. Keep single-team examples in `mcp-servers`.
 - **Platform access hardening:** platform API server/grant/session writes reject shared-catalog writes by non-admin callers and reject cross-namespace `serverRef.namespace`. Server writes default/validate `spec.teamID` against the authenticated principal namespace. Grant/session writes default missing `subject.teamID` from the referenced server team, but preserve explicit foreign `subject.teamID` values for delegated cross-team access.
 - **Advisory identity checks:** access apply commands warn, but do not block, when `subject.humanID` looks malformed, case-ambiguous, whitespace-padded, or namespace-encoded.

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ human workflows.
     <li>Optional HTTP and stdio agent adapters for governed framework integrations</li>
     <li>Compliance-oriented event records for who called what, when, against which server, and whether it was allowed or denied</li>
     <li>Ingress routing for path-based MCP endpoints</li>
-    <li>CLI for setup, status, registry, <code>server init</code>, access init/apply, Sentinel, and adapters</li>
+    <li>CLI for setup, status, registry, <code>server init</code>, access init/apply, adapters; admin kubectl tools for <code>sentinel *</code></li>
   </ul>
   </div>
 </section>

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ human workflows.
     <li>Optional HTTP and stdio agent adapters for governed framework integrations</li>
     <li>Compliance-oriented event records for who called what, when, against which server, and whether it was allowed or denied</li>
     <li>Ingress routing for path-based MCP endpoints</li>
-    <li>CLI for setup, status, registry, access, Sentinel, and servers</li>
+    <li>CLI for setup, status, registry, <code>server init</code>, access init/apply, Sentinel, and adapters</li>
   </ul>
   </div>
 </section>

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -10,10 +10,11 @@ grants, sessions, or policy:
   each JSON-RPC message to the same MCP Runtime HTTP route.
 
 Both adapters only **present** issued identity values. They do not create
-grants, create sessions, evaluate policy, or bypass the gateway. Platform
-admins still author `MCPAccessGrant` resources; the platform API and the
-adapter session endpoint together resolve which `MCPAgentSession` a caller
-runs under, and the gateway is the enforcement point.
+grants, evaluate policy, or bypass the gateway. Platform admins author
+`MCPAccessGrant` resources first — scaffold with `mcp-runtime access grant init`
+when helpful — and the platform API issues `MCPAgentSession` values through
+`POST /api/runtime/adapter/sessions` when the adapter starts with `--server`
+and `--agent`. The gateway is the enforcement point.
 
 The adapter surface is intentionally limited to stdio and Streamable HTTP, the
 two standard MCP transports. There is no separate legacy HTTP+SSE adapter.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,9 @@ flowchart TB
 3. Allowed tool calls emit analytics events through ingest → Kafka → processor
    → ClickHouse; Grafana surfaces usage and traces.
 
-Control-plane changes (setup, `server deploy`, grants) flow through the CLI or
-platform API into Kubernetes; the operator materializes Deployments, Services,
-Ingress, and policy ConfigMaps.
+Control-plane changes (setup, `server init`, `server deploy`, `access grant init`,
+`access session init`) flow through the CLI or platform API into Kubernetes;
+the operator materializes Deployments, Services, Ingress, and policy ConfigMaps.
 
 See [Request Flows](internals/request-flows.md) for allow/deny sequence diagrams,
 component-level paths, and E2E scenario mapping.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,10 +75,12 @@ flowchart TB
    → ClickHouse; Grafana surfaces usage and traces.
 
 Control-plane changes (setup, `auth login`, `server init`, `server deploy`,
-`access grant init`, `access session init`) flow through the CLI or platform API
+`access grant init`, `access grant apply`) flow through the CLI or platform API
 into Kubernetes; the operator materializes Deployments, Services, Ingress, and
-policy ConfigMaps. Admin-only `--use-kube` or `kubectl apply` bypasses platform
-auth and requires operator RBAC.
+policy ConfigMaps. Sessions for agent traffic are usually issued through
+`POST /api/runtime/adapter/sessions`; explicit session manifests are
+admin-only on the platform API. Admin-only `--use-kube` or `kubectl apply`
+bypasses platform auth and requires operator RBAC.
 
 See [Request Flows](internals/request-flows.md) for allow/deny sequence diagrams,
 component-level paths, and E2E scenario mapping.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ flowchart TB
     end
 
     CLI --> API
-    CLI --> K8s
+    CLI -. "admin --use-kube only" .-> K8s
     UI --> API
     Agent --> Ing
     MCP --> Ing
@@ -74,9 +74,11 @@ flowchart TB
 3. Allowed tool calls emit analytics events through ingest → Kafka → processor
    → ClickHouse; Grafana surfaces usage and traces.
 
-Control-plane changes (setup, `server init`, `server deploy`, `access grant init`,
-`access session init`) flow through the CLI or platform API into Kubernetes;
-the operator materializes Deployments, Services, Ingress, and policy ConfigMaps.
+Control-plane changes (setup, `auth login`, `server init`, `server deploy`,
+`access grant init`, `access session init`) flow through the CLI or platform API
+into Kubernetes; the operator materializes Deployments, Services, Ingress, and
+policy ConfigMaps. Admin-only `--use-kube` or `kubectl apply` bypasses platform
+auth and requires operator RBAC.
 
 See [Request Flows](internals/request-flows.md) for allow/deny sequence diagrams,
 component-level paths, and E2E scenario mapping.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,13 @@ flowchart TB
 3. Allowed tool calls emit analytics events through ingest → Kafka → processor
    → ClickHouse; Grafana surfaces usage and traces.
 
-Control-plane changes (setup, `auth login`, `server init`, `server deploy`,
-`access grant init`, `access grant apply`) flow through the CLI or platform API
-into Kubernetes; the operator materializes Deployments, Services, Ingress, and
+Local scaffolding commands (`server init`, `access grant init`, `access session init`)
+write manifests on the workstation only; they do not call the platform API or
+Kubernetes.
+
+Control-plane changes (setup, `auth login`, `server deploy`, `access grant apply`,
+and admin-only `access session apply`) flow through the CLI or platform API into
+Kubernetes; the operator materializes Deployments, Services, Ingress, and
 policy ConfigMaps. Sessions for agent traffic are usually issued through
 `POST /api/runtime/adapter/sessions`; explicit session manifests are
 admin-only on the platform API. Admin-only `--use-kube` or `kubectl apply`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-The `mcp-runtime` CLI is the operator-facing front door. It bootstraps clusters, manages registries, applies `MCPServer` manifests, operates access grants and sessions, and inspects the runtime + sentinel stack.
+The `mcp-runtime` CLI is the operator-facing front door. It bootstraps clusters, manages registries, publishes servers through the platform API, operates access grants and sessions, and inspects the runtime + sentinel stack. Direct Kubernetes manifest operations (`server apply`, `create`, `patch`, `logs`, …) require the admin-only `--use-kube` flag.
 
 ```mermaid
 flowchart LR

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -217,9 +217,32 @@ Notes:
 - `MCP_PLATFORM_API_TOKEN` overrides any saved token when set
 - `MCP_PLATFORM_API_URL` can provide the default API base URL
 - kubeconfig-based cluster commands are separate from platform auth
-- `--use-kube` is an admin/dev/test escape hatch for supported server and
-  access commands; it requires kubectl plus admin/operator Kubernetes RBAC and
-  is not the normal platform API path
+
+## Platform API vs `--use-kube`
+
+Most `server` and `access` commands use the **platform API** by default. Run
+`mcp-runtime auth login --api-url <platform-url>` (or set
+`MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`) before those flows.
+
+`--use-kube` is **admin/dev/test only**. It bypasses platform auth and talks to
+the Kubernetes API through your kubeconfig. Use it only when you have
+admin/operator RBAC and intentionally want direct CRD/manifest operations.
+
+| Default (platform API) | Requires `--use-kube` (admin only) |
+|---|---|
+| `access grant/session` list, get, apply, delete, enable/disable, revoke/unrevoke | same commands with `--use-kube` for raw kubectl CRUD |
+| `server list`, `get`, `delete`, `status`, `policy inspect`, `deploy` | `server create`, `apply`, `export`, `patch`, `logs` |
+| `registry push` (always platform API) | `kubectl apply -f` for manifests (separate from CLI flag) |
+
+Notes:
+
+- `server get` without `--use-kube` returns a platform API summary; full
+  MCPServer YAML needs `--use-kube`.
+- `server status` without `--use-kube` lists servers from the platform API;
+  pod-level detail needs `--use-kube`.
+- `server logs` always requires `--use-kube`; use `kubectl logs` or
+  `sentinel logs gateway` when you only have platform credentials.
+- `--team` is a platform API resolver and is rejected with `--use-kube`.
 
 ## status
 
@@ -301,10 +324,12 @@ For the full build, push, deploy, and verify flow, see [Publish an MCP Server](p
 
 ## access
 
-Scaffold manifests with `init`, then apply through the platform API (default)
-or with `--use-kube` for direct Kubernetes admin flows.
+Scaffold manifests with `init`, then apply through the platform API (default).
+Add `--use-kube` only for admin/operator direct Kubernetes flows.
 
 ```bash
+mcp-runtime auth login --api-url https://platform.example.com
+
 # Grants
 mcp-runtime access grant init payments-globex-cursor \
   --namespace mcp-team-acme \
@@ -411,10 +436,12 @@ mcp-runtime server create payments --file server.yaml --use-kube
 mcp-runtime server apply --file server.yaml --use-kube
 mcp-runtime server export payments --file payments.yaml --use-kube
 
-# Patch / inspect
-mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
+# Patch / inspect (platform API)
 mcp-runtime server status --namespace mcp-servers
 mcp-runtime server policy inspect payments
+
+# Admin/operator only — requires --use-kube
+mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
 mcp-runtime server logs payments --follow --use-kube
 
 # Build (push lives under registry)
@@ -422,12 +449,11 @@ mcp-runtime server build image payments --tag v1 --platform linux/amd64
 mcp-runtime registry push --scope public --image <exact-image-ref-from-build>
 ```
 
-When `--use-kube` is absent, supported `server` commands use the platform API
-and require `mcp-runtime auth login --api-url <platform-url>` or
-`MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`. `--team` is a platform API
-resolver; it is rejected in direct Kubernetes mode. In `--use-kube` mode, use
-`--namespace` and expect kubeconfig/RBAC failures unless the current principal
-has admin/operator cluster access.
+When `--use-kube` is absent, the supported `server` and `access` commands above
+use the platform API and require `mcp-runtime auth login --api-url
+<platform-url>` or `MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`.
+In `--use-kube` mode, use `--namespace` and expect kubeconfig/RBAC failures
+unless the current principal has admin/operator cluster access.
 
 `server patch` accepts inline `--patch` or `--patch-file` with `merge`, `json`, or `strategic` modes.
 
@@ -513,7 +539,7 @@ mcp-runtime server policy inspect payments
 mcp-runtime sentinel port-forward ui
 mcp-runtime sentinel logs api --since 10m
 
-# Patch a running server
+# Patch a running server (admin/operator — requires --use-kube)
 mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
 mcp-runtime server status
 mcp-runtime status

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,6 +1,10 @@
 # CLI
 
-The `mcp-runtime` CLI is the operator-facing front door. It bootstraps clusters, manages registries, publishes servers through the platform API, operates access grants and sessions, and inspects the runtime + sentinel stack. Direct Kubernetes manifest operations (`server apply`, `create`, `patch`, `logs`, …) require the admin-only `--use-kube` flag.
+The `mcp-runtime` CLI bootstraps clusters, manages registries, publishes servers
+through the platform API, operates access grants and sessions, and inspects the
+runtime stack. Direct Kubernetes manifest operations (`server apply`, `create`,
+`patch`, `logs`, …) require the admin-only `--use-kube` flag. The `sentinel`
+command group also requires admin/operator kubectl access.
 
 ```mermaid
 flowchart LR
@@ -57,8 +61,8 @@ mcp-runtime <group> <subcommand> --help
 | `server` | Manage `MCPServer` resources and operator-facing actions. | `init`, `list`, `get`, `create`, `apply`, `deploy`, `generate`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
 | `access` | Manage `MCPAccessGrant` and `MCPAgentSession` resources that feed the gateway policy layer. | `grant init/list/get/apply/delete/disable/enable`, `session init/list/get/apply/delete/revoke/unrevoke` |
 | `adapter` | HTTP proxy and stdio shims that inject governance identity/session headers for agents. | `proxy`, `stdio` |
-| `team` | Manage internal platform teams, team password users, and Kubernetes team namespaces. | `list`, `create`, `user list`, `user create`, `init` |
-| `sentinel` | Inspect and operate the bundled analytics, gateway, and observability stack. | `status`, `events`, `logs`, `port-forward`, `restart` |
+| `team` | Manage internal platform teams, team password users, and Kubernetes team namespaces. | `list`, `create`, `user list`, `user create` |
+| `sentinel` | Inspect and operate the bundled analytics, gateway, and observability stack (**admin/operator kubectl only**). | `status`, `events`, `logs`, `port-forward`, `restart` |
 | `status` | Aggregated platform health (cluster, registry, operator, servers, sentinel). | `status` |
 | `completion` | Generate shell completion (bash, zsh, fish). | `completion bash\|zsh\|fish` |
 
@@ -242,6 +246,9 @@ Notes:
   pod-level detail needs `--use-kube`.
 - `server logs` always requires `--use-kube`; use `kubectl logs` or
   `sentinel logs gateway` when you only have platform credentials.
+- `access session apply` through the platform API is **admin-only**; agents
+  should use `adapter stdio|proxy --server … --agent …` or admins use
+  `--use-kube` / `kubectl apply` for explicit session manifests.
 - `--team` is a platform API resolver and is rejected with `--use-kube`.
 
 ## status
@@ -381,7 +388,9 @@ mcp-runtime access session unrevoke ops-agent
 `allowedSideEffects`. `--tool` is shorthand for an allow rule at `--trust`
 (default `low`). Use `--tool-rule name:allow|deny:low|medium|high` for mixed
 decisions. `access session init` is for explicit/admin session manifests; adapter
-`--auto-refresh` usually creates sessions automatically at runtime.
+`--auto-refresh` usually creates sessions automatically at runtime. Platform
+API `access session apply` requires an **admin** role; server/team owners use
+grant apply plus adapter-issued sessions for normal agent flows.
 
 For multi-team deployments, namespace scoping controls who can write resources
 and `teamID` controls who can use them. Put each team's grants and sessions in
@@ -398,8 +407,6 @@ mcp-runtime team user create globex \
   --password '...' \
   --role member
 mcp-runtime team user list globex
-mcp-runtime team init acme --group acme-mcp-admins
-mcp-runtime team init acme --dry-run
 ```
 
 `team list`, `team create`, and `team user` use the platform API, so run
@@ -410,14 +417,8 @@ bundled Traefik is present. `team user create` is admin-only. It creates or
 updates a password-login user and adds that user to the team as `member` or
 `owner`; use `auth login --username/--email --password` for the user login.
 
-`team init` uses local `kubectl`. It creates the team namespace, restricted
-workload service account, default quota and limits, default-deny NetworkPolicy,
-same-namespace and bundled-Traefik ingress allowances, MCP Runtime team-admin
-RBAC, bundled Traefik watch RBAC, and patches the repo-managed
-`traefik/traefik` Deployment watch list unless
-`--skip-traefik-watch` is set. Use `--namespace`, `--group`, `--user`, or
-`--service-account` when the defaults do not match your cluster identity system.
-See
+`team init` is **deprecated** and rejects at runtime. Use `team create` for
+the normal platform-backed flow. See
 [Multi-team isolation](multi-team.md).
 
 ## server
@@ -460,6 +461,9 @@ unless the current principal has admin/operator cluster access.
 `server build image` updates matching `.mcp` metadata. It defaults Docker builds to `linux/amd64` so images can run on typical amd64 Kubernetes nodes; override with `--platform` or `MCP_DOCKER_PLATFORM` for another node architecture. It prefers an explicit registry host, then the cluster's `registry/registry` Ingress host, before falling back to the registry Service address. That keeps metadata images on a node-pullable public host such as `registry.example.com/public/payments:v1` when the cluster exposes one. Tenant metadata still uses the authenticated team repository prefix when platform credentials are configured. Push that exact ref after logging in to the platform. The command does not deploy by itself; push and deploy are separate steps. `server deploy --scope public` and `--scope org` let the platform resolve the active catalog namespace; `--scope tenant` uses the authenticated user's team namespace unless `--team` or `--namespace` selects one explicitly. Deploy accepts a short image name and expands it through the platform API to the configured node-pullable registry endpoint plus the active scope prefix. `server deploy --metadata-dir .mcp` includes the matching server inventory, including tool side-effect metadata used by governed tool calls. A repeat deploy with the same server name fails by default; pass `--update` when you intentionally want to redeploy an existing server.
 
 ## sentinel
+
+Admin/operator only — requires kubectl access to the cluster. Normal users
+should use the platform dashboard, `/api/*`, and top-level `mcp-runtime status`.
 
 ```bash
 # Health + recent Kubernetes events
@@ -526,13 +530,12 @@ mcp-runtime registry push --scope tenant --image <exact-image-ref-from-build>
 # Deploy from metadata
 mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
 
-# Scaffold and apply access policy
+# Scaffold and apply access policy (grant via platform API; session via adapter or admin)
 mcp-runtime access grant init payments-ops --server payments --agent-id ops-agent \
   --tool list_invoices --output grant.yaml
-mcp-runtime access session init payments-ops-session --server payments \
-  --agent-id ops-agent --trust high --output session.yaml
 mcp-runtime access grant apply --file grant.yaml
-mcp-runtime access session apply --file session.yaml
+mcp-runtime adapter stdio --runtime-url http://localhost:18080/payments/mcp \
+  --server payments --agent ops-agent --auto-refresh
 mcp-runtime server policy inspect payments
 
 # Open the sentinel UI locally

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,8 +26,13 @@ make build
 ./bin/mcp-runtime auth login --api-url https://platform.example.com --token-stdin < token.txt
 ./bin/mcp-runtime auth status
 
+./bin/mcp-runtime server init payments --tool list_invoices
+./bin/mcp-runtime server build image payments --tag v1
 ./bin/mcp-runtime registry push --image <image-ref-you-built-locally>
-./bin/mcp-runtime server deploy <server-name> --scope tenant --metadata-dir .mcp
+./bin/mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
+
+./bin/mcp-runtime access grant init payments-ops --server payments --agent-id ops-agent --tool list_invoices --output grant.yaml
+./bin/mcp-runtime access grant apply --file grant.yaml
 ```
 
 For a new workstation, run `make deps-install` first where supported, then `STRICT_DEPS_CHECK=1 make deps-check`. Required host tools are Go `1.26+`, Make, Docker with a reachable daemon, `kubectl` configured for the cluster, plus `curl`, `jq`, and `python3` for documented dev flows. `kind` is required only for local Kind clusters.
@@ -46,11 +51,11 @@ mcp-runtime <group> <subcommand> --help
 |---|---|---|
 | `bootstrap` | Preflight checks for cluster prerequisites (DNS, default StorageClass, ingress class, MetalLB). With `--apply` on k3s only, install bundled CoreDNS + local-path manifests. | `bootstrap`, `--apply`, `--provider auto\|k3s\|rke2\|kubeadm\|generic` |
 | `setup` | Install the platform stack, wire registry and ingress, deploy the operator, optionally include sentinel. | `setup`, `--with-tls`, `--without-sentinel` |
-| `auth` | Save and inspect platform API credentials for non-kubeconfig platform flows. | `login`, `logout`, `status` |
+| `auth` | Save and inspect platform API credentials for non-kubeconfig platform flows. | `login`, `logout`, `status`, `use` |
 | `cluster` | Initialize clusters, inspect health, configure kubeconfig and ingress, provision clusters, manage cert-manager. | `init`, `status`, `config`, `provision`, `cert status\|apply\|wait`, `doctor` |
 | `registry` | Inspect the internal registry, configure an external one, push images. | `status`, `info`, `provision`, `push` |
-| `server` | Manage `MCPServer` resources and operator-facing actions. | `list`, `get`, `create`, `apply`, `deploy`, `generate`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
-| `access` | Manage `MCPAccessGrant` and `MCPAgentSession` resources that feed the gateway policy layer. | `grant list/get/apply/delete/disable/enable`, `session list/get/apply/delete/revoke/unrevoke` |
+| `server` | Manage `MCPServer` resources and operator-facing actions. | `init`, `list`, `get`, `create`, `apply`, `deploy`, `generate`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
+| `access` | Manage `MCPAccessGrant` and `MCPAgentSession` resources that feed the gateway policy layer. | `grant init/list/get/apply/delete/disable/enable`, `session init/list/get/apply/delete/revoke/unrevoke` |
 | `adapter` | HTTP proxy and stdio shims that inject governance identity/session headers for agents. | `proxy`, `stdio` |
 | `team` | Manage internal platform teams, team password users, and Kubernetes team namespaces. | `list`, `create`, `user list`, `user create`, `init` |
 | `sentinel` | Inspect and operate the bundled analytics, gateway, and observability stack. | `status`, `events`, `logs`, `port-forward`, `restart` |
@@ -274,6 +279,16 @@ true`. Repeated `--tool` flags seed read/low tool metadata. Use repeated
 trust levels or side-effect classes. If a metadata entry with the same server
 name already exists, `server init` fails unless `--force` is passed.
 
+Typical platform path after `server init`:
+
+```bash
+mcp-runtime auth login --api-url https://platform.example.com
+mcp-runtime server build image payments --tag v1
+mcp-runtime registry push --scope tenant --image <exact-image-ref-from-build>
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp --update   # repeat deploys
+```
+
 ## server generate
 
 ```bash
@@ -285,6 +300,9 @@ mcp-runtime server generate --metadata-file .mcp/payments.yaml --output manifest
 For the full build, push, deploy, and verify flow, see [Publish an MCP Server](publish-mcp-server.md).
 
 ## access
+
+Scaffold manifests with `init`, then apply through the platform API (default)
+or with `--use-kube` for direct Kubernetes admin flows.
 
 ```bash
 # Grants
@@ -333,6 +351,12 @@ mcp-runtime access session unrevoke ops-agent
 ```
 
 `grant list` and `session list` default to `--all-namespaces`; pass `--namespace` to narrow scope.
+
+`access grant init` writes a reviewable YAML file with tool rules and
+`allowedSideEffects`. `--tool` is shorthand for an allow rule at `--trust`
+(default `low`). Use `--tool-rule name:allow|deny:low|medium|high` for mixed
+decisions. `access session init` is for explicit/admin session manifests; adapter
+`--auto-refresh` usually creates sessions automatically at runtime.
 
 For multi-team deployments, namespace scoping controls who can write resources
 and `teamID` controls who can use them. Put each team's grants and sessions in
@@ -469,13 +493,18 @@ mcp-runtime setup
 mcp-runtime auth login --api-url http://localhost:18080
 
 # Push a server image
+mcp-runtime server init payments --tool list_invoices
 mcp-runtime server build image payments
 mcp-runtime registry push --scope tenant --image <exact-image-ref-from-build>
 
 # Deploy from metadata
 mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
 
-# Apply access + inspect resulting policy
+# Scaffold and apply access policy
+mcp-runtime access grant init payments-ops --server payments --agent-id ops-agent \
+  --tool list_invoices --output grant.yaml
+mcp-runtime access session init payments-ops-session --server payments \
+  --agent-id ops-agent --trust high --output session.yaml
 mcp-runtime access grant apply --file grant.yaml
 mcp-runtime access session apply --file session.yaml
 mcp-runtime server policy inspect payments

--- a/docs/contributor/local-kind.md
+++ b/docs/contributor/local-kind.md
@@ -51,7 +51,7 @@ Check the platform:
 ./bin/mcp-runtime status
 ./bin/mcp-runtime cluster status
 ./bin/mcp-runtime registry status
-./bin/mcp-runtime sentinel status
+./bin/mcp-runtime sentinel status   # admin kubectl
 ./bin/mcp-runtime cluster doctor
 ```
 

--- a/docs/contributor/runtime-mcp-testing.md
+++ b/docs/contributor/runtime-mcp-testing.md
@@ -152,10 +152,15 @@ kubectl logs -n "$NAMESPACE" "$POD" -c mcp-gateway
 Gateway policy requires both an access grant and an agent session when the
 server has `spec.session.required=true`.
 
-Use `init` to scaffold manifests, then apply through the platform API:
+Use `init` to scaffold manifests. Apply the grant through the platform API
+after `auth login`. Platform API **session apply requires an admin role** — use
+admin login (`admin@mcpruntime.org` in test mode), `--use-kube`, or `kubectl
+apply` for explicit curl sessions. For agent testing, prefer the adapter path
+documented below.
 
 ```bash
-./bin/mcp-runtime auth login --api-url http://localhost:18080
+./bin/mcp-runtime auth login --api-url http://localhost:18080 \
+  --email admin@mcpruntime.org --password 'admin@123'
 
 ./bin/mcp-runtime access grant init workspace-assistant-grant \
   --namespace mcp-servers \

--- a/docs/contributor/runtime-mcp-testing.md
+++ b/docs/contributor/runtime-mcp-testing.md
@@ -144,9 +144,26 @@ kubectl logs -n "$NAMESPACE" "$POD" -c mcp-gateway
 Gateway policy requires both an access grant and an agent session when the
 server has `spec.session.required=true`.
 
-Use the CLI apply commands:
+Use `init` to scaffold manifests, then apply:
 
 ```bash
+./bin/mcp-runtime access grant init workspace-assistant-grant \
+  --namespace mcp-servers \
+  --server workspace-assistant-mcp \
+  --human-id local-user \
+  --agent-id local-agent \
+  --tool add --tool upper \
+  --trust high \
+  --output /tmp/grant.yaml
+
+./bin/mcp-runtime access session init local-session \
+  --namespace mcp-servers \
+  --server workspace-assistant-mcp \
+  --human-id local-user \
+  --agent-id local-agent \
+  --trust high \
+  --output /tmp/session.yaml
+
 ./bin/mcp-runtime access grant apply --file /tmp/grant.yaml --use-kube
 ./bin/mcp-runtime access session apply --file /tmp/session.yaml --use-kube
 ```

--- a/docs/contributor/runtime-mcp-testing.md
+++ b/docs/contributor/runtime-mcp-testing.md
@@ -126,6 +126,14 @@ NAMESPACE=mcp-servers
 kubectl get mcpserver "$SERVER" -n "$NAMESPACE" -o yaml
 kubectl get deploy/"$SERVER" svc/"$SERVER" ingress/"$SERVER" -n "$NAMESPACE" -o wide
 kubectl get cm -n "$NAMESPACE" "${SERVER}-gateway-policy" -o yaml
+
+./bin/mcp-runtime auth login --api-url http://localhost:18080
+./bin/mcp-runtime server policy inspect "$SERVER" --namespace "$NAMESPACE"
+```
+
+Admin/operator fallback when you need the raw ConfigMap JSON without platform auth:
+
+```bash
 ./bin/mcp-runtime server policy inspect "$SERVER" --namespace "$NAMESPACE" --use-kube
 ```
 
@@ -144,9 +152,11 @@ kubectl logs -n "$NAMESPACE" "$POD" -c mcp-gateway
 Gateway policy requires both an access grant and an agent session when the
 server has `spec.session.required=true`.
 
-Use `init` to scaffold manifests, then apply:
+Use `init` to scaffold manifests, then apply through the platform API:
 
 ```bash
+./bin/mcp-runtime auth login --api-url http://localhost:18080
+
 ./bin/mcp-runtime access grant init workspace-assistant-grant \
   --namespace mcp-servers \
   --server workspace-assistant-mcp \
@@ -164,6 +174,13 @@ Use `init` to scaffold manifests, then apply:
   --trust high \
   --output /tmp/session.yaml
 
+./bin/mcp-runtime access grant apply --file /tmp/grant.yaml
+./bin/mcp-runtime access session apply --file /tmp/session.yaml
+```
+
+Admin/operator direct Kubernetes fallback:
+
+```bash
 ./bin/mcp-runtime access grant apply --file /tmp/grant.yaml --use-kube
 ./bin/mcp-runtime access session apply --file /tmp/session.yaml --use-kube
 ```
@@ -172,6 +189,12 @@ Then verify materialization:
 
 ```bash
 kubectl get mcpaccessgrant,mcpagentsession -n "$NAMESPACE" -o wide
+./bin/mcp-runtime server policy inspect "$SERVER" --namespace "$NAMESPACE"
+```
+
+Raw ConfigMap inspection without platform auth (`--use-kube`):
+
+```bash
 ./bin/mcp-runtime server policy inspect "$SERVER" --namespace "$NAMESPACE" --use-kube
 ```
 

--- a/docs/contributor/service-iteration.md
+++ b/docs/contributor/service-iteration.md
@@ -82,7 +82,8 @@ For analytics pipeline changes:
 | Ingest | `mcp-sentinel-ingest` | `services/ingest/Dockerfile` | `.` | `mcp-sentinel-ingest` | `ingest` |
 | Processor | `mcp-sentinel-processor` | `services/processor/Dockerfile` | `.` | `mcp-sentinel-processor` | `processor` |
 
-After rolling either service, generate one MCP request and check both logs:
+After rolling either service, generate one MCP request and check both logs
+(admin kubectl):
 
 ```bash
 ./bin/mcp-runtime sentinel logs ingest --since 10m

--- a/docs/contributor/troubleshooting.md
+++ b/docs/contributor/troubleshooting.md
@@ -179,3 +179,27 @@ In local Kind, `MCPServer.status.phase` can stay `PartiallyReady` even when the
 Deployment is ready and traffic works, because strict ingress readiness waits
 for load balancer status. Use the Deployment, Service, Ingress, and actual
 traffic checks to decide whether local routing works.
+
+## Grant or Session Does Not Affect Traffic
+
+Use the platform API path first:
+
+```bash
+./bin/mcp-runtime auth login --api-url http://localhost:18080
+./bin/mcp-runtime access grant list --namespace mcp-servers
+./bin/mcp-runtime access session list --namespace mcp-servers
+./bin/mcp-runtime server policy inspect <server-name> --namespace mcp-servers
+```
+
+Allow a few seconds after apply; the gateway sidecar reloads rendered policy on
+a short polling loop. If policy looks correct but calls still fail, check
+gateway logs and request headers (`Mcp-Session-Id`, `X-MCP-Agent-Session`,
+`X-MCP-Human-ID`, `X-MCP-Agent-ID`).
+
+Admin/operator fallback:
+
+```bash
+kubectl get mcpaccessgrant,mcpagentsession -n <namespace> -o wide
+./bin/mcp-runtime server policy inspect <server-name> --namespace <namespace> --use-kube
+kubectl get cm -n <namespace> <server-name>-gateway-policy -o yaml
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -166,7 +166,32 @@ kubectl get ingress -A
 kubectl get ingress -n mcp-sentinel -o yaml
 ```
 
-Apply an access grant and session for the local request:
+Apply an access grant and session for the local request. Prefer `init` to
+scaffold manifests, or apply hand-written YAML:
+
+```bash
+./bin/mcp-runtime access grant init workspace-assistant-local \
+  --namespace mcp-servers \
+  --server workspace-assistant-mcp \
+  --human-id local-user \
+  --agent-id local-agent \
+  --tool add --tool upper \
+  --trust high \
+  --output /tmp/grant.yaml
+
+./bin/mcp-runtime access session init local-session \
+  --namespace mcp-servers \
+  --server workspace-assistant-mcp \
+  --human-id local-user \
+  --agent-id local-agent \
+  --trust high \
+  --output /tmp/session.yaml
+
+./bin/mcp-runtime access grant apply --file /tmp/grant.yaml --use-kube
+./bin/mcp-runtime access session apply --file /tmp/session.yaml --use-kube
+```
+
+Hand-written YAML fallback:
 
 ```bash
 cat > /tmp/workspace-assistant-access.yaml <<'EOF'
@@ -665,6 +690,43 @@ The target `MCPServer` should list the tools you want to govern, and every
 listed tool must include `sideEffect: read`, `write`, or `destructive`. Grants
 then declare which side-effect classes they allow.
 
+Scaffold manifests with `init`, then apply through the platform API:
+
+```bash
+./bin/mcp-runtime auth login --api-url <platform-url>
+
+./bin/mcp-runtime access grant init payments-ops-agent \
+  --namespace mcp-servers \
+  --server payments \
+  --human-id user-123 \
+  --agent-id ops-agent \
+  --tool list_invoices \
+  --tool-rule refund_invoice:allow:high \
+  --side-effect read \
+  --side-effect destructive \
+  --trust high \
+  --output grant.yaml
+
+./bin/mcp-runtime access session init payments-ops-agent-session \
+  --namespace mcp-servers \
+  --server payments \
+  --human-id user-123 \
+  --agent-id ops-agent \
+  --trust high \
+  --output session.yaml
+
+./bin/mcp-runtime access grant apply --file grant.yaml
+./bin/mcp-runtime access session apply --file session.yaml
+./bin/mcp-runtime server policy inspect payments
+```
+
+For adapter-driven traffic, the platform usually issues sessions through
+`POST /api/runtime/adapter/sessions` when you run `mcp-runtime adapter stdio`
+or `adapter proxy` with `--server` and `--agent`. Use `access session init`
+only when you need an explicit/admin session manifest.
+
+Hand-authored YAML reference:
+
 ```yaml
 # grant.yaml
 apiVersion: mcpruntime.org/v1alpha1
@@ -709,7 +771,6 @@ spec:
 ```
 
 ```bash
-./bin/mcp-runtime auth login --api-url <platform-url>
 ./bin/mcp-runtime access grant apply --file grant.yaml
 ./bin/mcp-runtime access session apply --file session.yaml
 ./bin/mcp-runtime server policy inspect payments
@@ -727,12 +788,11 @@ spec:
 
 ```mermaid
 flowchart LR
-    A[Build CLI<br/>make build] --> B[bootstrap<br/>cluster preflight]
-    B --> C[setup<br/>install platform]
-    C --> D[Apply MCPServer]
-    D --> E[Apply Grant + Session]
-    E --> F[Traffic flows<br/>through gateway]
-    F --> G[Observe in UI<br/>+ Grafana]
+    A[Build CLI<br/>make build] --> B[bootstrap + setup]
+    B --> C[server init<br/>build, push, deploy]
+    C --> D[grant init + session init<br/>apply]
+    D --> E[Traffic through gateway<br/>or adapter]
+    E --> F[Observe in UI + Grafana]
 ```
 
 ## Next steps

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,7 @@ Important contributor notes:
 | Symptom | First checks |
 |---------|--------------|
 | Pod is not ready or image pulls fail | `kubectl describe pod`, namespace events, `cluster doctor` |
-| Grant or session does not affect traffic | `kubectl get mcpaccessgrant,mcpagentsession`, `server policy inspect --use-kube`, raw policy ConfigMap |
+| Grant or session does not affect traffic | `access grant list`, `access session list`, `server policy inspect`, or admin-only `kubectl get mcpaccessgrant,mcpagentsession` |
 | Policy renders but tool calls are denied | `kubectl logs ... -c mcp-gateway`, request headers, `Mcp-Session-Id` / `X-MCP-Agent-Session` values |
 | Requests work but analytics are missing | `sentinel logs ingest`, `sentinel logs processor`, analytics secret and ingest URL |
 | Dashboard, API, or MCP route returns 404 | `kubectl get ingress -A`, Sentinel ingress YAML, Traefik logs |
@@ -167,9 +167,11 @@ kubectl get ingress -n mcp-sentinel -o yaml
 ```
 
 Apply an access grant and session for the local request. Prefer `init` to
-scaffold manifests, or apply hand-written YAML:
+scaffold manifests, then apply through the platform API:
 
 ```bash
+./bin/mcp-runtime auth login --api-url http://localhost:18080
+
 ./bin/mcp-runtime access grant init workspace-assistant-local \
   --namespace mcp-servers \
   --server workspace-assistant-mcp \
@@ -187,11 +189,27 @@ scaffold manifests, or apply hand-written YAML:
   --trust high \
   --output /tmp/session.yaml
 
+./bin/mcp-runtime access grant apply --file /tmp/grant.yaml
+./bin/mcp-runtime access session apply --file /tmp/session.yaml
+
+until ./bin/mcp-runtime server policy inspect workspace-assistant-mcp --namespace mcp-servers | grep -q local-session; do
+  sleep 2
+done
+
+# The proxy sidecar reloads rendered policy on a short polling loop, so give the
+# gateway a few seconds to observe the new access session before the first tool call.
+sleep 6
+```
+
+Admin/operator fallback with direct Kubernetes access (`--use-kube` or
+`kubectl apply`):
+
+```bash
 ./bin/mcp-runtime access grant apply --file /tmp/grant.yaml --use-kube
 ./bin/mcp-runtime access session apply --file /tmp/session.yaml --use-kube
 ```
 
-Hand-written YAML fallback:
+Hand-written YAML fallback (admin kubectl apply):
 
 ```bash
 cat > /tmp/workspace-assistant-access.yaml <<'EOF'
@@ -232,13 +250,17 @@ spec:
 EOF
 
 kubectl apply -f /tmp/workspace-assistant-access.yaml
+```
 
-until ./bin/mcp-runtime server policy inspect workspace-assistant-mcp --namespace mcp-servers --use-kube | grep -q local-session; do
+Then wait for policy materialization through the platform API (after
+`auth login`) or inspect the ConfigMap directly with kubectl when debugging
+operator output:
+
+```bash
+./bin/mcp-runtime auth login --api-url http://localhost:18080
+until ./bin/mcp-runtime server policy inspect workspace-assistant-mcp --namespace mcp-servers | grep -q local-session; do
   sleep 2
 done
-
-# The proxy sidecar reloads rendered policy on a short polling loop, so give the
-# gateway a few seconds to observe the new access session before the first tool call.
 sleep 6
 ```
 
@@ -555,7 +577,7 @@ spec:
 
 ```bash
 ./bin/mcp-runtime server apply --file payments.yaml --use-kube
-./bin/mcp-runtime server status --use-kube
+./bin/mcp-runtime server status --use-kube   # full pod detail; platform API status omits pods
 ```
 
 #### How to write the manifest
@@ -678,10 +700,14 @@ Useful checks after publish:
 If the server does not come up, stay in the CLI first:
 
 ```bash
+./bin/mcp-runtime auth login --api-url <platform-url>
 ./bin/mcp-runtime server get payments
-./bin/mcp-runtime server logs payments --follow --use-kube
+./bin/mcp-runtime server status
 ./bin/mcp-runtime sentinel logs gateway --follow
 ./bin/mcp-runtime status
+
+# Admin/operator only — pod logs need --use-kube or kubectl
+./bin/mcp-runtime server logs payments --follow --use-kube
 ```
 
 ## 9. Grant governed access (for gateway-enabled servers)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -797,6 +797,8 @@ spec:
 ```
 
 ```bash
+./bin/mcp-runtime auth login --api-url <platform-url>
+
 ./bin/mcp-runtime access grant apply --file grant.yaml
 ./bin/mcp-runtime access session apply --file session.yaml
 ./bin/mcp-runtime server policy inspect payments
@@ -815,10 +817,11 @@ spec:
 ```mermaid
 flowchart LR
     A[Build CLI<br/>make build] --> B[bootstrap + setup]
-    B --> C[server init<br/>build, push, deploy]
-    C --> D[grant init + session init<br/>apply]
-    D --> E[Traffic through gateway<br/>or adapter]
-    E --> F[Observe in UI + Grafana]
+    B --> C[auth login]
+    C --> D[server init<br/>build, push, deploy]
+    D --> E[grant init + session init<br/>apply]
+    E --> F[Traffic through gateway<br/>or adapter]
+    F --> G[Observe in UI + Grafana]
 ```
 
 ## Next steps

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,10 +138,10 @@ Important contributor notes:
 | Pod is not ready or image pulls fail | `kubectl describe pod`, namespace events, `cluster doctor` |
 | Grant or session does not affect traffic | `access grant list`, `access session list`, `server policy inspect`, or admin-only `kubectl get mcpaccessgrant,mcpagentsession` |
 | Policy renders but tool calls are denied | `kubectl logs ... -c mcp-gateway`, request headers, `Mcp-Session-Id` / `X-MCP-Agent-Session` values |
-| Requests work but analytics are missing | `sentinel logs ingest`, `sentinel logs processor`, analytics secret and ingest URL |
+| Requests work but analytics are missing | `sentinel logs ingest`, `sentinel logs processor` (admin kubectl), analytics secret and ingest URL |
 | Dashboard, API, or MCP route returns 404 | `kubectl get ingress -A`, Sentinel ingress YAML, Traefik logs |
 
-Useful local platform checks:
+Useful local platform checks (admin kubectl for `sentinel *`):
 
 ```bash
 ./bin/mcp-runtime cluster doctor
@@ -166,11 +166,19 @@ kubectl get ingress -A
 kubectl get ingress -n mcp-sentinel -o yaml
 ```
 
-Apply an access grant and session for the local request. Prefer `init` to
-scaffold manifests, then apply through the platform API:
+Apply an access grant and session for the local curl request. Prefer `init` to
+scaffold manifests. **Grant apply** uses the platform API for server/team
+owners after `auth login`. **Session apply through the platform API requires an
+admin role** — for explicit curl headers in test mode, log in as the seeded
+admin (`admin@mcpruntime.org` / `admin@123`) or use the admin/operator
+fallbacks below. For agent traffic, prefer `adapter stdio` / `adapter proxy`
+with `--server` and `--agent` so the platform issues the session automatically.
+
+Platform path (admin login required for session apply):
 
 ```bash
-./bin/mcp-runtime auth login --api-url http://localhost:18080
+./bin/mcp-runtime auth login --api-url http://localhost:18080 \
+  --email admin@mcpruntime.org --password 'admin@123'
 
 ./bin/mcp-runtime access grant init workspace-assistant-local \
   --namespace mcp-servers \
@@ -512,12 +520,11 @@ For a non-Google OIDC provider, set `OIDC_ISSUER`, `OIDC_AUDIENCE`, and
 `mcp-sentinel/mcp-sentinel-config`.
 
 For multi-team or tenant-separated deployments, keep setup as the platform
-install and provision one namespace per team with `mcp-runtime team init <slug>`
-or the platform API `mcp-runtime team create <slug>` flow. Both repo-managed
-paths wire bundled Traefik for the team namespace. Use the platform API to
-default team IDs, or set `spec.teamID` and `subject.teamID` directly in YAML; an
-explicit foreign `subject.teamID` delegates access to another team while the
-gateway still matches every non-empty subject field. See
+install and provision one namespace per team with `mcp-runtime team create
+<slug>` (platform API). Use the platform API to default team IDs, or set
+`spec.teamID` and `subject.teamID` directly in YAML; an explicit foreign
+`subject.teamID` delegates access to another team while the gateway still
+matches every non-empty subject field. See
 [Multi-team isolation](multi-team.md).
 
 Common variants:
@@ -664,12 +671,14 @@ The server lands at `/{server-name}/mcp` on the configured ingress host, behind 
 
 #### Publish to the platform: what to do, and what happens next
 
-There are two ways to get a server into the platform:
+There are two supported ways to publish a governed server:
 
-1. Build and push an image, then apply an `MCPServer` manifest directly.
-2. Build and push an image, then generate and deploy `MCPServer` manifests from `.mcp` metadata.
+1. **Platform path (normal):** `auth login` → build → `registry push` →
+   `server deploy --metadata-dir .mcp` (or `server deploy` with image flags).
+2. **Admin/GitOps path:** build → push → `server apply --use-kube` or
+   `server generate` + GitOps apply with admin kubectl access.
 
-The end-to-end flow is the same either way:
+The end-to-end platform flow is:
 
 1. Build the image for your server.
 2. Push that image to the platform registry or another registry the cluster can pull from.
@@ -716,7 +725,11 @@ The target `MCPServer` should list the tools you want to govern, and every
 listed tool must include `sideEffect: read`, `write`, or `destructive`. Grants
 then declare which side-effect classes they allow.
 
-Scaffold manifests with `init`, then apply through the platform API:
+Scaffold manifests with `init`, then apply the grant through the platform API.
+For agents, issue sessions through `adapter stdio` / `adapter proxy` with
+`--server` and `--agent` (recommended). Direct `access session apply` through
+the platform API is **admin-only**; use an admin login, `--use-kube`, or
+`kubectl apply` when you need an explicit session manifest for curl testing.
 
 ```bash
 ./bin/mcp-runtime auth login --api-url <platform-url>
@@ -742,16 +755,24 @@ Scaffold manifests with `init`, then apply through the platform API:
   --output session.yaml
 
 ./bin/mcp-runtime access grant apply --file grant.yaml
+
+# Admin-only on platform API — or use adapter --auto-refresh instead:
 ./bin/mcp-runtime access session apply --file session.yaml
 ./bin/mcp-runtime server policy inspect payments
 ```
 
-For adapter-driven traffic, the platform usually issues sessions through
-`POST /api/runtime/adapter/sessions` when you run `mcp-runtime adapter stdio`
-or `adapter proxy` with `--server` and `--agent`. Use `access session init`
-only when you need an explicit/admin session manifest.
+For adapter-driven traffic, skip manual session apply and run:
 
-Hand-authored YAML reference:
+```bash
+./bin/mcp-runtime adapter stdio \
+  --runtime-url https://mcp.example.com/payments/mcp \
+  --server payments \
+  --agent ops-agent \
+  --auto-refresh
+```
+
+Hand-authored YAML reference (apply grant via platform API; session via admin
+login, `--use-kube`, or `kubectl apply`):
 
 ```yaml
 # grant.yaml
@@ -798,13 +819,22 @@ spec:
 
 ```bash
 ./bin/mcp-runtime auth login --api-url <platform-url>
-
 ./bin/mcp-runtime access grant apply --file grant.yaml
-./bin/mcp-runtime access session apply --file session.yaml
+# session: admin login, adapter, --use-kube, or kubectl apply — see above
 ./bin/mcp-runtime server policy inspect payments
 ```
 
 ## 10. Observe live traffic and policy
+
+Use the platform dashboard and API first:
+
+```bash
+./bin/mcp-runtime auth login --api-url <platform-url>
+./bin/mcp-runtime status
+# Dashboard: http://localhost:18080/ (Kind) or https://platform.<domain>/
+```
+
+Admin/operator kubectl diagnostics (`sentinel *` requires admin cluster access):
 
 ```bash
 ./bin/mcp-runtime sentinel port-forward ui          # Governance + dashboard
@@ -819,9 +849,10 @@ flowchart LR
     A[Build CLI<br/>make build] --> B[bootstrap + setup]
     B --> C[auth login]
     C --> D[server init<br/>build, push, deploy]
-    D --> E[grant init + session init<br/>apply]
-    E --> F[Traffic through gateway<br/>or adapter]
-    F --> G[Observe in UI + Grafana]
+    D --> E[grant init + apply]
+    E --> F[adapter or admin session]
+    F --> G[Traffic through gateway]
+    G --> H[Observe in UI + Grafana]
 ```
 
 ## Next steps

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -68,8 +68,8 @@ sequenceDiagram
     participant R as Registry
     participant W as Workloads
 
-    U->>CLI: setup / server apply / server deploy
-    CLI->>K: apply CRDs, manifests, MCPServer
+    U->>CLI: setup / server deploy (platform API) or server apply --use-kube
+    CLI->>K: apply CRDs, manifests, MCPServer (platform API or --use-kube)
     CLI->>R: build or push images when requested
     K-->>O: watch MCPServer changes
     O->>K: create or update Deployment, Service, Ingress

--- a/docs/internals/cmd-mcp-runtime.md
+++ b/docs/internals/cmd-mcp-runtime.md
@@ -41,6 +41,7 @@ The root command wires these internal command groups:
 | `auth` | `internal/cli/auth` | `auth.go` |
 | `sentinel` | `internal/cli/sentinel` | `sentinel.go`, `manager.go`, shared workload/probe helpers in `internal/cli/platformstatus` |
 | `team` | `internal/cli/team` | `team.go`, `manager.go` |
+| `admin` | `internal/cli/admin` | `admin.go` (hidden; operator-only kubectl helpers such as `admin registry push`) |
 
 When adding a command, wire it here only after the implementation has focused
 package tests and help text is ready for golden snapshots.

--- a/docs/internals/internal-cli.md
+++ b/docs/internals/internal-cli.md
@@ -190,10 +190,8 @@ Tests: `adapter/adapter_test.go`, `adapter/platformsession_test.go`, and
 ## Team
 
 `internal/cli/team/` owns platform team commands. `team list`, `team create`,
-and `team user` call the platform API through `internal/cli/platformapi`;
-`team init` renders local Kubernetes namespace, RBAC, quota, limits,
-NetworkPolicy, workload service account, and bundled Traefik watch manifests
-before applying them with `kubectl`.
+and `team user` call the platform API through `internal/cli/platformapi`.
+`team init` is deprecated and rejects at runtime; use `team create`.
 
 Team behavior spans CLI and API code: platform-backed team creation and
 membership routes live in `services/api/internal/runtimeapi`, durable identity

--- a/docs/internals/internal-cli.md
+++ b/docs/internals/internal-cli.md
@@ -137,7 +137,7 @@ in `internal/cli/server/validation.go`.
 Keep these flows distinct:
 
 - `server init` scaffolds `.mcp/servers.yaml` with governed defaults.
-- `server apply` applies a manifest.
+- `server apply --use-kube` applies a manifest through kubectl (admin only).
 - `server build image` builds and updates metadata but does not deploy.
 - `server generate` renders manifests from metadata for review/GitOps.
 - `server deploy --metadata-dir .mcp` deploys metadata-backed servers through the platform API.
@@ -162,7 +162,8 @@ Tests: `server`/`metadata` package tests and golden CLI help snapshots.
 - `access session init|list|get|apply|delete|revoke|unrevoke`
 
 `init` scaffolds reviewable YAML; `apply` writes through the platform API by
-default or with `--use-kube` for direct Kubernetes admin flows.
+default. Add `--use-kube` only for admin/operator direct Kubernetes flows
+that bypass platform auth.
 
 The implementation patches `spec.disabled` for grants and `spec.revoked` for
 sessions. Input validation should prevent invalid names/namespaces before they

--- a/docs/internals/internal-cli.md
+++ b/docs/internals/internal-cli.md
@@ -136,6 +136,7 @@ in `internal/cli/server/validation.go`.
 
 Keep these flows distinct:
 
+- `server init` scaffolds `.mcp/servers.yaml` with governed defaults.
 - `server apply` applies a manifest.
 - `server build image` builds and updates metadata but does not deploy.
 - `server generate` renders manifests from metadata for review/GitOps.
@@ -157,8 +158,11 @@ Tests: `server`/`metadata` package tests and golden CLI help snapshots.
 
 `internal/cli/access/` provides commands for grants and sessions:
 
-- `access grant list|get|apply|delete|enable|disable`
-- `access session list|get|apply|delete|revoke|unrevoke`
+- `access grant init|list|get|apply|delete|enable|disable`
+- `access session init|list|get|apply|delete|revoke|unrevoke`
+
+`init` scaffolds reviewable YAML; `apply` writes through the platform API by
+default or with `--use-kube` for direct Kubernetes admin flows.
 
 The implementation patches `spec.disabled` for grants and `spec.revoked` for
 sessions. Input validation should prevent invalid names/namespaces before they

--- a/docs/internals/request-flows.md
+++ b/docs/internals/request-flows.md
@@ -339,12 +339,13 @@ Primary request paths:
 | Adapter proxy | `mcp-runtime adapter proxy` | local adapter, API, K8s session, operator, gateway | adapter session response, governance headers | `adapter-proxy` |
 | Adapter stdio | `mcp-runtime adapter stdio` | stdio shim, API, gateway, MCP server | stdin/stdout JSON-RPC, session state | `adapter-proxy`, unit tests |
 | Create/update grants | UI/CLI/API `/api/runtime/grants` | API, K8s, operator, gateway | grant validation, subject/team binding | `governance`, `api-platform` |
-| Create/update sessions | UI/CLI/API `/api/runtime/sessions` | API, K8s, operator, gateway | session trust, expiry, revoked state | `governance`, `api-platform` |
+| Create/update sessions (admin) | UI/CLI/API `POST /api/runtime/sessions` | API, K8s, operator, gateway | admin role required for direct session apply | `governance`, `api-platform` |
+| Adapter-issued sessions | `adapter stdio|proxy`, `POST /api/runtime/adapter/sessions` | adapter, API, K8s, gateway | matching grant, principal identity | `adapter-proxy`, `governance` |
 | Revoke/disable access | item action paths | API, K8s, operator, gateway | enable/disable/revoke/unrevoke | `governance`, `api-platform` |
 | Push or pull registry image | Docker `/v2/*` | registry ingress, Traefik forwardAuth, API, registry | scope authz, registry credentials | `api-platform`, `all` |
 | Create registry credential | `/api/user/registry-credentials` | API, Postgres, registry authz | one-time credential, revoke flow | `api-platform` |
 | Create user API key | `/api/user/api-keys` | API, Postgres, auth middleware | one-time key, revoke flow | `api-platform` |
-| Create team namespace | `/api/runtime/teams` or `team init` | API/CLI, Postgres, K8s namespace/RBAC, Traefik watch | team slug, namespace, membership, RBAC | `multitenancy`, `api-platform` |
+| Create team namespace | `/api/runtime/teams` or `team create` | API/CLI, Postgres, K8s namespace/RBAC, Traefik watch | team slug, namespace, membership, RBAC | `multitenancy`, `api-platform` |
 | Manage team members/users | `/api/runtime/teams/{slug}/*` | API, Postgres, namespace authorization | membership and user records | `multitenancy`, `api-platform` |
 | Query analytics | `/api/events*`, `/api/analytics/usage` | API, ClickHouse, gateway/ingest history | event envelope, filters, usage rows | `observability`, `api-platform` |
 | Direct ingest event | `POST /events` | ingest, auth, Kafka, processor, ClickHouse | event envelope and API key auth | `observability` |

--- a/docs/k3s-deployment-runbook.md
+++ b/docs/k3s-deployment-runbook.md
@@ -359,6 +359,8 @@ MCP_PLATFORM_API_URL=https://platform.mcpruntime.org \
   --profile myteam-user
 
 cd examples/workspace-assistant-mcp
+# .mcp/servers.yaml already exists in the example; for a new server run:
+# ../../bin/mcp-runtime server init <name> --tool <tool> --metadata-dir .mcp
 
 MCP_PLATFORM_API_URL=https://platform.mcpruntime.org MCP_PLATFORM_API_PROFILE=myteam-user \
   ../../bin/mcp-runtime server build image workspace-assistant-mcp \

--- a/docs/multi-team.md
+++ b/docs/multi-team.md
@@ -263,11 +263,13 @@ Keep identifiers stable:
 | `agentID` | Use a readable owner-purpose string such as `acme-cron-bot`, `globex-data-loader`, or `claude-code`. |
 
 `mcp-runtime access grant init`, `access grant apply`, `access session init`,
-and `access session apply` run a
-non-blocking advisory pass before applying manifests. The command warns about
-obvious `humanID` shape problems, such as whitespace, malformed email-like
-strings, case-sensitive uppercase email identifiers, or values that appear to
-encode `mcp-team-*` namespace names. These warnings never block the apply.
+and `access session apply` use the platform API by default after
+`mcp-runtime auth login --api-url <platform-url>`. Add `--use-kube` only for
+admin/operator direct Kubernetes writes. These commands run a non-blocking
+advisory pass before applying manifests. The command warns about obvious
+`humanID` shape problems, such as whitespace, malformed email-like strings,
+case-sensitive uppercase email identifiers, or values that appear to encode
+`mcp-team-*` namespace names. These warnings never block the apply.
 
 ## Audit And Reporting
 

--- a/docs/multi-team.md
+++ b/docs/multi-team.md
@@ -70,28 +70,9 @@ mcp-runtime auth login \
   --password '...'
 ```
 
-For direct Kubernetes administration, use `team init`:
-
-```bash
-mcp-runtime team init acme --group acme-mcp-admins
-```
-
-`team init` applies the namespace, a restricted `mcp-workload` service account,
-a default quota, default container limits, a default-deny NetworkPolicy that
-allows same-namespace ingress, bundled Traefik ingress, DNS, and basic outbound
-HTTP/S egress, a team-admin `Role`, a `RoleBinding`, and the `traefik-watch`
-`Role`/`RoleBinding` for the bundled Traefik service account. The
-`traefik-watch` role grants watch access to Services, Endpoints, Secrets, and
-Ingresses in the team namespace. Platform-created team namespaces use a
-RoleBinding to the repo-installed `mcp-runtime-traefik-watch` `ClusterRole`
-instead, so the API service account can bind the exact Traefik watch role
-without broad Secret read access. Both paths patch the bundled
-`traefik/traefik` Deployment so
-`--providers.kubernetesingress.namespaces` includes the new team namespace. Use
-`--dry-run` to print the generated manifest, and use `--skip-traefik-watch`
-when your ingress controller is external or managed outside this repo.
-
-The generated namespace/RBAC shape is:
+`team init` is **deprecated** and rejects at runtime. Use `team create` above
+for the normal platform-backed flow. The managed namespace shape that
+`team create` provisions includes:
 
 ```yaml
 apiVersion: v1
@@ -236,8 +217,9 @@ The bundled Traefik manifests watch only `registry`, `mcp-sentinel`,
 does not need broad namespace access. If MCP servers live in team namespaces,
 update the ingress controller watch list, bind the Traefik watch role in each
 team namespace, and allow ingress-controller traffic through the namespace
-NetworkPolicy. `mcp-runtime team init` and the platform API `team create` flow
-perform those changes for the repo-managed `traefik/traefik` Deployment.
+NetworkPolicy. The platform API `team create` flow performs those changes for
+the repo-managed `traefik/traefik` Deployment when
+`PLATFORM_TEAM_TRAEFIK_WATCH` is not `disabled`.
 
 For the bundled Traefik overlay, extend the argument:
 

--- a/docs/multi-team.md
+++ b/docs/multi-team.md
@@ -244,11 +244,13 @@ Keep identifiers stable:
 | `humanID` | Use the identity provider's stable subject claim, or email when that is stable in your environment. |
 | `agentID` | Use a readable owner-purpose string such as `acme-cron-bot`, `globex-data-loader`, or `claude-code`. |
 
-`mcp-runtime access grant init`, `access grant apply`, `access session init`,
-and `access session apply` use the platform API by default after
-`mcp-runtime auth login --api-url <platform-url>`. Add `--use-kube` only for
-admin/operator direct Kubernetes writes. These commands run a non-blocking
-advisory pass before applying manifests. The command warns about obvious
+`mcp-runtime access grant init` and `access session init` scaffold local YAML on
+the workstation only. `access grant apply` uses the platform API by default after
+`mcp-runtime auth login --api-url <platform-url>`; `access session apply` is
+admin-only on the platform API (agents should use `adapter stdio|proxy --server …
+--agent … --auto-refresh` instead). Add `--use-kube` only for admin/operator
+direct Kubernetes writes. The apply commands run a non-blocking advisory pass
+before applying manifests. The command warns about obvious
 `humanID` shape problems, such as whitespace, malformed email-like strings,
 case-sensitive uppercase email identifiers, or values that appear to encode
 `mcp-team-*` namespace names. These warnings never block the apply.

--- a/docs/multi-team.md
+++ b/docs/multi-team.md
@@ -262,7 +262,8 @@ Keep identifiers stable:
 | `humanID` | Use the identity provider's stable subject claim, or email when that is stable in your environment. |
 | `agentID` | Use a readable owner-purpose string such as `acme-cron-bot`, `globex-data-loader`, or `claude-code`. |
 
-`mcp-runtime access grant apply` and `mcp-runtime access session apply` run a
+`mcp-runtime access grant init`, `access grant apply`, `access session init`,
+and `access session apply` run a
 non-blocking advisory pass before applying manifests. The command warns about
 obvious `humanID` shape problems, such as whitespace, malformed email-like
 strings, case-sensitive uppercase email identifiers, or values that appear to

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -88,14 +88,14 @@ tool calls.
 - Add `spec.tools` with tool descriptions, trust levels, and side-effect classes so the platform catalog and policy engine mirror the tool summaries clients see from `tools/list`.
 - Add `spec.auth`, `spec.policy`, `spec.session`, or `spec.rollout` when you want stricter governance or more delivery control.
 
-Apply the manifest only from an admin/operator workstation. `server apply` uses
-direct Kubernetes mode, so it requires `--use-kube`, kubectl, and kubeconfig/RBAC
-access to the target namespace. For normal platform workflows, use the
-platform-backed `server deploy` flow in Option B instead.
+Apply the manifest only from an admin/operator workstation. `server apply`
+requires `--use-kube`, kubectl, and kubeconfig/RBAC access to the target
+namespace. For normal platform workflows, use the platform-backed
+`server deploy` flow in Option B instead.
 
 ```bash
 ./bin/mcp-runtime server apply --file payments.yaml --use-kube
-./bin/mcp-runtime server status --use-kube
+./bin/mcp-runtime server status --use-kube   # pod detail; omit --use-kube for platform API summary
 ```
 
 ## Option B: initialize or write `.mcp` metadata
@@ -127,6 +127,8 @@ session manifests, `access session init` supports `--trust`,
 `--expires-in`, `--expires-at`, `--revoked`, and upstream-token secret flags.
 
 ```bash
+mcp-runtime auth login --api-url https://platform.example.com
+
 ./bin/mcp-runtime access grant init payments-globex-cursor \
   --namespace mcp-team-acme \
   --server payments \
@@ -376,8 +378,10 @@ If the server uses governed access:
 If traffic is failing:
 
 ```bash
-./bin/mcp-runtime server logs payments --follow --use-kube
 ./bin/mcp-runtime sentinel logs gateway --follow
+
+# Admin/operator only — MCP server pod logs require --use-kube
+./bin/mcp-runtime server logs payments --follow --use-kube
 ```
 
 ## Common failure points

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -428,11 +428,12 @@ Request analytics only exist for traffic that flows through `mcp-gateway`.
 The adapter is not required for analytics; it only helps clients that cannot
 attach identity or session headers directly, or that want platform-issued
 sessions. Hand-written YAML must include `spec.gateway.enabled: true` for
-request analytics. If you apply raw YAML with `kubectl` instead of
-raw `kubectl apply`, also create a namespace-local ingest-key Secret
-and set `spec.analytics.apiKeySecretRef`; otherwise the gateway can reach
-ingest but events will be rejected with 401. Analytics is on by default for
-gateway traffic when the operator has `MCP_SENTINEL_INGEST_URL`; opt out with:
+request analytics. If you apply raw YAML with `kubectl apply` or
+`server apply --use-kube` instead of `server deploy`, also create a
+namespace-local ingest-key Secret and set `spec.analytics.apiKeySecretRef`;
+otherwise the gateway can reach ingest but events will be rejected with 401.
+Analytics is on by default for gateway traffic when the operator has
+`MCP_SENTINEL_INGEST_URL`; opt out with:
 
 ```yaml
 analytics:

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -149,10 +149,11 @@ mcp-runtime auth login --api-url https://platform.example.com
   --output session.yaml
 
 ./bin/mcp-runtime access grant apply --file grant.yaml
-./bin/mcp-runtime access session apply --file session.yaml
+# Platform API session apply is admin-only — use adapter for agents:
+# ./bin/mcp-runtime access session apply --file session.yaml
 ```
 
-Adapter-driven agents usually skip manual session apply; use
+Adapter-driven agents should skip manual session apply; use
 `mcp-runtime adapter stdio --server payments --agent cursor --auto-refresh`
 after the grant exists. See [Agent Adapters](agent-adapters.md).
 
@@ -321,10 +322,11 @@ exactly one server, it uses that server's inventory even when the deployed
 runtime name is different; this keeps `spec.tools` side-effect metadata in sync
 with governance policy.
 
-### Flow C — manual Docker build, push, and manifest apply
+### Flow C — manual Docker build, push, and manifest apply (admin/GitOps)
 
-Use this when you need full control of `MCPServer` fields and you have
-admin/operator Kubernetes access:
+Use this when you need full control of `MCPServer` fields and have
+admin/operator Kubernetes access. For the normal tenant platform path, use
+**Flow A/B** with `server deploy` instead of `server apply --use-kube`.
 
 ```bash
 docker build -t payments:v1.0.0 .
@@ -378,9 +380,11 @@ If the server uses governed access:
 If traffic is failing:
 
 ```bash
-./bin/mcp-runtime sentinel logs gateway --follow
+./bin/mcp-runtime server policy inspect payments
+./bin/mcp-runtime status
 
-# Admin/operator only — MCP server pod logs require --use-kube
+# Admin/operator only
+./bin/mcp-runtime sentinel logs gateway --follow
 ./bin/mcp-runtime server logs payments --follow --use-kube
 ```
 

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -126,7 +126,35 @@ when a grant needs mixed per-tool decisions or trust levels. For explicit
 session manifests, `access session init` supports `--trust`,
 `--expires-in`, `--expires-at`, `--revoked`, and upstream-token secret flags.
 
-Example:
+```bash
+./bin/mcp-runtime access grant init payments-globex-cursor \
+  --namespace mcp-team-acme \
+  --server payments \
+  --team-id <globex-team-id> \
+  --agent-id cursor \
+  --tool list_invoices \
+  --tool-rule refund_invoice:allow:high \
+  --side-effect read \
+  --output grant.yaml
+
+./bin/mcp-runtime access session init cursor-session \
+  --namespace mcp-team-acme \
+  --server payments \
+  --human-id <user-id> \
+  --agent-id cursor \
+  --trust medium \
+  --expires-in 1h \
+  --output session.yaml
+
+./bin/mcp-runtime access grant apply --file grant.yaml
+./bin/mcp-runtime access session apply --file session.yaml
+```
+
+Adapter-driven agents usually skip manual session apply; use
+`mcp-runtime adapter stdio --server payments --agent cursor --auto-refresh`
+after the grant exists. See [Agent Adapters](agent-adapters.md).
+
+Example metadata:
 
 ```yaml
 version: v1

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -117,8 +117,8 @@ flowchart LR
 | Initialize cluster | `cluster init`, `setup`, `bootstrap` |
 | Configure ingress + registry | `cluster config --ingress traefik`, `registry provision` |
 | Describe servers | `server init`, hand-written `MCPServer` YAML, or metadata in `.mcp/` |
-| Publish + deploy | `server build image`, `registry push`, `server deploy`, `server generate` for GitOps YAML |
-| Grant access | `access grant init`, `access grant apply`, `access session init`, `access session apply` |
+| Publish + deploy | `auth login`, `server build image`, `registry push`, `server deploy`, `server generate` for GitOps YAML |
+| Grant access | `auth login`, `access grant init`, `access grant apply`, `access session init`, `access session apply` |
 | Observe | `status`, `sentinel status`, `sentinel port-forward ui` |
 
 ## Traffic and enforcement model

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -107,8 +107,8 @@ flowchart TB
 flowchart LR
     A[01. Initialize cluster<br/>cluster init / setup] --> B[02. Configure ingress + registry]
     B --> C[03. Describe servers<br/>MCPServer YAML]
-    C --> D[04. Publish + deploy images<br/>registry push, server deploy]
-    D --> E[05. Grant access<br/>access grant / session apply]
+    C --> D[04. Scaffold + publish<br/>server init, build, push, deploy]
+    D --> E[05. Grant access<br/>grant init / session init, apply]
     E --> F[06. Observe<br/>status, sentinel, UI]
 ```
 
@@ -116,9 +116,9 @@ flowchart LR
 |---|---|
 | Initialize cluster | `cluster init`, `setup`, `bootstrap` |
 | Configure ingress + registry | `cluster config --ingress traefik`, `registry provision` |
-| Describe servers | hand-written `MCPServer` YAML or metadata in `.mcp/` |
+| Describe servers | `server init`, hand-written `MCPServer` YAML, or metadata in `.mcp/` |
 | Publish + deploy | `server build image`, `registry push`, `server deploy`, `server generate` for GitOps YAML |
-| Grant access | `access grant apply`, `access session apply` |
+| Grant access | `access grant init`, `access grant apply`, `access session init`, `access session apply` |
 | Observe | `status`, `sentinel status`, `sentinel port-forward ui` |
 
 ## Traffic and enforcement model

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -108,8 +108,8 @@ flowchart LR
     A[01. Initialize cluster<br/>cluster init / setup] --> B[02. Configure ingress + registry]
     B --> C[03. Describe servers<br/>MCPServer YAML]
     C --> D[04. Scaffold + publish<br/>server init, build, push, deploy]
-    D --> E[05. Grant access<br/>grant init / session init, apply]
-    E --> F[06. Observe<br/>status, sentinel, UI]
+    D --> E[05. Grant access<br/>grant init/apply; adapter sessions]
+    E --> F[06. Observe<br/>status, UI, API]
 ```
 
 | Step | Commands |
@@ -118,8 +118,8 @@ flowchart LR
 | Configure ingress + registry | `cluster config --ingress traefik`, `registry provision` |
 | Describe servers | `server init`, hand-written `MCPServer` YAML, or metadata in `.mcp/` |
 | Publish + deploy | `auth login`, `server build image`, `registry push`, `server deploy`, `server generate` for GitOps YAML |
-| Grant access | `auth login`, `access grant init`, `access grant apply`, `access session init`, `access session apply` |
-| Observe | `status`, `sentinel status`, `sentinel port-forward ui` |
+| Grant access | `auth login`, `access grant init`, `access grant apply`; sessions via `adapter stdio|proxy --server … --agent …` or admin `access session init/apply` |
+| Observe | `status`, platform UI/API; admin: `sentinel status`, `sentinel port-forward ui` |
 
 ## Traffic and enforcement model
 

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -281,7 +281,9 @@ list_invoices:allow
 refund_invoice:allow:high
 ```
 
-CLI parity: `mcp-runtime access grant` and `mcp-runtime access session` cover the same CRUD flows. CRs are the source of truth — the UI is a convenience layer.
+CLI parity: `mcp-runtime access grant init|apply` and
+`mcp-runtime access session init|apply` cover the same CRUD flows as the UI.
+CRs are the source of truth — the UI is a convenience layer.
 
 For platform API writes, grants and sessions must reference a server in the same
 namespace as the access resource. Non-admin callers cannot write access

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -281,9 +281,11 @@ list_invoices:allow
 refund_invoice:allow:high
 ```
 
-CLI parity: `mcp-runtime access grant init|apply` and
-`mcp-runtime access session init|apply` cover the same CRUD flows as the UI.
-CRs are the source of truth — the UI is a convenience layer.
+CLI parity: `mcp-runtime access grant init|apply` covers grant CRUD for
+authorized principals. `access session init|apply` matches the UI for
+**admin** session writes; agents and normal users should use
+`POST /api/runtime/adapter/sessions` via `adapter stdio|proxy --server …
+--agent …`. CRs are the source of truth — the UI is a convenience layer.
 
 For platform API writes, grants and sessions must reference a server in the same
 namespace as the access resource. Non-admin callers cannot write access
@@ -360,6 +362,9 @@ source subject preserved, never on the other server.
 `mcp-runtime setup` builds the sentinel images and deploys this stack by default. Use `--without-sentinel` to skip.
 
 ## Operating the stack
+
+These commands require **admin/operator kubectl** access. Normal users should
+use the platform dashboard and `/api/*` instead.
 
 ```bash
 # Health + Kubernetes events

--- a/docs/sentinel.md
+++ b/docs/sentinel.md
@@ -321,7 +321,8 @@ spec:
 # bob-server-b mirrors the above with serverRef server-b-mcp and a different toolRule
 ```
 
-Confirm each server's policy contains only its own subject:
+Confirm each server's policy contains only its own subject (after
+`mcp-runtime auth login --api-url <platform-url>`):
 
 ```bash
 mcp-runtime server policy inspect server-a-mcp --namespace mcp-servers   # alice only


### PR DESCRIPTION
## Summary
- Document `server init`, `access grant init`, and `access session init` across CLI reference, getting-started, publish, runtime, contributor, and related guides
- Update examples and flow diagrams to use init → review → apply instead of hand-written YAML only
- Add a k3s runbook note for new servers starting from `server init`

## Test plan
- [x] Verified flag names and defaults against live `./bin/mcp-runtime … init --help`
- [ ] MkDocs site build (optional)


Made with [Cursor](https://cursor.com)