### PR TITLE
fix(cli): refine init and auth defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,13 @@ Do not hand-wave command behavior from memory when the docs are meant to reflect
 - **Docs you were not asked to edit:** Avoid adding new top-level docs unless the task needs them; this file, `README`, and existing doc trees are the defaults for agents.
 - **Secrets and prod:** This repo is **alpha**; do not hardcode real credentials. Use the existing secret and env patterns documented below.
 - **Agent skills:** Keep `.claude/skills` as a symlink to `../.codex/skills`; see `.claude/README.md` before changing local agent-tool configuration.
-- **Skill upkeep:** After finishing a non-trivial feature, bugfix, operational workflow, or docs change, review the relevant `.codex/skills/*/SKILL.md` files. Update or fix skills when the change affects agent workflows, validation commands, runbooks, or recurring gotchas; keep long operational detail in focused skills or docs instead of duplicating it here.
+- **Skill upkeep:** Before closing a non-trivial feature, bugfix, CI failure,
+  operational workflow, or docs change, review the relevant
+  `.codex/skills/*/SKILL.md` files that future agents would use for the same
+  area. Update or fix those skills when the change affects agent workflows,
+  validation commands, runbooks, E2E assumptions, or recurring gotchas; keep
+  long operational detail in focused skills or docs instead of duplicating it
+  here.
 - **AI session hygiene:** Before ending a non-trivial session, propose updates to `ai-assist/` (durable agent-facing learnings, gotchas, cross-cutting tips, upstream tracking) and ask the user to review the diff manually before commit. See **AI session hygiene** below for the full charter.
 
 ## AI session hygiene

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -218,15 +218,18 @@ Notes:
 - saved credentials are local to the workstation
 - each login is saved as a named profile; `auth login` makes that profile current
 - `MCP_PLATFORM_API_PROFILE` selects a saved profile without changing the current profile
-- `MCP_PLATFORM_API_TOKEN` overrides any saved token when set
-- `MCP_PLATFORM_API_URL` can provide the default API base URL
+- `MCP_PLATFORM_API_TOKEN` overrides any saved token when set; if
+  `MCP_PLATFORM_API_URL` is unset, the CLI reuses the API URL from the selected
+  saved profile
+- `MCP_PLATFORM_API_URL` overrides the saved API base URL when set
 - kubeconfig-based cluster commands are separate from platform auth
 
 ## Platform API vs `--use-kube`
 
 Most `server` and `access` commands use the **platform API** by default. Run
-`mcp-runtime auth login --api-url <platform-url>` (or set
-`MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`) before those flows.
+`mcp-runtime auth login --api-url <platform-url>` before those flows. You can
+also set `MCP_PLATFORM_API_TOKEN`; set `MCP_PLATFORM_API_URL` too only when you
+want to override the saved profile's API URL.
 
 `--use-kube` is **admin/dev/test only**. It bypasses platform auth and talks to
 the Kubernetes API through your kubeconfig. Use it only when you have
@@ -279,7 +282,8 @@ mcp-runtime registry push --scope tenant --image payments:v1
 ```
 
 `registry push` requires platform credentials from `mcp-runtime auth login` or
-`MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`; unauthenticated pushes are
+`MCP_PLATFORM_API_TOKEN` with a saved or explicit `MCP_PLATFORM_API_URL`;
+unauthenticated pushes are
 rejected before the CLI saves the local image archive. The CLI uploads the docker
 save tar to `POST /api/runtime/registry/push`; the platform API pushes it to the
 registry from inside the cluster. When you use
@@ -302,9 +306,11 @@ mcp-runtime server init payments \
 
 `server init` creates or appends to `.mcp/servers.yaml`. It defaults `image` to
 the server name, `imageTag` to `latest`, `scope` to `tenant`, and the route to
-`/<name>/mcp`. It also writes governed defaults: header auth, allow-list policy
-with deny default, required adapter-issued sessions, and `gateway.enabled:
-true`. Repeated `--tool` flags seed read/low tool metadata. Use repeated
+`/<name>/mcp`. It enables the gateway, scaffolds allow-list/deny policy and a
+required session, and leaves platform-managed gateway wiring and auth/session
+header details out of the metadata file. Use `--policy-mode`,
+`--default-decision`, or `--session-required=false` when the initial governance
+shape should differ. Repeated `--tool` flags seed read/low tool metadata. Use repeated
 `--tool-spec name:low|medium|high:read|write|destructive` when tools need mixed
 trust levels or side-effect classes. If a metadata entry with the same server
 name already exists, `server init` fails unless `--force` is passed.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -648,10 +648,13 @@ Repeat deploys after metadata or image changes need `--update`:
 ./bin/mcp-runtime server deploy my-server --scope tenant --metadata-dir .mcp --update
 ```
 
-`server init` writes gateway-enabled, header-authenticated, session-required
-governance defaults. Edit `.mcp/servers.yaml` when a tool needs `medium` or
-`high` trust, or when its side effect is `write` or `destructive` instead of
-`read`. You can also seed that up front with
+`server init` enables the gateway, scaffolds allow-list/deny policy and a
+required session, and leaves platform-managed gateway wiring and auth/session
+header details out of `.mcp/servers.yaml`. Use `--policy-mode`,
+`--default-decision`, or `--session-required=false` when the initial governance
+shape should differ. Edit the metadata when a tool needs `medium` or `high`
+trust, or when its side effect is `write` or `destructive` instead of `read`.
+You can also seed that up front with
 `--tool-spec name:low|medium|high:read|write|destructive`; `--tool name` remains
 the read/low shorthand.
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -5692,7 +5692,7 @@ Package server owns routing for the server top-level command.
 - [`func (m *ServerManager) ExportServer(name, namespace, file string) error`](#cli-server-func-m-servermanager-exportserver-name-namespace-file-string-error)
 - [`func (m *ServerManager) GenerateManifests(metadataFile, metadataDir, outputDir string) error`](#cli-server-func-m-servermanager-generatemanifests-metadatafile-metadatadir-outputdir-string-error)
 - [`func (m *ServerManager) GetServer(name, namespace string) error`](#cli-server-func-m-servermanager-getserver-name-namespace-string-error)
-- [`func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope string, port int32, tools, toolSpecs []string, force bool) error`](#cli-server-func-m-servermanager-initserver-name-metadatadir-image-imagetag-scope-string-port-int32-tools-toolspecs-string-force-bool-error)
+- [`func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope, policyMode, defaultDecision string, sessionRequired bool, port int32, tools, toolSpecs []string, force bool) error`](#cli-server-func-m-servermanager-initserver-name-metadatadir-image-imagetag-scope-policymode-defaultdecision-string-sessionrequired-bool-port-int32-tools-toolspecs-string-force-bool-error)
 - [`func (m *ServerManager) InspectServerPolicy(name, namespace string) error`](#cli-server-func-m-servermanager-inspectserverpolicy-name-namespace-string-error)
 - [`func (m *ServerManager) ListServers(namespace, team string) error`](#cli-server-func-m-servermanager-listservers-namespace-team-string-error)
 - [`func (m *ServerManager) Logger() *zap.Logger`](#cli-server-func-m-servermanager-logger-zap-logger)
@@ -5813,9 +5813,9 @@ func (m *ServerManager) GetServer(name, namespace string) error
 
 ```
 
-<a id="cli-server-func-m-servermanager-initserver-name-metadatadir-image-imagetag-scope-string-port-int32-tools-toolspecs-string-force-bool-error"></a>
+<a id="cli-server-func-m-servermanager-initserver-name-metadatadir-image-imagetag-scope-policymode-defaultdecision-string-sessionrequired-bool-port-int32-tools-toolspecs-string-force-bool-error"></a>
 ```text
-func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope string, port int32, tools, toolSpecs []string, force bool) error
+func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope, policyMode, defaultDecision string, sessionRequired bool, port int32, tools, toolSpecs []string, force bool) error
 
 ```
 

--- a/docs/internals/internal-cli.md
+++ b/docs/internals/internal-cli.md
@@ -136,7 +136,9 @@ in `internal/cli/server/validation.go`.
 
 Keep these flows distinct:
 
-- `server init` scaffolds `.mcp/servers.yaml` with governed defaults.
+- `server init` scaffolds `.mcp/servers.yaml` with `gateway.enabled: true`,
+  policy, and session intent; it leaves gateway wiring and header defaults to
+  the metadata loader and CRD defaulting.
 - `server apply --use-kube` applies a manifest through kubectl (admin only).
 - `server build image` builds and updates metadata but does not deploy.
 - `server generate` renders manifests from metadata for review/GitOps.

--- a/docs/js/mermaid-init.js
+++ b/docs/js/mermaid-init.js
@@ -1,10 +1,111 @@
-document.addEventListener("DOMContentLoaded", function () {
-  if (typeof mermaid !== "undefined") {
+(function () {
+  async function renderMermaid() {
+    if (typeof mermaid === "undefined") {
+      return;
+    }
+
+    var fallbackSources = [];
+    try {
+      var response = await fetch(window.location.href, { cache: "no-store" });
+      var page = new DOMParser().parseFromString(await response.text(), "text/html");
+      fallbackSources = Array.from(
+        page.querySelectorAll("pre.mermaid-source > code, pre.mermaid > code"),
+      ).map(function (code) {
+        return code.textContent.trim();
+      });
+    } catch (error) {
+      fallbackSources = [];
+    }
+
+    document
+      .querySelectorAll("pre.mermaid-source > code, pre.mermaid > code")
+      .forEach(function (code, index) {
+        var container = document.createElement("div");
+        container.className = "mermaid";
+        container.textContent = code.textContent.trim() || fallbackSources[index] || "";
+        code.parentElement.replaceWith(container);
+      });
+
     mermaid.initialize({
-      theme: "default",
+      startOnLoad: false,
+      theme: "base",
+      themeVariables: {
+        background: "#ffffff",
+        fontSize: "17px",
+        fontFamily:
+          'Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        primaryColor: "#eff6ff",
+        primaryBorderColor: "#2563eb",
+        primaryTextColor: "#172033",
+        secondaryColor: "#ecfdf5",
+        secondaryBorderColor: "#047857",
+        tertiaryColor: "#f8fafc",
+        tertiaryBorderColor: "#94a3b8",
+        lineColor: "#334155",
+        textColor: "#172033",
+        mainBkg: "#ffffff",
+        nodeBorder: "#2563eb",
+        clusterBkg: "#f8fafc",
+        clusterBorder: "#b7c3d2",
+        edgeLabelBackground: "#ffffff",
+        actorBkg: "#eff6ff",
+        actorBorder: "#2563eb",
+        actorTextColor: "#172033",
+        actorLineColor: "#334155",
+        signalColor: "#334155",
+        signalTextColor: "#172033",
+        labelBoxBkgColor: "#f8fafc",
+        labelBoxBorderColor: "#94a3b8",
+        labelTextColor: "#172033",
+        loopTextColor: "#172033",
+        noteBkgColor: "#fef3c7",
+        noteBorderColor: "#d97706",
+        noteTextColor: "#172033",
+        activationBkgColor: "#dbeafe",
+        activationBorderColor: "#2563eb",
+        actorFontSize: "17px",
+        messageFontSize: "16px",
+        noteFontSize: "16px",
+      },
       flowchart: { useMaxWidth: true, htmlLabels: true },
-      sequence: { useMaxWidth: true },
+      sequence: {
+        useMaxWidth: true,
+        diagramMarginX: 36,
+        diagramMarginY: 24,
+        boxMargin: 12,
+        actorMargin: 72,
+        messageMargin: 40,
+      },
       securityLevel: "strict",
     });
+
+    var diagrams = Array.from(document.querySelectorAll(".mermaid"));
+    for (var index = 0; index < diagrams.length; index += 1) {
+      var diagram = diagrams[index];
+      var source = diagram.textContent.trim();
+      if (!source || diagram.dataset.processed === "true") {
+        continue;
+      }
+
+      try {
+        var rendered = await mermaid.render(
+          "mcp-runtime-mermaid-" + index + "-" + Date.now(),
+          source,
+        );
+        diagram.innerHTML = rendered.svg;
+        diagram.dataset.processed = "true";
+        if (rendered.bindFunctions) {
+          rendered.bindFunctions(diagram);
+        }
+      } catch (error) {
+        console.error("Mermaid render failed", error);
+      }
+    }
   }
-});
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", renderMermaid);
+  } else {
+    renderMermaid();
+  }
+})();

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,7 +37,7 @@ markdown_extensions:
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
-          class: mermaid
+          class: mermaid-source
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
   - pymdownx.tabbed:
@@ -46,7 +46,8 @@ markdown_extensions:
   - md_in_html
 
 extra_javascript:
-  - js/mermaid-init.js
+  - https://unpkg.com/mermaid@10.9.3/dist/mermaid.min.js
+  - js/mermaid-init.js?v=20260526-4
 
 extra_css:
   - stylesheets/infra.css

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,9 +2,7 @@
 
 {% block extrahead %}
   {{ super() }}
-  <script
-    src="https://unpkg.com/mermaid@10.9.3/dist/mermaid.min.js"
-    integrity="sha384-R63zfMfSwJF4xCR11wXii+QUsbiBIdiDzDbtxia72oGWfkT7WHJfmD/I/eeHPJyT"
-    crossorigin="anonymous"
-  ></script>
+  <script>
+    window.mermaid = { startOnLoad: false };
+  </script>
 {% endblock %}

--- a/docs/publish-mcp-server.md
+++ b/docs/publish-mcp-server.md
@@ -170,15 +170,6 @@ servers:
     route: /payments
     port: 8088
     replicas: 1
-    auth:
-      mode: header
-    policy:
-      mode: allow-list
-      defaultDecision: deny
-      enforceOn: call_tool
-      policyVersion: v1
-    session:
-      required: true
     gateway:
       enabled: true
     tools:
@@ -203,11 +194,13 @@ servers:
 - `imageTag`
   The image tag.
 - `scope`
-  Optional publish destination: `tenant`, `org`, or `public`. `org` resolves to
-  the org catalog namespace, and `public` resolves to the public catalog
-  namespace. `tenant` selects one of the authenticated user's team namespaces
-  when you publish through the platform API; when generating Kubernetes YAML
-  directly, set `namespace` explicitly for team deployments.
+  Optional publish destination: `tenant`, `org`, or `public`. `server init`
+  writes `scope: tenant` by default so new metadata starts in the private team
+  publish path. `org` resolves to the org catalog namespace, and `public`
+  resolves to the public catalog namespace. `tenant` selects one of the
+  authenticated user's team namespaces when you publish through the platform
+  API; when generating Kubernetes YAML directly, set `namespace` explicitly for
+  team deployments.
 - `route`
   The public path prefix that will become the server ingress path.
 - `port`
@@ -219,13 +212,15 @@ servers:
 - `tools`
   Tool inventory for the platform catalog and policy authoring. Include each tool's description when the MCP server SDK exposes one through `tools/list`, and set `sideEffect` to `read`, `write`, or `destructive`. Tool side effects are required when a tool is listed.
 - `auth`, `policy`, `session`, and `gateway`
-  Governed request-path settings. `server init` writes header auth, allow-list/deny policy, required adapter-issued sessions, and `gateway.enabled: true` so public tool calls go through the adapter/session path by default.
+  Governed request-path settings. `server init` writes `gateway.enabled: true`, allow-list/deny policy, and `session.required: true` so public tool calls go through the adapter/session path by default. Use `--policy-mode`, `--default-decision`, or `--session-required=false` to change those scaffolded values. Init omits platform-managed gateway wiring and auth/session header details unless you override them intentionally.
 
 ### Metadata defaults
 
 If fields are omitted, the loader applies defaults:
 
 - image defaults toward the platform registry path
+- `server init` writes `scope: tenant` unless you pass `--scope org` or
+  `--scope public`
 - `scope: org` / `scope: public` prefix default image repositories with
   `org/` or `public/` and default the generated namespace to
   `mcp-servers-org` or `mcp-servers-public`
@@ -234,8 +229,9 @@ If fields are omitted, the loader applies defaults:
 - port defaults to `8088`
 - replicas default to `1`
 - namespace defaults to `mcp-servers`
-- `server init` writes explicit governed defaults; hand-authored metadata may
-  omit them only when you intentionally want the platform/operator defaults
+- `server init` omits platform-managed gateway wiring and auth/session header
+  details; add those fields only when you intentionally need to override the
+  platform/operator defaults
 
 For multi-team deployments, set `scope: tenant` and deploy through
 `server deploy --scope tenant` with platform credentials. The platform API
@@ -266,7 +262,7 @@ MCP Runtime supports two practical image flows. Keep these flows separate so tag
 ./bin/mcp-runtime server build image payments --tag v1.0.0 --platform linux/amd64
 ```
 
-`server build image` builds the image, resolves the target registry host, tags the local image with that resolved reference, and rewrites matching `.mcp` metadata (`image` and `imageTag`). The command defaults Docker builds to `linux/amd64`, matching common amd64 Kubernetes nodes; set `--platform` or `MCP_DOCKER_PLATFORM` when your target nodes use another architecture. Registry resolution prefers explicit registry env, then the cluster's `registry/registry` Ingress host, before falling back to the registry Service address. When metadata sets `scope: tenant`, the build command uses platform credentials to resolve the same team repository prefix that `registry push --scope tenant` uses, so log in first or set `MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`.
+`server build image` builds the image, resolves the target registry host, tags the local image with that resolved reference, and rewrites matching `.mcp` metadata (`image` and `imageTag`). The command defaults Docker builds to `linux/amd64`, matching common amd64 Kubernetes nodes; set `--platform` or `MCP_DOCKER_PLATFORM` when your target nodes use another architecture. Registry resolution prefers explicit registry env, then the cluster's `registry/registry` Ingress host, before falling back to the registry Service address. When metadata sets `scope: tenant`, the build command uses platform credentials to resolve the same team repository prefix that `registry push --scope tenant` uses, so log in first or set `MCP_PLATFORM_API_TOKEN` with a saved or explicit `MCP_PLATFORM_API_URL`.
 
 After this command, push the exact image reference produced by the build output (or read it from the rewritten metadata):
 
@@ -276,7 +272,8 @@ mcp-runtime auth login --api-url https://platform.example.com
 ```
 
 `registry push` requires platform credentials from `mcp-runtime auth login` or
-`MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`; unauthenticated pushes are
+`MCP_PLATFORM_API_TOKEN` with a saved or explicit `MCP_PLATFORM_API_URL`;
+unauthenticated pushes are
 rejected before Docker or the in-cluster helper starts. `<exact-image-ref-from-build>`
 may be a resolved public registry host such as `registry.example.com/org/payments:v1.0.0`,
 or a registry Service address when no public registry Ingress is configured.

--- a/docs/stylesheets/infra.css
+++ b/docs/stylesheets/infra.css
@@ -506,7 +506,80 @@ body {
   border: 1px solid var(--infra-line);
   border-radius: 8px;
   background: #ffffff;
+  color: var(--infra-ink);
+  font-size: 0.85rem;
+  max-width: 100%;
+  margin: 1rem 0 1.25rem;
+  overflow-x: auto;
   padding: 1rem;
+  scrollbar-color: var(--infra-line-strong) #f8fafc;
+}
+
+.md-typeset .mermaid svg {
+  display: block;
+  width: max(100%, 1280px) !important;
+  max-width: none !important;
+  min-width: 1280px;
+  height: auto !important;
+}
+
+.md-typeset .mermaid svg[aria-roledescription="flowchart-v2"] {
+  width: max(100%, 880px) !important;
+  min-width: 880px;
+}
+
+.md-typeset .mermaid .actor,
+.md-typeset .mermaid .messageText,
+.md-typeset .mermaid .labelText,
+.md-typeset .mermaid .loopText,
+.md-typeset .mermaid .noteText,
+.md-typeset .mermaid text {
+  fill: var(--infra-ink) !important;
+  color: var(--infra-ink) !important;
+}
+
+.md-typeset .mermaid .messageLine0,
+.md-typeset .mermaid .messageLine1,
+.md-typeset .mermaid .flowchart-link {
+  stroke: #334155 !important;
+  stroke-width: 2px !important;
+}
+
+.md-typeset .mermaid .actor {
+  fill: #eff6ff !important;
+  stroke: #2563eb !important;
+  stroke-width: 2px !important;
+}
+
+.md-typeset .mermaid .actor-line {
+  stroke: #64748b !important;
+  stroke-width: 1.5px !important;
+}
+
+.md-typeset .mermaid .labelBox,
+.md-typeset .mermaid .loopLine {
+  fill: #f8fafc !important;
+  stroke: #94a3b8 !important;
+  stroke-width: 1.5px !important;
+}
+
+.md-typeset .mermaid .note {
+  fill: #fef3c7 !important;
+  stroke: #d97706 !important;
+  stroke-width: 1.5px !important;
+}
+
+.md-typeset .mermaid .activation0,
+.md-typeset .mermaid .activation1,
+.md-typeset .mermaid .activation2 {
+  stroke: #2563eb !important;
+  fill: #dbeafe !important;
+}
+
+.md-typeset .mermaid rect,
+.md-typeset .mermaid polygon {
+  fill-opacity: 1 !important;
+  stroke-opacity: 1 !important;
 }
 
 .md-footer {

--- a/examples/data-utility-mcp/.mcp/servers.yaml
+++ b/examples/data-utility-mcp/.mcp/servers.yaml
@@ -1,83 +1,17 @@
 version: v1
 servers:
-  - name: data-utility-mcp
-    description: Data utility MCP server for text cleanup, lightweight math, timestamps, task summaries, prompts, and resources.
-    route: /data-utility-mcp/mcp
-    publicPathPrefix: data-utility-mcp
-    port: 8088
-    namespace: mcp-servers
-    envVars:
-      - name: MCP_PATH
-        value: /data-utility-mcp/mcp
-    tools:
-      - name: ping
-        description: Check that the data utility server is reachable.
-        requiredTrust: low
-        sideEffect: read
-      - name: echo
-        description: Echo the provided message.
-        requiredTrust: low
-        sideEffect: read
-      - name: reverse
-        description: Reverse the provided text.
-        requiredTrust: low
-        sideEffect: read
-      - name: add
-        description: Add two numeric values.
-        requiredTrust: low
-        sideEffect: read
-      - name: multiply
-        description: Multiply two numeric values.
-        requiredTrust: low
-        sideEffect: read
-      - name: upper
-        description: Convert text to uppercase.
-        requiredTrust: medium
-        sideEffect: read
-      - name: lower
-        description: Convert text to lowercase.
-        requiredTrust: low
-        sideEffect: read
-      - name: slugify
-        description: Convert text into a URL-safe slug.
-        requiredTrust: low
-        sideEffect: read
-      - name: word_count
-        description: Count words in the provided message.
-        requiredTrust: low
-        sideEffect: read
-      - name: extract_keywords
-        description: Extract stable lowercase keywords from a short text sample.
-        requiredTrust: low
-        sideEffect: read
-      - name: summarize_numbers
-        description: Summarize numbers found in comma, space, or prose separated text.
-        requiredTrust: low
-        sideEffect: read
-      - name: now
-        description: Return the current UTC timestamp in RFC 3339 form.
-        requiredTrust: low
-        sideEffect: read
-      - name: create_task
-        description: Create a deterministic task summary for IDE and adapter smoke tests.
-        requiredTrust: low
-        sideEffect: write
-    prompts:
-      - name: hello
-        description: Return a simple greeting prompt.
-      - name: summarize
-        description: Summarize a short text input.
-      - name: task_brief
-        description: Draft a concise task brief from a goal.
-      - name: data_quality_review
-        description: Draft a concise data quality review prompt.
-    mcpResources:
-      - name: readme
-        description: Data utility overview and supported workflow notes.
-      - name: task-guide
-        description: Task workflow guidance for data utility smoke tests.
-      - name: data-cleaning-checklist
-        description: Checklist for lightweight data-cleaning demos.
-    tasks:
-      - name: create_task
-        description: Deterministic task creation workflow for adapter smoke tests.
+    - name: data-utility-mcp
+      description: data-utility-mcp MCP server
+      image: data-utility-mcp
+      imageTag: latest
+      route: /data-utility-mcp/mcp
+      publicPathPrefix: data-utility-mcp
+      port: 8088
+      scope: tenant
+      policy:
+        mode: allow-list
+        defaultDecision: deny
+      session:
+        required: true
+      gateway:
+        enabled: true

--- a/internal/cli/auth/auth.go
+++ b/internal/cli/auth/auth.go
@@ -65,7 +65,7 @@ The token is stored in a local file (mode 0600) under the user config directory,
 
 Optional environment:
   ` + authfile.EnvAPIURL + `      default API base for login, e.g. https://platform.example.com
-  ` + authfile.EnvAPIToken + `    use this token for API calls; overrides a saved file
+  ` + authfile.EnvAPIToken + `    use this token for API calls; overrides the saved token
   ` + authfile.EnvAPIProfile + `  select a saved credentials profile
   MCP_RUNTIME_CONFIG_DIR    override the config directory (default ~/.mcpruntime)`,
 	}
@@ -287,12 +287,8 @@ func (m *manager) NewStatusCmd() *cobra.Command {
 		Short: "Show whether platform API credentials are configured",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			stdout := cmd.OutOrStdout()
-			stderr := cmd.ErrOrStderr()
 			if t := strings.TrimSpace(os.Getenv(authfile.EnvAPIToken)); t != "" {
-				fmt.Fprintln(stdout, "A platform API token is set in "+authfile.EnvAPIToken+" and overrides any saved file.")
-				if b := strings.TrimSpace(os.Getenv(authfile.EnvAPIURL)); b == "" {
-					fmt.Fprintln(stderr, "Note: "+authfile.EnvAPIURL+" is not set. Commands that need a base URL require it (or a saved `mcp-runtime auth login`).")
-				}
+				fmt.Fprintln(stdout, "A platform API token is set in "+authfile.EnvAPIToken+" and overrides any saved token.")
 			} else {
 				p, perr := authfile.FilePath()
 				if perr == nil {
@@ -316,7 +312,7 @@ func (m *manager) NewStatusCmd() *cobra.Command {
 			if api != "" {
 				fmt.Fprintln(stdout, "  API base URL:", api)
 			} else {
-				fmt.Fprintln(stdout, "  API base URL: (set --api-url on login or "+authfile.EnvAPIURL+" if using "+authfile.EnvAPIToken+" only)")
+				fmt.Fprintln(stdout, "  API base URL: (set --api-url on login or "+authfile.EnvAPIURL+")")
 			}
 			if c, cErr := fileCredentialsIfRelevant(); cErr == nil && c != nil {
 				account, profile, aErr := c.SelectedAccount(os.Getenv(authfile.EnvAPIProfile))

--- a/internal/cli/registry/manager.go
+++ b/internal/cli/registry/manager.go
@@ -359,7 +359,7 @@ func requirePlatformPushCredentials(ctx context.Context) (*platformapi.PlatformC
 	}
 	client, err := platformapi.NewPlatformClient()
 	if err != nil {
-		return nil, fmt.Errorf("registry push requires platform credentials; run mcp-runtime auth login or set MCP_PLATFORM_API_TOKEN and MCP_PLATFORM_API_URL: %w", err)
+		return nil, fmt.Errorf("registry push requires platform credentials; run mcp-runtime auth login or set MCP_PLATFORM_API_TOKEN with a saved or explicit MCP_PLATFORM_API_URL: %w", err)
 	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -65,7 +65,7 @@ func NewWithManager(mgr *RegistryManager) *cobra.Command {
 	pushCmd := &cobra.Command{
 		Use:   "push",
 		Short: "Push an image to the platform registry",
-		Long:  "Save a local image and push it to the platform registry through the platform API. Requires `mcp-runtime auth login` or MCP_PLATFORM_API_TOKEN plus MCP_PLATFORM_API_URL.",
+		Long:  "Save a local image and push it to the platform registry through the platform API. Requires `mcp-runtime auth login` or MCP_PLATFORM_API_TOKEN with a saved or explicit MCP_PLATFORM_API_URL.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunRegistryPush(cmd.Context(), mgr, image, "", name, scope)
 		},

--- a/internal/cli/server/build_image.go
+++ b/internal/cli/server/build_image.go
@@ -116,7 +116,7 @@ func scopedRepositoryNameForBuild(ctx context.Context, serverName, metadataFile,
 	if scope == publishscope.Tenant {
 		client, err := platformapi.NewPlatformClient()
 		if err != nil {
-			return "", fmt.Errorf("build tenant-scoped image requires platform credentials; run mcp-runtime auth login or set MCP_PLATFORM_API_TOKEN and MCP_PLATFORM_API_URL: %w", err)
+			return "", fmt.Errorf("build tenant-scoped image requires platform credentials; run mcp-runtime auth login or set MCP_PLATFORM_API_TOKEN with a saved or explicit MCP_PLATFORM_API_URL: %w", err)
 		}
 		scopedCtx, cancel := context.WithTimeout(ctx, buildTenantScopeTimeout)
 		defer cancel()

--- a/internal/cli/server/manager.go
+++ b/internal/cli/server/manager.go
@@ -60,7 +60,7 @@ func (m *ServerManager) requireKubectlForMutation() error {
 	return nil
 }
 
-func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope string, port int32, tools, toolSpecs []string, force bool) error {
+func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope, policyMode, defaultDecision string, sessionRequired bool, port int32, tools, toolSpecs []string, force bool) error {
 	name, err := validateManifestValue("name", name)
 	if err != nil {
 		return err
@@ -88,6 +88,24 @@ func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope str
 	if _, err := publishscope.Normalize(scope); err != nil {
 		return err
 	}
+	policyMode = strings.TrimSpace(policyMode)
+	if policyMode == "" {
+		policyMode = string(metadata.PolicyModeAllowList)
+	}
+	switch metadata.PolicyMode(policyMode) {
+	case metadata.PolicyModeAllowList, metadata.PolicyModeObserve:
+	default:
+		return core.NewWithSentinel(nil, fmt.Sprintf("invalid policy mode %q; must be allow-list or observe", policyMode))
+	}
+	defaultDecision = strings.TrimSpace(defaultDecision)
+	if defaultDecision == "" {
+		defaultDecision = string(metadata.PolicyDecisionDeny)
+	}
+	switch metadata.PolicyDecision(defaultDecision) {
+	case metadata.PolicyDecisionAllow, metadata.PolicyDecisionDeny:
+	default:
+		return core.NewWithSentinel(nil, fmt.Sprintf("invalid default decision %q; must be allow or deny", defaultDecision))
+	}
 	if port <= 0 {
 		port = defaultDeployPort()
 	}
@@ -109,6 +127,11 @@ func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope str
 		registry.Version = "v1"
 	}
 
+	var session *metadata.SessionConfig
+	if sessionRequired {
+		session = &metadata.SessionConfig{Required: true}
+	}
+
 	server := metadata.ServerMetadata{
 		Name:             name,
 		Description:      fmt.Sprintf("%s MCP server", name),
@@ -119,32 +142,13 @@ func (m *ServerManager) InitServer(name, metadataDir, image, imageTag, scope str
 		Route:            "/" + name + "/mcp",
 		Port:             port,
 		Tools:            nil,
-		Auth: &metadata.AuthConfig{
-			Mode:            metadata.AuthModeHeader,
-			HumanIDHeader:   "X-MCP-Human-ID",
-			AgentIDHeader:   "X-MCP-Agent-ID",
-			TeamIDHeader:    "X-MCP-Team-ID",
-			SessionIDHeader: "X-MCP-Agent-Session",
-			TokenHeader:     "Authorization",
-		},
 		Policy: &metadata.PolicyConfig{
-			Mode:            metadata.PolicyModeAllowList,
-			DefaultDecision: metadata.PolicyDecisionDeny,
-			EnforceOn:       "call_tool",
-			PolicyVersion:   "v1",
+			Mode:            metadata.PolicyMode(policyMode),
+			DefaultDecision: metadata.PolicyDecision(defaultDecision),
 		},
-		Session: &metadata.SessionConfig{
-			Required:            true,
-			Store:               "kubernetes",
-			HeaderName:          "X-MCP-Agent-Session",
-			MaxLifetime:         "24h",
-			IdleTimeout:         "1h",
-			UpstreamTokenHeader: "Authorization",
-		},
+		Session: session,
 		Gateway: &metadata.GatewayConfig{
-			Enabled:     true,
-			Port:        8091,
-			UpstreamURL: fmt.Sprintf("http://127.0.0.1:%d", port),
+			Enabled: true,
 		},
 	}
 	toolMetadata, err := initToolMetadata(tools, toolSpecs)

--- a/internal/cli/server/manager_test.go
+++ b/internal/cli/server/manager_test.go
@@ -32,11 +32,34 @@ func TestInitServerCreatesMetadata(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), ".mcp")
 	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
 
-	if err := mgr.InitServer("payments", dir, "", "v1", "tenant", 8088, []string{"add", "add", "echo"}, []string{"refund_invoice:high:destructive"}, false); err != nil {
+	if err := mgr.InitServer("payments", dir, "", "v1", "tenant", "allow-list", "deny", true, 8088, []string{"add", "add", "echo"}, []string{"refund_invoice:high:destructive"}, false); err != nil {
 		t.Fatalf("InitServer() error = %v", err)
 	}
 
-	registry, err := metadata.LoadFromFile(filepath.Join(dir, "servers.yaml"))
+	metadataPath := filepath.Join(dir, "servers.yaml")
+	rawMetadata, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	raw := string(rawMetadata)
+	for _, platformDefault := range []string{
+		"auth:",
+		"enforceOn:",
+		"policyVersion:",
+		"store:",
+		"headerName:",
+		"maxLifetime:",
+		"idleTimeout:",
+		"upstreamTokenHeader:",
+		"port: 8091",
+		"upstreamURL:",
+	} {
+		if strings.Contains(raw, platformDefault) {
+			t.Fatalf("raw metadata contains platform-managed default %q:\n%s", platformDefault, rawMetadata)
+		}
+	}
+
+	registry, err := metadata.LoadFromFile(metadataPath)
 	if err != nil {
 		t.Fatalf("LoadFromFile() error = %v", err)
 	}
@@ -59,8 +82,8 @@ func TestInitServerCreatesMetadata(t *testing.T) {
 	if server.Gateway == nil || !server.Gateway.Enabled {
 		t.Fatalf("gateway = %#v, want enabled", server.Gateway)
 	}
-	if server.Auth == nil || server.Auth.Mode != metadata.AuthModeHeader {
-		t.Fatalf("auth = %#v, want header mode", server.Auth)
+	if server.Auth != nil {
+		t.Fatalf("auth header defaults should be omitted from metadata: auth=%#v", server.Auth)
 	}
 	if server.Policy == nil || server.Policy.Mode != metadata.PolicyModeAllowList || server.Policy.DefaultDecision != metadata.PolicyDecisionDeny {
 		t.Fatalf("policy = %#v, want allow-list/deny", server.Policy)
@@ -74,13 +97,13 @@ func TestInitServerAppendsAndRejectsDuplicate(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), ".mcp")
 	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
 
-	if err := mgr.InitServer("one", dir, "", "latest", "tenant", 8088, nil, nil, false); err != nil {
+	if err := mgr.InitServer("one", dir, "", "latest", "tenant", "allow-list", "deny", true, 8088, nil, nil, false); err != nil {
 		t.Fatalf("InitServer(one) error = %v", err)
 	}
-	if err := mgr.InitServer("two", dir, "custom/two", "v2", "org", 9000, []string{"search"}, nil, false); err != nil {
+	if err := mgr.InitServer("two", dir, "custom/two", "v2", "org", "allow-list", "deny", true, 9000, []string{"search"}, nil, false); err != nil {
 		t.Fatalf("InitServer(two) error = %v", err)
 	}
-	err := mgr.InitServer("one", dir, "", "latest", "tenant", 8088, nil, nil, false)
+	err := mgr.InitServer("one", dir, "", "latest", "tenant", "allow-list", "deny", true, 8088, nil, nil, false)
 	if err == nil || !strings.Contains(err.Error(), "--force") {
 		t.Fatalf("duplicate error = %v, want --force guidance", err)
 	}
@@ -94,14 +117,49 @@ func TestInitServerAppendsAndRejectsDuplicate(t *testing.T) {
 	}
 }
 
+func TestInitServerUsesGovernanceFlags(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".mcp")
+	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
+
+	if err := mgr.InitServer("payments", dir, "", "latest", "tenant", "observe", "allow", false, 8088, nil, nil, false); err != nil {
+		t.Fatalf("InitServer() error = %v", err)
+	}
+
+	registry, err := metadata.LoadFromFile(filepath.Join(dir, "servers.yaml"))
+	if err != nil {
+		t.Fatalf("LoadFromFile() error = %v", err)
+	}
+	server := registry.Servers[0]
+	if server.Policy == nil || server.Policy.Mode != metadata.PolicyModeObserve || server.Policy.DefaultDecision != metadata.PolicyDecisionAllow {
+		t.Fatalf("policy = %#v, want observe/allow", server.Policy)
+	}
+	if server.Session != nil {
+		t.Fatalf("session = %#v, want omitted for required=false", server.Session)
+	}
+}
+
+func TestInitServerRejectsInvalidGovernanceFlags(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".mcp")
+	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
+
+	err := mgr.InitServer("payments", dir, "", "latest", "tenant", "audit", "deny", true, 8088, nil, nil, false)
+	if err == nil || !strings.Contains(err.Error(), "invalid policy mode") {
+		t.Fatalf("policy mode error = %v, want invalid policy mode", err)
+	}
+	err = mgr.InitServer("payments", dir, "", "latest", "tenant", "allow-list", "maybe", true, 8088, nil, nil, false)
+	if err == nil || !strings.Contains(err.Error(), "invalid default decision") {
+		t.Fatalf("default decision error = %v, want invalid default decision", err)
+	}
+}
+
 func TestInitServerForceReplacesExisting(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), ".mcp")
 	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
 
-	if err := mgr.InitServer("payments", dir, "payments", "v1", "tenant", 8088, []string{"add"}, nil, false); err != nil {
+	if err := mgr.InitServer("payments", dir, "payments", "v1", "tenant", "allow-list", "deny", true, 8088, []string{"add"}, nil, false); err != nil {
 		t.Fatalf("InitServer() error = %v", err)
 	}
-	if err := mgr.InitServer("payments", dir, "payments-v2", "v2", "tenant", 9090, []string{"echo"}, nil, true); err != nil {
+	if err := mgr.InitServer("payments", dir, "payments-v2", "v2", "tenant", "allow-list", "deny", true, 9090, []string{"echo"}, nil, true); err != nil {
 		t.Fatalf("InitServer(force) error = %v", err)
 	}
 	registry, err := metadata.LoadFromFile(filepath.Join(dir, "servers.yaml"))
@@ -121,7 +179,7 @@ func TestInitServerRejectsDuplicateToolSpec(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), ".mcp")
 	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
 
-	err := mgr.InitServer("payments", dir, "", "latest", "tenant", 8088, []string{"add"}, []string{"add:high:write"}, false)
+	err := mgr.InitServer("payments", dir, "", "latest", "tenant", "allow-list", "deny", true, 8088, []string{"add"}, []string{"add:high:write"}, false)
 	if err == nil || !strings.Contains(err.Error(), "duplicate tool metadata") {
 		t.Fatalf("error = %v, want duplicate tool metadata", err)
 	}
@@ -131,7 +189,7 @@ func TestInitServerRejectsInvalidToolSpec(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), ".mcp")
 	mgr := NewServerManager(core.NewTestKubectlClient(&core.MockExecutor{}), zap.NewNop())
 
-	err := mgr.InitServer("payments", dir, "", "latest", "tenant", 8088, nil, []string{"refund_invoice:full:danger"}, false)
+	err := mgr.InitServer("payments", dir, "", "latest", "tenant", "allow-list", "deny", true, 8088, nil, []string{"refund_invoice:full:danger"}, false)
 	if err == nil || !strings.Contains(err.Error(), "trust must be low, medium, or high") {
 		t.Fatalf("error = %v, want trust validation", err)
 	}

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"mcp-runtime/internal/cli/core"
+	"mcp-runtime/pkg/metadata"
 )
 
 // New returns the server command.
@@ -41,6 +42,9 @@ For pushing images, use 'registry push'.`,
 	var initImage string
 	var initTag string
 	var initScope string
+	var initPolicyMode string
+	var initDefaultDecision string
+	var initSessionRequired bool
 	var initPort int32
 	var initTools []string
 	var initToolSpecs []string
@@ -51,13 +55,16 @@ For pushing images, use 'registry push'.`,
 		Long:  "Initialize .mcp/servers.yaml metadata for a server. Use repeated --tool flags to seed governed tool metadata, then build, push, and deploy with server build image, registry push, and server deploy.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return mgr.InitServer(args[0], initMetadataDir, initImage, initTag, initScope, initPort, initTools, initToolSpecs, initForce)
+			return mgr.InitServer(args[0], initMetadataDir, initImage, initTag, initScope, initPolicyMode, initDefaultDecision, initSessionRequired, initPort, initTools, initToolSpecs, initForce)
 		},
 	}
 	initCmd.Flags().StringVar(&initMetadataDir, "metadata-dir", ".mcp", "Directory where servers.yaml will be written")
 	initCmd.Flags().StringVar(&initImage, "image", "", "Container image repository (default: server name)")
 	initCmd.Flags().StringVar(&initTag, "tag", "latest", "Container image tag")
 	initCmd.Flags().StringVar(&initScope, "scope", "tenant", "Publish scope: tenant, org, or public")
+	initCmd.Flags().StringVar(&initPolicyMode, "policy-mode", string(metadata.PolicyModeAllowList), "Policy mode: allow-list or observe")
+	initCmd.Flags().StringVar(&initDefaultDecision, "default-decision", string(metadata.PolicyDecisionDeny), "Default policy decision: allow or deny")
+	initCmd.Flags().BoolVar(&initSessionRequired, "session-required", true, "Require adapter-issued agent sessions")
 	initCmd.Flags().Int32Var(&initPort, "port", defaultDeployPort(), "Container port")
 	initCmd.Flags().StringArrayVar(&initTools, "tool", nil, "Tool name to add with read side-effect metadata; repeat for multiple tools")
 	initCmd.Flags().StringArrayVar(&initToolSpecs, "tool-spec", nil, "Tool metadata as name:low|medium|high:read|write|destructive; repeat for mixed trust or side effects")

--- a/pkg/authfile/authfile.go
+++ b/pkg/authfile/authfile.go
@@ -316,7 +316,11 @@ const EnvAPIProfile = "MCP_PLATFORM_API_PROFILE"
 // If apiBase is empty, callers may still have a token from [EnvAPIToken] only.
 func ResolveToken() (token, apiBase, source string, err error) {
 	if t := strings.TrimSpace(os.Getenv(EnvAPIToken)); t != "" {
-		return t, strings.TrimSpace(os.Getenv(EnvAPIURL)), EnvAPIToken, nil
+		apiBase := strings.TrimSpace(os.Getenv(EnvAPIURL))
+		if apiBase == "" {
+			apiBase = savedAPIBaseURL()
+		}
+		return t, apiBase, EnvAPIToken, nil
 	}
 	path, err := FilePath()
 	if err != nil {
@@ -335,6 +339,22 @@ func ResolveToken() (token, apiBase, source string, err error) {
 		source += " profile " + profile
 	}
 	return account.Token, account.APIBaseURL, source, nil
+}
+
+func savedAPIBaseURL() string {
+	path, err := FilePath()
+	if err != nil {
+		return ""
+	}
+	c, err := Load(path)
+	if err != nil {
+		return ""
+	}
+	account, _, err := c.SelectedAccount(os.Getenv(EnvAPIProfile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(account.APIBaseURL)
 }
 
 // CurrentRegistryHost returns the registry host saved with the active platform login.

--- a/pkg/authfile/authfile_test.go
+++ b/pkg/authfile/authfile_test.go
@@ -27,6 +27,49 @@ func TestResolveToken_PrefersEnv(t *testing.T) {
 	}
 }
 
+func TestResolveToken_EnvTokenUsesSavedAPIURL(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("MCP_RUNTIME_CONFIG_DIR", d)
+	t.Setenv(EnvAPIToken, "envkey")
+	p := filepath.Join(d, "config.json")
+	if err := SaveProfile(p, "admin", CredentialAccount{APIBaseURL: "https://admin.example", Token: "admin-token"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveProfile(p, "acme", CredentialAccount{APIBaseURL: "https://acme.example", Token: "acme-token"}); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, api, src, err := ResolveToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok != "envkey" || api != "https://acme.example" || src != EnvAPIToken {
+		t.Fatalf("got %q %q %q", tok, api, src)
+	}
+}
+
+func TestResolveToken_EnvTokenUsesSavedProfileAPIURL(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("MCP_RUNTIME_CONFIG_DIR", d)
+	t.Setenv(EnvAPIToken, "envkey")
+	t.Setenv(EnvAPIProfile, "admin")
+	p := filepath.Join(d, "config.json")
+	if err := SaveProfile(p, "admin", CredentialAccount{APIBaseURL: "https://admin.example", Token: "admin-token"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveProfile(p, "acme", CredentialAccount{APIBaseURL: "https://acme.example", Token: "acme-token"}); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, api, src, err := ResolveToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok != "envkey" || api != "https://admin.example" || src != EnvAPIToken {
+		t.Fatalf("got %q %q %q", tok, api, src)
+	}
+}
+
 func TestConfigDir_RespectsEnv(t *testing.T) {
 	d := t.TempDir()
 	t.Setenv("MCP_RUNTIME_CONFIG_DIR", d)

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -380,6 +380,7 @@ mkdir -p "${E2E_PIPELINE_CONFIG_DIR}"
 STAGE_LOG_DIR="${WORKDIR}/stage-logs"
 KIND_CONFIG="$(mktemp)"
 KUBECONFIG_FILE="$(mktemp)"
+KUBECONFIG_BACKUP_FILE="$(mktemp)"
 ORIG_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
 PIDS=()
 PARALLEL_PIDS=()
@@ -417,6 +418,7 @@ cleanup() {
   rm -rf "${WORKDIR}"
   rm -f "${KIND_CONFIG}"
   rm -f "${KUBECONFIG_FILE}"
+  rm -f "${KUBECONFIG_BACKUP_FILE}"
 }
 trap cleanup EXIT
 
@@ -1825,19 +1827,31 @@ restart_deployment_pods() {
   kubectl rollout status "deploy/${name}" -n "${namespace}" --timeout="${timeout}"
 }
 
-prepare_example_metadata() {
+init_example_metadata() {
   local metadata_dir="$1"
   local server_name="$2"
-  local ingress_host="$3"
-  local route_path="$4"
-  local image_repo="$5"
-  local image_tag="$6"
+  local route_path="$3"
+  local image_repo="$4"
+  local image_tag="$5"
+  local smoke_tool="$6"
 
-  SERVER_NAME_OVERRIDE="${server_name}" \
-  SERVER_HOST_OVERRIDE="${ingress_host}" \
+  rm -rf "${metadata_dir}"
+  mkdir -p "${metadata_dir}"
+  (
+    cd "$(dirname "${metadata_dir}")"
+    "${PROJECT_ROOT}/bin/mcp-runtime" server init "${server_name}" \
+      --metadata-dir "$(basename "${metadata_dir}")" \
+      --image "${image_repo}" \
+      --tag "${image_tag}" \
+      --port 8088 \
+      --policy-mode observe \
+      --default-decision allow \
+      --session-required=false \
+      --tool "${smoke_tool}" \
+      --force
+  )
+
   SERVER_ROUTE_OVERRIDE="${route_path}" \
-  SERVER_IMAGE_OVERRIDE="${image_repo}" \
-  SERVER_IMAGE_TAG_OVERRIDE="${image_tag}" \
   METADATA_DIR_OVERRIDE="${metadata_dir}" \
   python3 <<'PY'
 from pathlib import Path
@@ -1846,131 +1860,72 @@ import os
 metadata_dir = Path(os.environ["METADATA_DIR_OVERRIDE"])
 path = metadata_dir / "servers.yaml"
 lines = path.read_text(encoding="utf-8").splitlines()
+route = os.environ["SERVER_ROUTE_OVERRIDE"].strip()
+prefix = route.strip("/")
+if prefix.endswith("/mcp"):
+    prefix = prefix[:-len("/mcp")].rstrip("/")
+
 updated = []
-server_name_updated = False
-server_image_updated = False
-server_image_tag_updated = False
-mcp_path_updated = False
-public_path_prefix_updated = False
-in_env_vars = False
-current_env_name = None
-resources_present = any(line.startswith("    resources:") for line in lines)
-image_tag_present = any(line.lstrip().startswith("imageTag: ") for line in lines)
-
-route_override = os.environ["SERVER_ROUTE_OVERRIDE"].strip()
-route_prefix = route_override.strip("/")
-if route_prefix.endswith("/mcp"):
-    route_prefix = route_prefix[: -len("/mcp")].rstrip("/")
-if not route_prefix:
-    route_prefix = os.environ["SERVER_NAME_OVERRIDE"]
-
+server_field_indent = None
+env_inserted = False
+resources_inserted = False
+public_path_prefix_seen = False
 for line in lines:
     stripped = line.lstrip()
     indent = line[: len(line) - len(stripped)]
-    if not server_name_updated and indent == "  " and stripped.startswith("- name: "):
-        updated.append(f"{indent}- name: {os.environ['SERVER_NAME_OVERRIDE']}")
-        server_name_updated = True
-    elif stripped.startswith("ingressHost: "):
-        updated.append(f"{indent}ingressHost: {os.environ['SERVER_HOST_OVERRIDE']}")
-    elif stripped.startswith("route: "):
-        updated.append(f"{indent}route: {os.environ['SERVER_ROUTE_OVERRIDE']}")
-    elif stripped.startswith("publicPathPrefix: "):
-        updated.append(f"{indent}publicPathPrefix: {route_prefix}")
-        public_path_prefix_updated = True
-    elif not server_image_updated and indent == "    " and stripped.startswith("image: "):
-        updated.append(f"{indent}image: {os.environ['SERVER_IMAGE_OVERRIDE']}")
-        server_image_updated = True
-        if not image_tag_present:
-            updated.append(f"{indent}imageTag: {os.environ['SERVER_IMAGE_TAG_OVERRIDE']}")
-            server_image_tag_updated = True
-    elif indent == "    " and stripped.startswith("imageTag: "):
-        updated.append(f"{indent}imageTag: {os.environ['SERVER_IMAGE_TAG_OVERRIDE']}")
-        server_image_tag_updated = True
-    elif indent == "    " and stripped == "envVars:":
-        in_env_vars = True
-        current_env_name = None
-        updated.append(line)
-    elif in_env_vars and indent == "      " and stripped.startswith("- name: "):
-        current_env_name = stripped.split(": ", 1)[1]
-        updated.append(line)
-    elif in_env_vars and current_env_name == "MCP_PATH" and indent == "        " and stripped.startswith("value: "):
-        updated.append(f'{indent}value: "{os.environ["SERVER_ROUTE_OVERRIDE"]}"')
-        mcp_path_updated = True
-    else:
-        if in_env_vars and indent.startswith("    ") and indent != "      " and indent != "        ":
-            in_env_vars = False
-            current_env_name = None
-        updated.append(line)
-if not server_image_updated:
-    final = []
-    inserted = False
-    for line in updated:
-        final.append(line)
-        stripped = line.lstrip()
-        indent = line[: len(line) - len(stripped)]
-        if not inserted and indent == "  " and stripped.startswith("- name: "):
-            final.append(f"{indent}  image: {os.environ['SERVER_IMAGE_OVERRIDE']}")
-            final.append(f"{indent}  imageTag: {os.environ['SERVER_IMAGE_TAG_OVERRIDE']}")
-            inserted = True
-    updated = final
-    server_image_updated = inserted
-    server_image_tag_updated = inserted
-if not mcp_path_updated:
-    final = []
-    inserted = False
-    for line in updated:
-        final.append(line)
-        stripped = line.lstrip()
-        indent = line[: len(line) - len(stripped)]
-        if not inserted and indent == "    " and stripped.startswith("namespace: "):
-            final.append(f"{indent}envVars:")
-            final.append(f"{indent}  - name: MCP_PATH")
-            final.append(f'{indent}    value: "{os.environ["SERVER_ROUTE_OVERRIDE"]}"')
-            inserted = True
-    updated = final
-    mcp_path_updated = inserted
-if not public_path_prefix_updated:
-    final = []
-    inserted = False
-    for line in updated:
-        final.append(line)
-        stripped = line.lstrip()
-        indent = line[: len(line) - len(stripped)]
-        if not inserted and indent == "    " and stripped.startswith("route: "):
-            final.append(f"{indent}publicPathPrefix: {route_prefix}")
-            inserted = True
-    updated = final
-    public_path_prefix_updated = inserted
-if not resources_present:
-    final = []
-    inserted = False
-    for line in updated:
-        final.append(line)
-        stripped = line.lstrip()
-        indent = line[: len(line) - len(stripped)]
-        if not inserted and indent == "    " and stripped.startswith("namespace: "):
-            final.append(f"{indent}resources:")
-            final.append(f"{indent}  requests:")
-            final.append(f"{indent}    cpu: 1m")
-            final.append(f"{indent}    memory: 32Mi")
-            inserted = True
-    updated = final
-    resources_present = inserted
-path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+    updated.append(line)
+    if stripped.startswith("- name: ") and server_field_indent is None:
+        server_field_indent = indent + "  "
+    if server_field_indent is None:
+        continue
+    if indent == server_field_indent and stripped.startswith("route: "):
+        updated[-1] = f"{indent}route: {route}"
+    elif indent == server_field_indent and stripped.startswith("publicPathPrefix: "):
+        updated[-1] = f"{indent}publicPathPrefix: {prefix}"
+        public_path_prefix_seen = True
+    elif indent == server_field_indent and stripped.startswith("port: ") and not env_inserted:
+        updated.append(f"{indent}envVars:")
+        updated.append(f"{indent}  - name: MCP_PATH")
+        updated.append(f'{indent}    value: "{route}"')
+        env_inserted = True
+    elif indent == server_field_indent and stripped.startswith("scope: ") and not resources_inserted:
+        updated.append(f"{indent}resources:")
+        updated.append(f"{indent}  requests:")
+        updated.append(f"{indent}    cpu: 1m")
+        updated.append(f"{indent}    memory: 32Mi")
+        resources_inserted = True
 
-# Verify substitutions landed; missing fields cause silent failures later.
-if not server_name_updated:
-    raise SystemExit(f"prepare_example_metadata: no '- name:' entry found to replace in {path}")
-if not server_image_updated:
-    raise SystemExit(f"prepare_example_metadata: image field was not updated in {path}")
-if not server_image_tag_updated:
-    raise SystemExit(f"prepare_example_metadata: imageTag field was not updated in {path}")
-if not mcp_path_updated:
-    raise SystemExit(f"prepare_example_metadata: MCP_PATH env var was not updated in {path}")
-if not public_path_prefix_updated:
-    raise SystemExit(f"prepare_example_metadata: publicPathPrefix was not updated in {path}")
-if not resources_present:
-    raise SystemExit(f"prepare_example_metadata: resources were not inserted in {path}")
+if not env_inserted:
+    raise SystemExit(f"init_example_metadata: failed to insert MCP_PATH env var in {path}")
+if prefix and not public_path_prefix_seen:
+    final = []
+    inserted = False
+    for line in updated:
+        final.append(line)
+        stripped = line.lstrip()
+        indent = line[: len(line) - len(stripped)]
+        if not inserted and indent == server_field_indent and stripped.startswith("route: "):
+            final.append(f"{indent}publicPathPrefix: {prefix}")
+            inserted = True
+    updated = final
+    public_path_prefix_seen = inserted
+if prefix and not public_path_prefix_seen:
+    raise SystemExit(f"init_example_metadata: failed to set publicPathPrefix in {path}")
+if not resources_inserted:
+    raise SystemExit(f"init_example_metadata: failed to insert resources in {path}")
+
+# These sample servers are deployed directly into the local Kind namespace.
+# Leaving scope unset keeps server build on the local registry path instead of
+# resolving tenant registry ownership through platform credentials.
+updated = [
+    line for line in updated
+    if not (
+        server_field_indent is not None
+        and line[: len(line) - len(line.lstrip())] == server_field_indent
+        and line.lstrip().startswith("scope: ")
+    )
+]
+path.write_text("\n".join(updated) + "\n", encoding="utf-8")
 PY
 }
 
@@ -1985,6 +1940,7 @@ deploy_example_server_via_pipeline() {
   local route_path="$3"
   local example_source_dir="$4"
   local example_workspace_dir="$5"
+  local smoke_tool="$6"
   local image_repo
   local image_ref
 
@@ -1994,7 +1950,7 @@ deploy_example_server_via_pipeline() {
 
   image_repo="registry.registry.svc.cluster.local:5000/${server_name}"
   image_ref="${image_repo}:${E2E_WORKLOAD_TAG}"
-  prepare_example_metadata "${example_workspace_dir}/.mcp" "${server_name}" "${ingress_host}" "${route_path}" "${image_repo}" "${E2E_WORKLOAD_TAG}"
+  init_example_metadata "${example_workspace_dir}/.mcp" "${server_name}" "${route_path}" "${image_repo}" "${E2E_WORKLOAD_TAG}" "${smoke_tool}"
 
   if cache_mode_enabled && docker image inspect "${image_ref}" >/dev/null 2>&1; then
     echo "[cache] skipping example image build for ${image_ref}"
@@ -2664,6 +2620,9 @@ refresh_kind_kubeconfig() {
   local refreshed_kubeconfig
   local existing_ok=0
 
+  if [[ -s "${KUBECONFIG_FILE}" ]]; then
+    cp "${KUBECONFIG_FILE}" "${KUBECONFIG_BACKUP_FILE}" 2>/dev/null || true
+  fi
   if [[ -s "${KUBECONFIG_FILE}" ]] && KUBECONFIG="${KUBECONFIG_FILE}" kubectl cluster-info --request-timeout=5s >/dev/null 2>&1; then
     existing_ok=1
   fi
@@ -2671,14 +2630,19 @@ refresh_kind_kubeconfig() {
   refreshed_kubeconfig="$(mktemp)"
   if kind get kubeconfig --name "${CLUSTER_NAME}" > "${refreshed_kubeconfig}" 2>/dev/null && [[ -s "${refreshed_kubeconfig}" ]]; then
     mv "${refreshed_kubeconfig}" "${KUBECONFIG_FILE}"
+    cp "${KUBECONFIG_FILE}" "${KUBECONFIG_BACKUP_FILE}" 2>/dev/null || true
   else
     rm -f "${refreshed_kubeconfig}"
     if [[ "${existing_ok}" -eq 1 ]]; then
       echo "[kind][warn] could not refresh kubeconfig for ${CLUSTER_NAME}; reusing existing ${KUBECONFIG_FILE}" >&2
     elif [[ -s "${KUBECONFIG_FILE}" ]]; then
       echo "[kind][warn] could not refresh kubeconfig for ${CLUSTER_NAME}; reusing existing ${KUBECONFIG_FILE}" >&2
+    elif [[ -s "${KUBECONFIG_BACKUP_FILE}" ]]; then
+      cp "${KUBECONFIG_BACKUP_FILE}" "${KUBECONFIG_FILE}"
+      echo "[kind][warn] could not refresh kubeconfig for ${CLUSTER_NAME}; restored last-known-good kubeconfig" >&2
     elif kubectl config view --raw --minify > "${refreshed_kubeconfig}" 2>/dev/null && [[ -s "${refreshed_kubeconfig}" ]]; then
       mv "${refreshed_kubeconfig}" "${KUBECONFIG_FILE}"
+      cp "${KUBECONFIG_FILE}" "${KUBECONFIG_BACKUP_FILE}" 2>/dev/null || true
       echo "[kind][warn] could not refresh kubeconfig for ${CLUSTER_NAME}; captured current kubectl context" >&2
     else
       rm -f "${refreshed_kubeconfig}"
@@ -2998,19 +2962,22 @@ parallel_start "${E2E_EXAMPLE_DEPLOY_PARALLELISM}" "deploy ${PYTHON_EXAMPLE_SERV
   "${PYTHON_EXAMPLE_SERVER_HOST}" \
   "${PYTHON_EXAMPLE_SERVER_ROUTE}" \
   "${PYTHON_EXAMPLE_SOURCE_DIR}" \
-  "${PYTHON_EXAMPLE_WORKDIR}"
+  "${PYTHON_EXAMPLE_WORKDIR}" \
+  "echo"
 parallel_start "${E2E_EXAMPLE_DEPLOY_PARALLELISM}" "deploy ${RUST_EXAMPLE_SERVER_NAME}" deploy_example_server_via_pipeline \
   "${RUST_EXAMPLE_SERVER_NAME}" \
   "${RUST_EXAMPLE_SERVER_HOST}" \
   "${RUST_EXAMPLE_SERVER_ROUTE}" \
   "${RUST_EXAMPLE_SOURCE_DIR}" \
-  "${RUST_EXAMPLE_WORKDIR}"
+  "${RUST_EXAMPLE_WORKDIR}" \
+  "repeat"
 parallel_start "${E2E_EXAMPLE_DEPLOY_PARALLELISM}" "deploy ${GO_EXAMPLE_SERVER_NAME}" deploy_example_server_via_pipeline \
   "${GO_EXAMPLE_SERVER_NAME}" \
   "${GO_EXAMPLE_SERVER_HOST}" \
   "${GO_EXAMPLE_SERVER_ROUTE}" \
   "${GO_EXAMPLE_SOURCE_DIR}" \
-  "${GO_EXAMPLE_WORKDIR}"
+  "${GO_EXAMPLE_WORKDIR}" \
+  "lower"
 parallel_wait_all
 
 echo "[cli] checking server commands"
@@ -3106,47 +3073,27 @@ print(json.dumps(config, indent=2))
 PYEOF
 
 echo "[policy] applying access grant via CLI"
-cat >"${WORKDIR}/access-grant.yaml" <<EOF
-apiVersion: mcpruntime.org/v1alpha1
-kind: MCPAccessGrant
-metadata:
-  name: ${SERVER_NAME}-grant
-  namespace: mcp-servers
-spec:
-  serverRef:
-    name: ${SERVER_NAME}
-  subject:
-    humanID: ${HUMAN_ID}
-    agentID: ${AGENT_ID}
-  maxTrust: high
-  allowedSideEffects: [read]
-  policyVersion: v1
-  toolRules:
-    - name: aaa-ping
-      decision: allow
-    - name: echo
-      decision: allow
-    - name: upper
-      decision: allow
-EOF
+"${PROJECT_ROOT}/bin/mcp-runtime" access --use-kube grant init "${SERVER_NAME}-grant" \
+  --server "${SERVER_NAME}" \
+  --human-id "${HUMAN_ID}" \
+  --agent-id "${AGENT_ID}" \
+  --trust high \
+  --side-effect read \
+  --tool aaa-ping \
+  --tool echo \
+  --tool upper \
+  --output "${WORKDIR}/access-grant.yaml" \
+  --force
 (cd "${WORKDIR}" && "${PROJECT_ROOT}/bin/mcp-runtime" access --use-kube grant apply --file access-grant.yaml)
 
 echo "[policy] applying low-trust session via CLI"
-cat >"${WORKDIR}/access-session.yaml" <<EOF
-apiVersion: mcpruntime.org/v1alpha1
-kind: MCPAgentSession
-metadata:
-  name: ${SESSION_ID}
-  namespace: mcp-servers
-spec:
-  serverRef:
-    name: ${SERVER_NAME}
-  subject:
-    humanID: ${HUMAN_ID}
-    agentID: ${AGENT_ID}
-  consentedTrust: low
-  policyVersion: v1
-EOF
+"${PROJECT_ROOT}/bin/mcp-runtime" access --use-kube session init "${SESSION_ID}" \
+  --server "${SERVER_NAME}" \
+  --human-id "${HUMAN_ID}" \
+  --agent-id "${AGENT_ID}" \
+  --trust low \
+  --output "${WORKDIR}/access-session.yaml" \
+  --force
 (cd "${WORKDIR}" && "${PROJECT_ROOT}/bin/mcp-runtime" access --use-kube session apply --file access-session.yaml)
 
 wait_for_policy_text "\"name\": \"${SESSION_ID}\""

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -3079,9 +3079,9 @@ echo "[policy] applying access grant via CLI"
   --agent-id "${AGENT_ID}" \
   --trust high \
   --side-effect read \
-  --tool aaa-ping \
-  --tool echo \
-  --tool upper \
+  --tool-rule aaa-ping:allow:low \
+  --tool-rule echo:allow:low \
+  --tool-rule upper:allow:medium \
   --output "${WORKDIR}/access-grant.yaml" \
   --force
 (cd "${WORKDIR}" && "${PROJECT_ROOT}/bin/mcp-runtime" access --use-kube grant apply --file access-grant.yaml)

--- a/test/golden/cli/testdata/mcp-runtime_auth_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_auth_help.golden
@@ -7,7 +7,7 @@ The token is stored in a local file (mode 0600) under the user config directory,
 
 Optional environment:
   MCP_PLATFORM_API_URL      default API base for login, e.g. https://platform.example.com
-  MCP_PLATFORM_API_TOKEN    use this token for API calls; overrides a saved file
+  MCP_PLATFORM_API_TOKEN    use this token for API calls; overrides the saved token
   MCP_PLATFORM_API_PROFILE  select a saved credentials profile
   MCP_RUNTIME_CONFIG_DIR    override the config directory (default ~/.mcpruntime)
 

--- a/test/golden/cli/testdata/mcp-runtime_registry_push_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_registry_push_help.golden
@@ -1,4 +1,4 @@
-Save a local image and push it to the platform registry through the platform API. Requires `mcp-runtime auth login` or MCP_PLATFORM_API_TOKEN plus MCP_PLATFORM_API_URL.
+Save a local image and push it to the platform registry through the platform API. Requires `mcp-runtime auth login` or MCP_PLATFORM_API_TOKEN with a saved or explicit MCP_PLATFORM_API_URL.
 
 Usage:
   mcp-runtime registry push [flags]

--- a/test/golden/cli/testdata/mcp-runtime_server_init_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_server_init_help.golden
@@ -4,15 +4,18 @@ Usage:
   mcp-runtime server init [name] [flags]
 
 Flags:
-      --force                   Replace an existing metadata entry with the same server name
-  -h, --help                    help for init
-      --image string            Container image repository (default: server name)
-      --metadata-dir string     Directory where servers.yaml will be written (default ".mcp")
-      --port int32              Container port (default 8088)
-      --scope string            Publish scope: tenant, org, or public (default "tenant")
-      --tag string              Container image tag (default "latest")
-      --tool stringArray        Tool name to add with read side-effect metadata; repeat for multiple tools
-      --tool-spec stringArray   Tool metadata as name:low|medium|high:read|write|destructive; repeat for mixed trust or side effects
+      --default-decision string   Default policy decision: allow or deny (default "deny")
+      --force                     Replace an existing metadata entry with the same server name
+  -h, --help                      help for init
+      --image string              Container image repository (default: server name)
+      --metadata-dir string       Directory where servers.yaml will be written (default ".mcp")
+      --policy-mode string        Policy mode: allow-list or observe (default "allow-list")
+      --port int32                Container port (default 8088)
+      --scope string              Publish scope: tenant, org, or public (default "tenant")
+      --session-required          Require adapter-issued agent sessions (default true)
+      --tag string                Container image tag (default "latest")
+      --tool stringArray          Tool name to add with read side-effect metadata; repeat for multiple tools
+      --tool-spec stringArray     Tool metadata as name:low|medium|high:read|write|destructive; repeat for mixed trust or side effects
 
 Global Flags:
       --debug      Enable debug mode with structured error logging


### PR DESCRIPTION
## Summary
- keep `server init` metadata focused on user-facing governance intent while omitting platform-managed gateway wiring
- add init flags for policy mode, default policy decision, and session-required behavior
- let env API tokens reuse a saved profile API URL when `MCP_PLATFORM_API_URL` is unset
- harden Kind E2E kubeconfig refresh with a last-known-good backup

## Validation
- pre-commit hooks during commit: gitleaks, go fmt, staticcheck, go vet, go unit tests, generated-file drift
- `go test ./internal/cli/server ./pkg/authfile ./internal/cli/auth ./internal/cli/registry ./test/golden/... -count=1`
- `bash -n test/e2e/kind.sh`