### PR TITLE
feat(cli): server validate, server init --from-server, preflight Kafka check, CLI docs rewrite

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,239 +1,199 @@
 # CLI reference
 
-`mcp-runtime` is the single binary for the entire platform — from cluster bootstrap
-through server deployment, access policy, and runtime observability. Commands are
-grouped into families; each family has a dedicated doc page linked below.
+`mcp-runtime` is the single binary for the entire platform — cluster setup, server
+deployment, access policy, and observability. This page covers every command group
+with role markers, key flags, and links to the full guide for each family.
+
+---
 
 ## Who can run what
 
-Two access layers control what each command can do:
-
-| Layer | How to authenticate | Commands |
+| Badge | Role | How to authenticate |
 |---|---|---|
-| **Platform API** | `auth login` → token saved in `~/.mcpruntime/config.json` | `server`, `access`, `registry push`, `team`, `adapter` |
-| **Kubernetes (admin)** | `KUBECONFIG` / kubeconfig file with cluster-admin RBAC | `bootstrap`, `setup`, `cluster`, `sentinel`, `server --use-kube`, `access --use-kube` |
+| 👤 **User** | Team member deploying servers | `mcp-runtime auth login` (token in `~/.mcpruntime/`) |
+| 🔑 **Admin** | Platform admin or operator with kube access | Platform API admin role **or** `--use-kube` + cluster-admin RBAC |
+| ⚙️ **Operator** | Cluster operator | `KUBECONFIG` with cluster-admin RBAC, no platform login needed |
 
-> **Quick rule:** if you're a developer or team member deploying MCP servers, use Platform API
-> commands. If you're an operator setting up the cluster or debugging the stack, use the
-> Kubernetes commands.
+> **Quick rule:** developers and team members use 👤 commands. Cluster operators use ⚙️ commands. Platform admins use 🔑 commands for team/user management.
 
-### Role legend used in this page
+---
 
-| Badge | Meaning |
-|---|---|
-| 👤 **User** | Platform API; requires `auth login` or `MCP_PLATFORM_API_TOKEN` |
-| 🔑 **Admin** | Platform API admin role *or* `--use-kube` (cluster-admin RBAC) |
-| ⚙️ **Operator** | Kubernetes only; cluster-admin RBAC required |
+## Profiles (saved credentials)
 
-## Credentials and profiles
-
-Login credentials are stored locally at `~/.mcpruntime/config.json`. Each login is
-saved as a **named profile** so you can switch between admin, team user, and
-multi-tenant identities without re-typing credentials.
+Credentials are saved locally in `~/.mcpruntime/config.json`. Each login is a
+named **profile** so you can switch between identities without re-typing passwords.
 
 ```bash
-# Save credentials under the default profile
-mcp-runtime auth login --api-url https://platform.mcpruntime.org
+# Log in (saved as the default profile)
+mcp-runtime auth login --api-url https://platform.example.com
 
-# Save under a named profile
-mcp-runtime auth login --api-url https://platform.mcpruntime.org \
+# Log in under a named profile
+mcp-runtime auth login --api-url https://platform.example.com \
   --email admin@example.com --password '...' --profile admin
 
-# Switch the active profile
+# Switch the active profile for all subsequent commands
 mcp-runtime auth use admin
 mcp-runtime auth use acme-owner
 
-# Use a profile for a single command without switching
-MCP_PLATFORM_API_PROFILE=admin mcp-runtime server list
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime team list
+# Use a different profile for one command only
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team list
 
-# Check which profile is active and what token it holds
+# See which profile is active
 mcp-runtime auth status
 ```
 
-**Environment overrides** (take precedence over saved profiles):
+**Environment overrides** (take precedence over any saved profile):
 
 | Variable | Effect |
 |---|---|
 | `MCP_PLATFORM_API_TOKEN` | Use this token instead of the saved one |
-| `MCP_PLATFORM_API_URL` | Override the saved API base URL |
-| `MCP_PLATFORM_API_PROFILE` | Select a saved profile without switching the current one |
+| `MCP_PLATFORM_API_URL` | Override the API base URL |
+| `MCP_PLATFORM_API_PROFILE` | Pick a profile for one command without switching |
 
-## Fast path
-
-```bash
-# Operator: cluster + platform install
-mcp-runtime bootstrap
-mcp-runtime setup --env-file config/deployments/mcpruntime-org.env
-
-# Developer: log in, deploy a server, grant access
-mcp-runtime auth login --api-url https://platform.mcpruntime.org
-mcp-runtime server init payments --tool list_invoices
-mcp-runtime server build image payments --tag v1
-mcp-runtime registry push --image <image-ref> --scope tenant
-mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
-
-mcp-runtime access grant init payments-ops \
-  --server payments --agent-id ops-agent --tool list_invoices --output grant.yaml
-mcp-runtime access grant apply --file grant.yaml
-
-# Check everything
-mcp-runtime status
-```
-
-Use built-in help for the exact flags and defaults of any command:
-
-```bash
-mcp-runtime --help
-mcp-runtime <group> --help
-mcp-runtime <group> <subcommand> --help
-```
+---
 
 ## Command map
 
-| Group | Role | What it covers | Full reference |
+| Command | Role | What it does | Guide |
 |---|---|---|---|
-| `auth` | 👤 User | Save and switch platform API credentials | [this page §auth](#auth) |
-| `status` | 👤 User | Aggregated platform health summary | [this page §status](#status) |
-| `server` | 👤 User / 🔑 Admin | Deploy and manage `MCPServer` resources | [Publish an MCP Server](publish-mcp-server.md) |
-| `registry` | 👤 User / ⚙️ Operator | Push images; inspect and provision the registry | [this page §registry](#registry) |
-| `access` | 👤 User / 🔑 Admin | Manage access grants and agent sessions | [API reference](api.md) |
-| `adapter` | 👤 User | HTTP proxy and stdio shims for agent runtimes | [Agent adapters](agent-adapters.md) |
-| `team` | 🔑 Admin | Manage platform teams and team users | [Multi-team isolation](multi-team.md) |
-| `sentinel` | ⚙️ Operator | Inspect and operate the analytics/observability stack | [Sentinel](sentinel.md) |
-| `bootstrap` | ⚙️ Operator | Preflight checks for cluster prerequisites | [Cluster readiness](cluster-readiness.md) |
-| `setup` | ⚙️ Operator | Full platform install: operator, registry, TLS, sentinel | [this page §setup](#setup) |
-| `cluster` | ⚙️ Operator | Initialize, configure, provision clusters; cert-manager | [Deployment targets](deployment-targets.md) |
-| `completion` | 👤 User | Shell completion scripts | — |
+| `auth` | 👤 | Save and switch platform credentials | [§ auth](#auth) |
+| `status` | 👤 | Platform health at a glance | [§ status](#status) |
+| `server` | 👤 / 🔑 | Scaffold, build, deploy, and manage servers | [Publish a server](publish-mcp-server.md) |
+| `registry` | 👤 / ⚙️ | Push images; inspect and configure the registry | [§ registry](#registry) |
+| `access` | 👤 / 🔑 | Grants and sessions for the gateway policy | [API reference](api.md) |
+| `adapter` | 👤 | HTTP proxy and stdio shim for agents | [Agent adapters](agent-adapters.md) |
+| `team` | 🔑 | Create teams and add users | [Multi-team](multi-team.md) |
+| `sentinel` | ⚙️ | Inspect and operate the analytics stack | [Sentinel](sentinel.md) |
+| `bootstrap` | ⚙️ | Pre-install cluster checks | [Cluster readiness](cluster-readiness.md) |
+| `setup` | ⚙️ | Install the full platform stack | [§ setup](#setup) |
+| `cluster` | ⚙️ | Initialize clusters and manage cert-manager | [Deployment targets](deployment-targets.md) |
+
+---
+
+## Typical end-to-end flow
+
+```
+Operator          → bootstrap → setup
+Admin             → team create → team user create
+Developer         → auth login → server init → server validate
+                  → server build image → registry push → server deploy
+Admin             → access grant init → access grant apply
+                  → access session init → access session apply
+Agent / Developer → adapter proxy  (or adapter stdio)
+```
 
 ---
 
 ## auth
 
-👤 **User** — platform API credentials only; no Kubernetes required.
-
-Save tokens locally and switch between profiles for multi-platform or multi-role
-workflows. These credentials are used by `server`, `access`, `registry push`,
-`team`, and `adapter` commands.
+👤 **User**
 
 ```bash
-# Interactive login (prompts for token)
-mcp-runtime auth login --api-url https://platform.mcpruntime.org
+# Interactive
+mcp-runtime auth login --api-url https://platform.example.com
 
-# Non-interactive (CI / scripted)
-mcp-runtime auth login --api-url https://platform.mcpruntime.org --token-stdin < token.txt
+# Non-interactive (CI)
+mcp-runtime auth login --api-url https://platform.example.com --token-stdin < token.txt
 
-# Email + password login
-mcp-runtime auth login \
-  --api-url https://platform.mcpruntime.org \
-  --email admin@example.com --password '...' --profile admin
+# Email + password
+mcp-runtime auth login --api-url https://platform.example.com \
+  --email alice@example.com --password '...' --profile alice
 
-# Record the registry host alongside the token
-mcp-runtime auth login \
-  --api-url https://platform.mcpruntime.org \
-  --token-stdin --registry-host registry.mcpruntime.org < token.txt
-
-# Switch profiles
-mcp-runtime auth use admin
-mcp-runtime auth use acme-owner
-
-# Check active credentials
+# Switch / inspect / remove
+mcp-runtime auth use alice
 mcp-runtime auth status
-
-# Remove saved credentials
 mcp-runtime auth logout
 ```
-
-Notes:
-- Credentials live in `~/.mcpruntime/config.json` (mode 0600)
-- Each `auth login` saves a profile and makes it current
-- `MCP_PLATFORM_API_PROFILE` selects a profile for a single command without switching
 
 ---
 
 ## status
 
-👤 **User** — reads from the platform API and from Kubernetes if kubeconfig is available.
+👤 **User** (kubeconfig optional for cluster detail)
 
 ```bash
-mcp-runtime status           # aggregated: cluster, registry, operator, sentinel
-mcp-runtime cluster status   # cluster-level health
-mcp-runtime registry status  # registry deployment + endpoint
-mcp-runtime sentinel status  # sentinel stack (needs kubeconfig)
+mcp-runtime status                          # overall: registry, operator, API
+mcp-runtime registry status                 # registry pod + endpoint
+KUBECONFIG=~/.kube/config mcp-runtime sentinel status   # sentinel stack
 ```
 
 ---
 
 ## server
 
-👤 **User** by default (platform API) · 🔑 **Admin** with `--use-kube`.
-
-Scaffold, build, push, and deploy `MCPServer` resources. Most day-to-day operations
-go through the platform API — only manifest-level operations (`create`, `apply`,
-`patch`, `logs`, `export`) require `--use-kube` and cluster-admin RBAC.
+👤 **User** by default · 🔑 **Admin** with `--use-kube`
 
 > **Full guide:** [Publish an MCP Server](publish-mcp-server.md)
 
-### Platform API commands (👤 User)
+Most day-to-day work uses the platform API. Direct CRD operations (`create`,
+`apply`, `patch`, `logs`, `export`) require `--use-kube` and cluster-admin RBAC.
+
+### Step 1 — scaffold metadata
+
+Tool names in `.mcp/servers.yaml` **must match** your server's actual tool
+implementations. Use `--from-server` to discover them automatically:
 
 ```bash
-mcp-runtime auth login --api-url https://platform.mcpruntime.org
+# Recommended: run your server locally, then discover tool names automatically
+go run . &                                          # start your MCP server
+mcp-runtime server init payments \
+  --from-server http://localhost:8088               # discovers real tool names
+                                                    # /mcp appended automatically
 
-# List and inspect
+# Manual: if you already know your tool names
+mcp-runtime server init payments \
+  --tool list_invoices \
+  --tool-spec refund_invoice:high:destructive       # name:trust:side-effect
+```
+
+### Step 2 — validate before building
+
+Catches mismatches (missing tools, wrong side effects) that would cause
+`tool_side_effect_unknown` errors at the gateway:
+
+```bash
+mcp-runtime server validate --metadata-dir .mcp
+mcp-runtime server validate --metadata-dir .mcp --grant-file grant.yaml
+mcp-runtime server validate --metadata-dir .mcp --from-server http://localhost:8088
+```
+
+### Step 3 — build, push, deploy
+
+```bash
+mcp-runtime server build image payments --tag v1 --platform linux/amd64
+mcp-runtime registry push --image <exact-ref-from-build> --scope tenant
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp --update   # re-deploy
+```
+
+`--scope` values: `tenant` (your team namespace), `org`, `public`.
+
+### Inspect
+
+```bash
 mcp-runtime server list
-mcp-runtime server get payments --namespace mcp-team-acme   # always pass --namespace for team servers
-mcp-runtime server status
+mcp-runtime server get payments --namespace mcp-team-acme   # --namespace required for team servers
 mcp-runtime server status --namespace mcp-team-acme
 mcp-runtime server policy inspect payments --namespace mcp-team-acme
-
-# Scaffold server metadata
-# Option A: manually specify tools (names MUST match your server implementation)
-mcp-runtime server init payments --tool list_invoices --tool refund_invoice
-mcp-runtime server init payments --tool-spec list_invoices:low:read --tool-spec refund_invoice:high:destructive
-
-# Option B: auto-discover tools from a locally running MCP server (recommended)
-# Run your server locally first, then:
-mcp-runtime server init payments --from-server http://localhost:8088
-
-# Validate metadata and grant/session YAML before deploying (catches tool name mismatches)
-mcp-runtime server validate --metadata-dir .mcp
-mcp-runtime server validate --metadata-dir .mcp --grant-file grant.yaml --session-file session.yaml
-mcp-runtime server validate --metadata-dir .mcp --from-server http://localhost:8088   # verify against live server
-
-# Build the image
-mcp-runtime server build image payments --tag v1 --platform linux/amd64
-
-# Deploy (after pushing the image)
-mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
-mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp --update   # redeploy
-
-# Delete
 mcp-runtime server delete payments
-
-# Generate GitOps manifests
-mcp-runtime server generate --metadata-dir .mcp --output manifests/
+mcp-runtime server generate --metadata-dir .mcp --output manifests/   # GitOps YAML
 ```
 
-### Admin / operator commands (🔑 --use-kube)
+### Admin / operator (🔑 --use-kube)
 
 ```bash
-# Direct CRD operations — requires cluster-admin RBAC
-mcp-runtime server create payments --image repo/payments --tag latest --use-kube
-mcp-runtime server create payments --file server.yaml --use-kube
-mcp-runtime server apply --file server.yaml --use-kube
-mcp-runtime server export payments --file payments.yaml --use-kube
-mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
-mcp-runtime server logs payments --follow --use-kube
+mcp-runtime server create payments --image repo/payments --tag v1 --use-kube
+mcp-runtime server apply  --file server.yaml --use-kube
+mcp-runtime server export payments --use-kube
+mcp-runtime server patch  payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
+mcp-runtime server logs   payments --follow --use-kube
 ```
-
-`--scope` values: `tenant` (team namespace), `org` (`mcp-servers-org`), `public` (`mcp-servers-public`).
-`server deploy --update` is required for repeat deploys of the same server name.
 
 ---
 
 ## registry
 
-👤 **User** for `push` · ⚙️ **Operator** for `provision` and `status`.
+👤 **User** for `push` · ⚙️ **Operator** for `status`, `info`, `provision`
 
 ```bash
 # Inspect (operator)
@@ -242,205 +202,190 @@ mcp-runtime registry info
 
 # Configure an external registry (operator)
 mcp-runtime registry provision --url registry.example.com
-mcp-runtime registry provision \
-  --url registry.example.com \
-  --operator-image registry.example.com/mcp-runtime-operator:latest
 
-# Push images (user — requires auth login)
-mcp-runtime registry push --image registry.mcpruntime.org/payments:v1
-mcp-runtime registry push --image payments:v1 --name payments-api --scope tenant
-mcp-runtime registry push --scope public --image payments:v1
+# Push an image (user — requires auth login)
+mcp-runtime registry push --image <exact-ref-from-server-build> --scope tenant
+mcp-runtime registry push --image payments:v1 --scope public
 ```
 
-`registry push` uploads via `POST /api/runtime/registry/push`; the platform API
-pushes the image from inside the cluster. Always push the **exact ref** produced
-by `server build image`.
+Always push the **exact image ref** that `server build image` printed.
 
 ---
 
 ## access
 
-👤 **User** for grant read/write · 🔑 **Admin** for session `apply` and `--use-kube` flows.
+👤 **User** for grants · 🔑 **Admin** for session `apply`
 
-Manage `MCPAccessGrant` and `MCPAgentSession` CRDs that feed the gateway policy layer.
-Most developers scaffold a grant with `init`, review the YAML, then `apply` through
-the platform API. Session creation for agents is usually handled automatically by
-`adapter stdio/proxy --auto-refresh`.
+> **Full reference:** [API reference](api.md)
 
-> **Full reference:** [API reference — access fields](api.md)
+> ⚠️ **Tool names in grants must match `.mcp/servers.yaml` exactly.** If a
+> `toolRule` names a tool absent from the metadata, the gateway returns
+> `tool_side_effect_unknown`. Run `server validate --grant-file grant.yaml`
+> before applying.
 
-> ⚠️ **Tool names must match exactly.** Grant `toolRules` reference tool names
-> from your server's `.mcp/servers.yaml`. If a grant rule names a tool that is
-> not in the metadata the gateway returns `tool_side_effect_unknown` and denies
-> the call. Run `server validate --grant-file grant.yaml` before applying to
-> catch mismatches early. Use `server init --from-server http://localhost:<port>`
-> to populate metadata with the real tool names from your running server.
+### Grants (👤 User)
 
 ```bash
-mcp-runtime auth login --api-url https://platform.mcpruntime.org
-
-# Grants (👤 User)
+# Scaffold a grant YAML
 mcp-runtime access grant init payments-ops \
-  --server payments --agent-id ops-agent \
-  --tool list_invoices --tool-rule refund_invoice:allow:high \
+  --server payments --namespace mcp-team-acme \
+  --agent-id cursor \
+  --tool list_invoices \
+  --tool-rule refund_invoice:allow:high \   # name:allow|deny:trust
   --output grant.yaml
-mcp-runtime access grant apply --file grant.yaml
-mcp-runtime access grant list
-mcp-runtime access grant list --namespace mcp-team-acme
-mcp-runtime access grant get payments-ops
-mcp-runtime access grant disable payments-ops
-mcp-runtime access grant enable payments-ops
-mcp-runtime access grant delete payments-ops
 
-# Sessions (🔑 Admin — session apply via platform API requires admin role)
-mcp-runtime access session init cursor-session \
-  --server payments --human-id <user-id> --agent-id cursor \
-  --trust medium --expires-in 1h --output session.yaml
-mcp-runtime access session apply --file session.yaml   # admin only
-mcp-runtime access session list
-mcp-runtime access session get cursor-session
-mcp-runtime access session revoke cursor-session
-mcp-runtime access session unrevoke cursor-session
+# Validate grant before applying
+mcp-runtime server validate --metadata-dir .mcp --grant-file grant.yaml
+
+# Apply / manage
+mcp-runtime access grant apply  --file grant.yaml
+mcp-runtime access grant list
+mcp-runtime access grant list   --namespace mcp-team-acme
+mcp-runtime access grant get    payments-ops --namespace mcp-team-acme
+mcp-runtime access grant disable payments-ops --namespace mcp-team-acme
+mcp-runtime access grant enable  payments-ops --namespace mcp-team-acme
+mcp-runtime access grant delete  payments-ops --namespace mcp-team-acme
 ```
 
-`grant list` and `session list` default to `--all-namespaces`; pass `--namespace` to
-narrow scope.
+### Sessions (🔑 Admin for `apply`)
 
-**Cross-team access** — a Team A owner can grant Team B users access to Team A's servers.
-Set `--team-id <globex-team-uuid>` on `grant init` to scope the grant to Team B agents,
-then apply from Team A's credentials. Team B agents get sessions via `adapter --auto-refresh`
-or an admin applies a session using `session apply` with the same `teamID` in `spec.subject`.
+Agents normally get sessions automatically via `adapter --auto-refresh`. Use
+`session init` + `session apply` only when you need an explicit session.
 
 ```bash
-# acme-owner grants globex team's cursor agent access to payments
-MCP_PLATFORM_API_PROFILE=acme-owner \
-  mcp-runtime access grant init payments-globex \
-    --server payments --namespace mcp-team-acme \
-    --team-id <globex-team-uuid> --agent-id cursor \
-    --tool list_invoices --output grant.yaml
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant apply --file grant.yaml
+mcp-runtime access session init cursor-session \
+  --server payments --namespace mcp-team-acme \
+  --agent-id cursor --trust low --expires-in 2h \
+  --output session.yaml
 
-# Admin creates the cross-team session
-MCP_PLATFORM_API_PROFILE=admin \
-  mcp-runtime access session init globex-session \
-    --server payments --namespace mcp-team-acme \
-    --team-id <globex-team-uuid> --agent-id cursor \
-    --trust low --expires-in 2h --output session.yaml
+mcp-runtime access session apply    --file session.yaml   # admin only
+mcp-runtime access session list
+mcp-runtime access session get      cursor-session --namespace mcp-team-acme
+mcp-runtime access session revoke   cursor-session --namespace mcp-team-acme
+mcp-runtime access session unrevoke cursor-session --namespace mcp-team-acme
+```
+
+### Cross-team access
+
+Team A can grant Team B's agents access to Team A's servers:
+
+```bash
+# Team A owner grants Team B's cursor agent access to payments
+mcp-runtime access grant init payments-to-teamB \
+  --server payments --namespace mcp-team-acme \
+  --team-id <team-b-uuid> --agent-id cursor \
+  --tool list_invoices --output grant.yaml
+mcp-runtime access grant apply --file grant.yaml
+
+# Admin creates a session for Team B's agent
+mcp-runtime access session init teamB-session \
+  --server payments --namespace mcp-team-acme \
+  --team-id <team-b-uuid> --agent-id cursor \
+  --trust low --expires-in 2h --output session.yaml
 MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session apply --file session.yaml
 ```
 
-See [Multi-team isolation](multi-team.md) for namespace layout and RBAC details.
+See [Multi-team isolation](multi-team.md) for namespace layout and RBAC.
 
 ---
 
 ## adapter
 
-👤 **User** — for agent runtimes that need platform-governed identity headers.
-
-Run an HTTP reverse proxy or a stdio shim that injects `x-mcp-human-id`,
-`x-mcp-agent-id`, `x-mcp-session-id`, and other governance headers before
-requests reach the MCP server. Adapters create agent sessions automatically
-when `--auto-refresh` is set.
+👤 **User** — injects governance headers before requests reach the MCP server.
 
 > **Full guide:** [Agent adapters](agent-adapters.md)
 
+When `--server` is set the adapter creates a platform session automatically
+(`--auto-refresh` keeps it alive). Use `--agent-id` to set the agent identity
+header sent to the server.
+
 ```bash
-# HTTP reverse proxy
+# HTTP reverse proxy (agents call http://127.0.0.1:8099)
 mcp-runtime adapter proxy \
-  --runtime-url https://platform.mcpruntime.org/payments/mcp \
-  --server payments --agent my-agent \
-  --auto-refresh
+  --runtime-url https://mcp.example.com/payments/mcp \
+  --server payments \
+  --agent cursor \
+  --agent-id cursor \
+  --auto-refresh \
+  --listen 127.0.0.1:8099
 
 # stdio shim (for Claude Desktop / local agent processes)
 mcp-runtime adapter stdio \
-  --runtime-url https://platform.mcpruntime.org/payments/mcp \
-  --server payments --agent my-agent \
+  --runtime-url https://mcp.example.com/payments/mcp \
+  --server payments \
+  --agent cursor \
+  --agent-id cursor \
   --auto-refresh
 ```
 
-Both adapters use the active platform credentials (`auth login` profile or
-`MCP_PLATFORM_API_TOKEN`) to authenticate session creation with the platform API.
+`--agent` is the session name (used to create/refresh the platform session).
+`--agent-id` is the identity injected as `X-MCP-Agent-ID` on each request.
 
 ---
 
 ## team
 
-🔑 **Admin** — all `team` commands require platform API admin role.
-
-Create and manage platform teams. Each team gets a dedicated Kubernetes namespace
-with quota, NetworkPolicy, service account, and ingress wiring.
+🔑 **Admin** — all `team` commands require the platform API admin role.
 
 > **Full guide:** [Multi-team isolation](multi-team.md)
 
 ```bash
-mcp-runtime auth login --api-url https://platform.mcpruntime.org --profile admin
 MCP_PLATFORM_API_PROFILE=admin mcp-runtime team list
 
-# Create a team
-mcp-runtime team create acme --name "Acme Corp"
+# Create a team (also creates the Kubernetes namespace with RBAC)
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team create acme --name "Acme Corp"
 
-# Add a password-login user to the team
-mcp-runtime team user create acme \
-  --username acme-dev@example.com --password '...' --role member
-mcp-runtime team user list acme
+# Add a password-login user
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team user create acme \
+  --username alice@example.com --password '...' --role owner
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team user list acme
 ```
 
-`team user create` creates or updates a password user and adds them to the team as
-`member` or `owner`. Users then log in with `auth login --email ... --password ...`.
+Users log in with `auth login --email alice@example.com --password '...'`.
 
-> ⚠️ `team init` is **deprecated** and rejects at runtime. Use `team create`.
+> ⚠️ `team init` is **deprecated**. Use `team create`.
 
 ---
 
 ## sentinel
 
-⚙️ **Operator** — requires `KUBECONFIG` pointing at a cluster with admin RBAC.
-Normal users should use the platform dashboard or top-level `mcp-runtime status`.
-
-Inspect and operate the bundled analytics, gateway, and observability stack.
+⚙️ **Operator** — requires `KUBECONFIG` with cluster-admin RBAC.
 
 > **Full guide:** [Sentinel](sentinel.md)
 
 ```bash
-# Health + events
 KUBECONFIG=~/.kube/config mcp-runtime sentinel status
 KUBECONFIG=~/.kube/config mcp-runtime sentinel events
 
-# Logs (--follow / --tail / --since / --previous)
+# Logs
 KUBECONFIG=~/.kube/config mcp-runtime sentinel logs api --since 15m --follow
-KUBECONFIG=~/.kube/config mcp-runtime sentinel logs grafana --tail 500
+KUBECONFIG=~/.kube/config mcp-runtime sentinel logs ingest --tail 200
 
-# Restart a component
+# Restart
 KUBECONFIG=~/.kube/config mcp-runtime sentinel restart gateway
 KUBECONFIG=~/.kube/config mcp-runtime sentinel restart --all
 
-# Port-forward shortcuts
-KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward ui
-KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward api --port 18080
+# Open a local port to a component
+KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward ui      # :8082
+KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward grafana # :3000
 ```
 
-**Component keys** for `logs` and `restart`:
-`clickhouse`, `zookeeper`, `kafka`, `ingest`, `api`, `processor`, `ui`, `gateway`,
-`prometheus`, `grafana`, `otel-collector`, `tempo`, `loki`, `promtail`.
-
-**Built-in port-forward shortcuts:** `api`, `ui`, `prometheus`, `grafana`.
+Component names for `logs` / `restart`:
+`clickhouse`, `zookeeper`, `kafka`, `ingest`, `processor`, `api`, `ui`,
+`gateway`, `prometheus`, `grafana`, `otel-collector`, `tempo`, `loki`, `promtail`.
 
 ---
 
 ## bootstrap
 
-⚙️ **Operator** — run on a fresh cluster before `setup`.
-
-Validate kubectl connectivity, CoreDNS, default `StorageClass`, Traefik
-`IngressClass`, and MetalLB availability. Missing pieces are reported as warnings
-so you can decide what to install.
+⚙️ **Operator** — run before `setup` on a fresh cluster.
 
 > **Full guide:** [Cluster readiness](cluster-readiness.md)
 
 ```bash
-mcp-runtime bootstrap
-mcp-runtime bootstrap --provider k3s
-mcp-runtime bootstrap --apply --provider k3s   # automated fix — k3s only
+mcp-runtime bootstrap                        # check DNS, StorageClass, IngressClass
+mcp-runtime bootstrap --provider k3s        # k3s-aware checks
+mcp-runtime bootstrap --apply --provider k3s  # auto-fix on k3s (installs CoreDNS etc.)
 ```
 
 ---
@@ -449,168 +394,135 @@ mcp-runtime bootstrap --apply --provider k3s   # automated fix — k3s only
 
 ⚙️ **Operator** — installs the full platform stack.
 
-Install the runtime namespace, internal registry, operator, ingress wiring, and
-the bundled sentinel analytics stack. Setup is reconcile-oriented and runs
-pre-flight checks before applying state.
+Runs pre-flight checks before applying anything. Use `--env-file` to drive all
+flags from a file (see `config/deployments/mcpruntime-org.env.example`):
 
 ```bash
-# Minimal (all flags from env file)
+# Recommended: drive everything from an env file
 mcp-runtime setup --env-file config/deployments/mcpruntime-org.env
 
-# Common flags
-mcp-runtime setup --with-tls --tls-cluster-issuer letsencrypt-prod \
-  --registry-mode bundled-https --platform-mode tenant --ingress none
+# Common flags (same as env vars below)
+mcp-runtime setup \
+  --with-tls --tls-cluster-issuer letsencrypt-prod \
+  --registry-mode bundled-https \
+  --platform-mode tenant \
+  --ingress none
 
-mcp-runtime setup --with-tls --acme-email ops@example.com  # Let's Encrypt
-mcp-runtime setup --platform-mode public                   # anonymous catalog
-mcp-runtime setup --without-sentinel                       # skip analytics stack
-mcp-runtime setup --test-mode                              # local Kind dev path
-mcp-runtime setup --registry-mode external \
-  --external-registry-url registry.example.com
+mcp-runtime setup --with-tls --acme-email ops@example.com   # Let's Encrypt
+mcp-runtime setup --without-sentinel                         # skip analytics
+mcp-runtime setup --test-mode                                # local Kind dev
 ```
 
-**Key env vars** (used with `--env-file`; see `config/deployments/mcpruntime-org.env.example`):
+**Key env vars** (`--env-file` equivalents):
 
-| Variable | Flag equivalent |
+| Env var | Flag |
 |---|---|
+| `MCP_PLATFORM_DOMAIN=example.com` | derives `registry.`, `mcp.`, `platform.` hostnames |
 | `MCP_SETUP_WITH_TLS=1` | `--with-tls` |
 | `MCP_SETUP_TLS_CLUSTER_ISSUER=letsencrypt-prod` | `--tls-cluster-issuer` |
 | `MCP_SETUP_REGISTRY_MODE=bundled-https` | `--registry-mode` |
 | `MCP_SETUP_PLATFORM_MODE=tenant` | `--platform-mode` |
 | `MCP_SETUP_INGRESS=none` | `--ingress` |
 | `MCP_SETUP_SKIP_CERT_MANAGER_INSTALL=1` | `--skip-cert-manager-install` |
-| `MCP_PLATFORM_DOMAIN=mcpruntime.org` | derives all three ingress hostnames |
 
-`--platform-mode` accepts `tenant` (default), `org`, or `public`.
-`--registry-mode` accepts `auto`, `bundled-http`, `bundled-https`, or `external`.
+`--registry-mode`: `auto` · `bundled-http` · `bundled-https` · `external`
+`--platform-mode`: `tenant` (default) · `org` · `public`
 
 ---
 
 ## cluster
 
-⚙️ **Operator** — Kubernetes cluster operations.
-
-Initialize CRDs and namespaces, configure ingress, provision new clusters, and
-manage cert-manager. Most subcommands require a kubeconfig with cluster-admin RBAC.
+⚙️ **Operator**
 
 > **Full guide:** [Deployment targets](deployment-targets.md)
 
 ```bash
-# Initialize / re-target
-mcp-runtime cluster init
-mcp-runtime cluster init --kubeconfig ~/.kube/config --context dev
+mcp-runtime cluster init                                         # install CRDs + namespaces
+mcp-runtime cluster config --ingress traefik                     # configure ingress
+mcp-runtime cluster provision --provider kind --nodes 3          # create a Kind cluster
+mcp-runtime cluster provision --provider eks --name prod-mcp
 
-# Configure ingress
-mcp-runtime cluster config --ingress traefik
-
-# Provision a new cluster (kind / eks)
-mcp-runtime cluster provision --provider kind --nodes 3
-mcp-runtime cluster provision --provider eks --name prod-mcp --region us-west-1
-
-# cert-manager helpers
-mcp-runtime cluster cert status
+mcp-runtime cluster cert status                                  # cert-manager TLS state
 mcp-runtime cluster cert apply
 mcp-runtime cluster cert wait --timeout 10m
 
-# Post-install diagnostics (runs 37 checks)
-KUBECONFIG=~/.kube/config mcp-runtime cluster doctor
+KUBECONFIG=~/.kube/config mcp-runtime cluster doctor            # 37-point post-install check
 ```
 
-**Active providers:** `kind`, `eks`. (`gke` / `aks` flags exist but provisioning
-helpers are not yet implemented.)
+Active providers: `kind`, `eks`. (`gke` / `aks` exist but provisioning is not yet implemented.)
 
 ---
 
-## Platform API vs `--use-kube`
-
-Most `server` and `access` commands use the **platform API** by default.
-Set up credentials with `auth login` first.
-
-`--use-kube` is **admin/dev/test only** — it bypasses platform auth and talks
-directly to the Kubernetes API through your kubeconfig.
-
-| Default (platform API) 👤 | Requires `--use-kube` 🔑 |
-|---|---|
-| `server list`, `get`, `delete`, `status`, `policy inspect`, `deploy` | `server create`, `apply`, `export`, `patch`, `logs` |
-| `access grant/session` list, get, apply, delete, enable/disable, revoke | Same commands with `--use-kube` for raw CRD operations |
-| `registry push` | Direct `kubectl apply` for manifests |
-
-- `server get` without `--use-kube` returns a platform API summary; full MCPServer YAML needs `--use-kube`.
-- `server logs` always requires `--use-kube`; use `sentinel logs gateway` when you only have platform credentials.
-- `access session apply` via platform API is **admin-only**; agents normally get sessions automatically via `adapter --auto-refresh`.
-- `--team` is a platform API resolver and is rejected with `--use-kube`.
-
----
-
-## Common flows
+## Full example: two teams, cross-team access
 
 ```bash
-# ─── Operator: first-time cluster setup ───────────────────────────────────────
-KUBECONFIG=~/.kube/config mcp-runtime cluster provision --provider kind --nodes 3
+# ── 1. Operator: install ─────────────────────────────────────────────────────
 KUBECONFIG=~/.kube/config mcp-runtime bootstrap
-KUBECONFIG=~/.kube/config mcp-runtime setup --env-file config/deployments/mcpruntime-org.env
+KUBECONFIG=~/.kube/config mcp-runtime setup \
+  --env-file config/deployments/mcpruntime-org.env
 
-# ─── Admin: create teams and users ────────────────────────────────────────────
-mcp-runtime auth login --api-url https://platform.mcpruntime.org \
+# ── 2. Admin: create two teams ───────────────────────────────────────────────
+mcp-runtime auth login --api-url https://platform.example.com \
   --email admin@example.com --password '...' --profile admin
 
 MCP_PLATFORM_API_PROFILE=admin mcp-runtime team create acme --name "Acme Corp"
 MCP_PLATFORM_API_PROFILE=admin mcp-runtime team user create acme \
-  --username acme-owner@example.com --password '...' --role owner
+  --username alice@example.com --password '...' --role owner
 
 MCP_PLATFORM_API_PROFILE=admin mcp-runtime team create globex --name "Globex Corp"
 MCP_PLATFORM_API_PROFILE=admin mcp-runtime team user create globex \
-  --username globex-dev@example.com --password '...' --role member
+  --username bob@example.com --password '...' --role member
 
-# ─── Developer (Team A): log in, deploy a server ──────────────────────────────
-mcp-runtime auth login --api-url https://platform.mcpruntime.org \
-  --email acme-owner@example.com --password '...' --profile acme-owner
+# ── 3. Developer (Acme): deploy a server ─────────────────────────────────────
+mcp-runtime auth login --api-url https://platform.example.com \
+  --email alice@example.com --password '...' --profile alice
 
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server init payments \
-  --tool list_invoices --tool refund_invoice
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server build image payments --tag v1
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime registry push \
-  --image <exact-image-ref-from-build> --scope tenant
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server deploy payments \
-  --scope tenant --metadata-dir .mcp
+mcp-runtime auth use alice
 
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server list
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server get payments --namespace mcp-team-acme
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server policy inspect payments \
-  --namespace mcp-team-acme
+# Run server locally, discover real tool names, validate, build, push, deploy
+go run ./payments &
+mcp-runtime server init payments --from-server http://localhost:8088
+mcp-runtime server validate --metadata-dir .mcp
+mcp-runtime server build image payments --tag v1
+mcp-runtime registry push --image registry.example.com/acme/payments:v1 --scope tenant
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
 
-# ─── Access control: grant Team B access to Team A's server ───────────────────
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant init payments-globex \
+# ── 4. Acme grants Globex access ─────────────────────────────────────────────
+GLOBEX_TEAM_ID="<uuid from team list>"
+
+mcp-runtime access grant init payments-to-globex \
   --server payments --namespace mcp-team-acme \
-  --team-id <globex-team-uuid> --agent-id cursor \
+  --team-id $GLOBEX_TEAM_ID --agent-id cursor \
   --tool list_invoices --output grant.yaml
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant apply --file grant.yaml
-MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant list
 
-# ─── Admin applies a cross-team session ───────────────────────────────────────
-MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session init globex-session \
+mcp-runtime server validate --metadata-dir .mcp --grant-file grant.yaml
+mcp-runtime access grant apply --file grant.yaml
+
+# ── 5. Admin creates a session for Globex's cursor agent ─────────────────────
+mcp-runtime auth use admin
+
+mcp-runtime access session init globex-session \
   --server payments --namespace mcp-team-acme \
-  --team-id <globex-team-uuid> --agent-id cursor \
-  --trust low --expires-in 2h --output session.yaml
-MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session apply --file session.yaml
-MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session list
+  --team-id $GLOBEX_TEAM_ID --agent-id cursor \
+  --trust low --expires-in 4h --output session.yaml
+mcp-runtime access session apply --file session.yaml
 
-# ─── Agent connects via adapter (uses auto-refresh for session) ───────────────
-mcp-runtime adapter stdio \
-  --runtime-url https://platform.mcpruntime.org/payments/mcp \
-  --server payments --agent cursor --auto-refresh
+# ── 6. Globex agent connects via adapter ─────────────────────────────────────
+mcp-runtime auth use bob   # (after bob logs in)
 
-# ─── Operator: inspect the stack ──────────────────────────────────────────────
+mcp-runtime adapter proxy \
+  --runtime-url https://mcp.example.com/payments/mcp \
+  --server payments --agent cursor --agent-id cursor \
+  --auto-refresh --listen 127.0.0.1:8099
+# → agent calls http://127.0.0.1:8099 with standard MCP
+
+# ── 7. Inspect ───────────────────────────────────────────────────────────────
 mcp-runtime status
+mcp-runtime server list
+mcp-runtime access grant list
+mcp-runtime access session list
 KUBECONFIG=~/.kube/config mcp-runtime sentinel status
 KUBECONFIG=~/.kube/config mcp-runtime sentinel logs api --since 10m
-KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward ui
-
-# ─── Admin: patch a running server (Kubernetes) ───────────────────────────────
-KUBECONFIG=~/.kube/config mcp-runtime server patch payments \
-  --namespace mcp-team-acme --patch '{"spec":{"imageTag":"v2"}}' --use-kube
-KUBECONFIG=~/.kube/config mcp-runtime server logs payments \
-  --namespace mcp-team-acme --tail 50 --use-kube
 ```
 
 ---
@@ -619,10 +531,10 @@ KUBECONFIG=~/.kube/config mcp-runtime server logs payments \
 
 | Topic | Link |
 |---|---|
-| Build, push, deploy, verify a server end-to-end (includes `server validate`) | [Publish an MCP Server](publish-mcp-server.md) |
-| Resource fields: MCPServer, MCPAccessGrant, MCPAgentSession | [API reference](api.md) |
-| HTTP proxy and stdio adapter configuration | [Agent adapters](agent-adapters.md) |
-| Multi-team namespaces, RBAC, isolation | [Multi-team isolation](multi-team.md) |
+| Build → push → deploy flow with `server validate` | [Publish an MCP Server](publish-mcp-server.md) |
+| MCPServer, MCPAccessGrant, MCPAgentSession field reference | [API reference](api.md) |
+| HTTP proxy and stdio adapter config | [Agent adapters](agent-adapters.md) |
+| Multi-team namespaces and RBAC | [Multi-team isolation](multi-team.md) |
 | Sentinel logs, events, restart, port-forward | [Sentinel](sentinel.md) |
 | Distro-specific cluster prerequisites | [Cluster readiness](cluster-readiness.md) |
-| Kind, EKS, GKE, AKS, k3s deployment | [Deployment targets](deployment-targets.md) |
+| Kind, EKS, k3s deployment | [Deployment targets](deployment-targets.md) |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,47 +1,87 @@
-# CLI
+# CLI reference
 
-The `mcp-runtime` CLI bootstraps clusters, manages registries, publishes servers
-through the platform API, operates access grants and sessions, and inspects the
-runtime stack. Direct Kubernetes manifest operations (`server apply`, `create`,
-`patch`, `logs`, …) require the admin-only `--use-kube` flag. The `sentinel`
-command group also requires admin/operator kubectl access.
+`mcp-runtime` is the single binary for the entire platform — from cluster bootstrap
+through server deployment, access policy, and runtime observability. Commands are
+grouped into families; each family has a dedicated doc page linked below.
 
-```mermaid
-flowchart LR
-    CLI[mcp-runtime] --> Boot[bootstrap]
-    CLI --> Setup[setup]
-    CLI --> Cluster[cluster]
-    CLI --> Reg[registry]
-    CLI --> Server[server]
-    CLI --> Access[access]
-    CLI --> Sent[sentinel]
-    CLI --> Status[status]
+## Who can run what
+
+Two access layers control what each command can do:
+
+| Layer | How to authenticate | Commands |
+|---|---|---|
+| **Platform API** | `auth login` → token saved in `~/.mcpruntime/config.json` | `server`, `access`, `registry push`, `team`, `adapter` |
+| **Kubernetes (admin)** | `KUBECONFIG` / kubeconfig file with cluster-admin RBAC | `bootstrap`, `setup`, `cluster`, `sentinel`, `server --use-kube`, `access --use-kube` |
+
+> **Quick rule:** if you're a developer or team member deploying MCP servers, use Platform API
+> commands. If you're an operator setting up the cluster or debugging the stack, use the
+> Kubernetes commands.
+
+### Role legend used in this page
+
+| Badge | Meaning |
+|---|---|
+| 👤 **User** | Platform API; requires `auth login` or `MCP_PLATFORM_API_TOKEN` |
+| 🔑 **Admin** | Platform API admin role *or* `--use-kube` (cluster-admin RBAC) |
+| ⚙️ **Operator** | Kubernetes only; cluster-admin RBAC required |
+
+## Credentials and profiles
+
+Login credentials are stored locally at `~/.mcpruntime/config.json`. Each login is
+saved as a **named profile** so you can switch between admin, team user, and
+multi-tenant identities without re-typing credentials.
+
+```bash
+# Save credentials under the default profile
+mcp-runtime auth login --api-url https://platform.mcpruntime.org
+
+# Save under a named profile
+mcp-runtime auth login --api-url https://platform.mcpruntime.org \
+  --email admin@example.com --password '...' --profile admin
+
+# Switch the active profile
+mcp-runtime auth use admin
+mcp-runtime auth use acme-owner
+
+# Use a profile for a single command without switching
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime server list
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime team list
+
+# Check which profile is active and what token it holds
+mcp-runtime auth status
 ```
+
+**Environment overrides** (take precedence over saved profiles):
+
+| Variable | Effect |
+|---|---|
+| `MCP_PLATFORM_API_TOKEN` | Use this token instead of the saved one |
+| `MCP_PLATFORM_API_URL` | Override the saved API base URL |
+| `MCP_PLATFORM_API_PROFILE` | Select a saved profile without switching the current one |
 
 ## Fast path
 
 ```bash
-make deps
-make build
+# Operator: cluster + platform install
+mcp-runtime bootstrap
+mcp-runtime setup --env-file config/deployments/mcpruntime-org.env
 
-./bin/mcp-runtime setup
-./bin/mcp-runtime status
+# Developer: log in, deploy a server, grant access
+mcp-runtime auth login --api-url https://platform.mcpruntime.org
+mcp-runtime server init payments --tool list_invoices
+mcp-runtime server build image payments --tag v1
+mcp-runtime registry push --image <image-ref> --scope tenant
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
 
-./bin/mcp-runtime auth login --api-url https://platform.example.com --token-stdin < token.txt
-./bin/mcp-runtime auth status
+mcp-runtime access grant init payments-ops \
+  --server payments --agent-id ops-agent --tool list_invoices --output grant.yaml
+mcp-runtime access grant apply --file grant.yaml
 
-./bin/mcp-runtime server init payments --tool list_invoices
-./bin/mcp-runtime server build image payments --tag v1
-./bin/mcp-runtime registry push --image <image-ref-you-built-locally>
-./bin/mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
-
-./bin/mcp-runtime access grant init payments-ops --server payments --agent-id ops-agent --tool list_invoices --output grant.yaml
-./bin/mcp-runtime access grant apply --file grant.yaml
+# Check everything
+mcp-runtime status
 ```
 
-For a new workstation, run `make deps-install` first where supported, then `STRICT_DEPS_CHECK=1 make deps-check`. Required host tools are Go `1.26+`, Make, Docker with a reachable daemon, `kubectl` configured for the cluster, plus `curl`, `jq`, and `python3` for documented dev flows. `kind` is required only for local Kind clusters.
-
-Use the built-in help for the exact description, flags, and defaults of any command:
+Use built-in help for the exact flags and defaults of any command:
 
 ```bash
 mcp-runtime --help
@@ -51,512 +91,538 @@ mcp-runtime <group> <subcommand> --help
 
 ## Command map
 
-| Group | What it covers | Important subcommands |
-|---|---|---|
-| `bootstrap` | Preflight checks for cluster prerequisites (DNS, default StorageClass, ingress class, MetalLB). With `--apply` on k3s only, install bundled CoreDNS + local-path manifests. | `bootstrap`, `--apply`, `--provider auto\|k3s\|rke2\|kubeadm\|generic` |
-| `setup` | Install the platform stack, wire registry and ingress, deploy the operator, optionally include sentinel. | `setup`, `--with-tls`, `--without-sentinel` |
-| `auth` | Save and inspect platform API credentials for non-kubeconfig platform flows. | `login`, `logout`, `status`, `use` |
-| `cluster` | Initialize clusters, inspect health, configure kubeconfig and ingress, provision clusters, manage cert-manager. | `init`, `status`, `config`, `provision`, `cert status\|apply\|wait`, `doctor` |
-| `registry` | Inspect the internal registry, configure an external one, push images. | `status`, `info`, `provision`, `push` |
-| `server` | Manage `MCPServer` resources and operator-facing actions. | `init`, `list`, `get`, `create`, `apply`, `deploy`, `generate`, `export`, `patch`, `delete`, `logs`, `status`, `policy inspect`, `build image` |
-| `access` | Manage `MCPAccessGrant` and `MCPAgentSession` resources that feed the gateway policy layer. | `grant init/list/get/apply/delete/disable/enable`, `session init/list/get/apply/delete/revoke/unrevoke` |
-| `adapter` | HTTP proxy and stdio shims that inject governance identity/session headers for agents. | `proxy`, `stdio` |
-| `team` | Manage internal platform teams, team password users, and Kubernetes team namespaces. | `list`, `create`, `user list`, `user create` |
-| `sentinel` | Inspect and operate the bundled analytics, gateway, and observability stack (**admin/operator kubectl only**). | `status`, `events`, `logs`, `port-forward`, `restart` |
-| `status` | Aggregated platform health (cluster, registry, operator, servers, sentinel). | `status` |
-| `completion` | Generate shell completion (bash, zsh, fish). | `completion bash\|zsh\|fish` |
+| Group | Role | What it covers | Full reference |
+|---|---|---|---|
+| `auth` | 👤 User | Save and switch platform API credentials | [this page §auth](#auth) |
+| `status` | 👤 User | Aggregated platform health summary | [this page §status](#status) |
+| `server` | 👤 User / 🔑 Admin | Deploy and manage `MCPServer` resources | [Publish an MCP Server](publish-mcp-server.md) |
+| `registry` | 👤 User / ⚙️ Operator | Push images; inspect and provision the registry | [this page §registry](#registry) |
+| `access` | 👤 User / 🔑 Admin | Manage access grants and agent sessions | [API reference](api.md) |
+| `adapter` | 👤 User | HTTP proxy and stdio shims for agent runtimes | [Agent adapters](agent-adapters.md) |
+| `team` | 🔑 Admin | Manage platform teams and team users | [Multi-team isolation](multi-team.md) |
+| `sentinel` | ⚙️ Operator | Inspect and operate the analytics/observability stack | [Sentinel](sentinel.md) |
+| `bootstrap` | ⚙️ Operator | Preflight checks for cluster prerequisites | [Cluster readiness](cluster-readiness.md) |
+| `setup` | ⚙️ Operator | Full platform install: operator, registry, TLS, sentinel | [this page §setup](#setup) |
+| `cluster` | ⚙️ Operator | Initialize, configure, provision clusters; cert-manager | [Deployment targets](deployment-targets.md) |
+| `completion` | 👤 User | Shell completion scripts | — |
 
-The root command exposes `--debug` and `--version`. Subcommands inherit `--debug`; use `mcp-runtime --version` at the top level.
-
-## bootstrap
-
-Validate kubectl connectivity, CoreDNS, default `StorageClass`, Traefik `IngressClass`, and MetalLB. Missing pieces are warnings — the command surfaces them so you can decide what to install.
-
-```bash
-mcp-runtime bootstrap
-mcp-runtime bootstrap --provider k3s
-mcp-runtime bootstrap --apply --provider k3s   # Only k3s is automated
-```
-
-When to run it: on a fresh cluster before `setup`. Skip if your platform team already provides DNS, default storage, ingress, and load balancing.
-
-## setup
-
-The broad install path: runtime namespace, internal registry, operator, ingress wiring, bundled sentinel stack.
-
-```bash
-mcp-runtime setup
-mcp-runtime setup --with-tls                   # cert-manager TLS for registry
-mcp-runtime setup --platform-mode public       # anonymous public preview catalog
-mcp-runtime setup --without-sentinel           # skip request-path stack
-mcp-runtime setup --test-mode                  # local Kind/dev build+push path
-mcp-runtime setup --parallel-builds            # build/publish setup images concurrently
-mcp-runtime setup --registry-mode external --external-registry-url registry.example.com
-```
-
-Flags: `--registry-type`, `--registry-storage`, `--registry-mode`, `--external-registry-url`, `--external-registry-username`, `--external-registry-password`, `--platform-mode`, `--ingress`, `--ingress-manifest`, `--force-ingress-install`, `--with-tls`, `--test-mode`, `--parallel-builds`, `--without-sentinel`, plus operator overrides `--operator-leader-elect`, `--operator-metrics-addr`, `--operator-probe-addr`.
-
-`--registry-mode` accepts `auto`, `bundled-http`, `bundled-https`, or
-`external`. `auto` preserves the legacy behavior: use a provisioned registry
-config when one exists, otherwise install the bundled registry. `bundled-http`
-uses the bundled registry over HTTP for platform image pulls and requires node
-insecure-registry config. `bundled-https` makes the bundled registry pod serve
-HTTPS and requires `--with-tls` plus node trust for the issuing CA.
-`external` skips the bundled registry and uses `--external-registry-url`,
-`PROVISIONED_REGISTRY_URL`, or `mcp-runtime registry provision`.
-
-Setup-built images default to the Linux architecture reported by the cluster
-nodes. Override with `MCP_IMAGE_PLATFORM=linux/amd64` or
-`MCP_IMAGE_PLATFORM=linux/arm64` when the build host differs from the target
-cluster.
-
-For non-test public/TLS setup, configure the platform hostnames before running
-setup: set `MCP_PLATFORM_DOMAIN` to derive `platform.<domain>`,
-`registry.<domain>`, and `mcp.<domain>`, or set
-`MCP_PLATFORM_INGRESS_HOST`, `MCP_REGISTRY_INGRESS_HOST`, and
-`MCP_MCP_INGRESS_HOST` explicitly. For bundled HTTPS with a public domain,
-set `MCP_REGISTRY_ENDPOINT=registry.<domain>` so node pulls match the TLS
-certificate — do not use the registry Service ClusterIP or `MCP_REGISTRY_HOST`
-as the pull URL. Production setup also requires an
-admin allowlist through `MCP_PLATFORM_ADMIN_EMAIL` or `ADMIN_USERS`; that
-allowlist is what promotes Google/OIDC logins to platform admin.
-
-`--platform-mode` selects the namespace model. `tenant` is the default and
-scopes signed-in users to team namespaces for teams they belong to; `org` uses
-`mcp-servers-org` for signed-in org-wide publishing while preserving team
-namespace access; `public` uses `mcp-servers-public`, exposes anonymous catalog
-reads, and lets signed-in users publish public preview MCP servers while
-preserving team namespace access. `MCP_PLATFORM_MODE` provides the same
-value when the flag is not set. Non-test public TLS setup also requires
-`GOOGLE_CLIENT_ID` / `MCP_GOOGLE_CLIENT_ID` or the complete custom OIDC trio:
-`OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL`.
-
-`--test-mode` relaxes production guardrails, but it still builds and pushes the
-operator, gateway proxy, and Sentinel images with `latest` tags to the
-configured or bundled registry. With the bundled plain HTTP registry, cluster
-nodes still need containerd/Docker trust for the exact image host they pull
-from.
-
-`--parallel-builds` keeps cluster, registry, TLS, and rollout sequencing
-unchanged, but builds and publishes the runtime and Sentinel setup images
-concurrently.
-
-Setup is reconcile-oriented and refuses known control-plane conflicts before
-applying more state. Registry TLS is owned by the explicit
-`registry/registry-cert` Certificate for the `registry-tls` Secret; the
-registry Ingress does not request a second ingress-shim certificate. If an old
-`registry/registry-tls` Certificate or another Certificate already references
-that Secret, delete or rename the extra Certificate before re-running setup.
-For ingress, setup reuses an existing external Traefik such as k3s'
-`kube-system/traefik` and refuses to force-install the repo-managed
-`traefik/traefik` stack on top of it.
-
-For local development where ingress traffic is exposed through port-forward or NodePort and the ingress controller does not publish load-balancer status, set `MCP_INGRESS_READINESS_MODE=permissive` before `setup`. The default is strict and waits for `Ingress.status.loadBalancer.ingress[]`.
+---
 
 ## auth
 
-Use `auth` for platform API credentials, not for Kubernetes cluster access.
+👤 **User** — platform API credentials only; no Kubernetes required.
 
-Use cases:
-
-- saving a platform API token locally for day-to-day platform flows
-- saving multiple platform identities, such as an admin profile plus team user profiles
-- recording a registry host alongside that token
-- checking whether local platform credentials are already configured
-
-Do not use `auth` for:
-
-- `setup`
-- cluster bootstrap
-- cluster admin operations
-- raw Kubernetes access
-
-Examples:
+Save tokens locally and switch between profiles for multi-platform or multi-role
+workflows. These credentials are used by `server`, `access`, `registry push`,
+`team`, and `adapter` commands.
 
 ```bash
-# Save a token interactively
-mcp-runtime auth login --api-url https://platform.example.com
+# Interactive login (prompts for token)
+mcp-runtime auth login --api-url https://platform.mcpruntime.org
 
-# Save a token non-interactively
-cat token.txt | mcp-runtime auth login \
-  --api-url https://platform.example.com \
-  --token-stdin
+# Non-interactive (CI / scripted)
+mcp-runtime auth login --api-url https://platform.mcpruntime.org --token-stdin < token.txt
 
-# Email/password login when the platform supports it
+# Email + password login
 mcp-runtime auth login \
-  --api-url https://platform.example.com \
-  --email admin@example.com \
-  --password '...' \
-  --profile admin
+  --api-url https://platform.mcpruntime.org \
+  --email admin@example.com --password '...' --profile admin
 
-# `--username` is accepted as an alias for `--email`
+# Record the registry host alongside the token
 mcp-runtime auth login \
-  --api-url https://platform.example.com \
-  --username globex@example.com \
-  --password '...' \
-  --profile globex
+  --api-url https://platform.mcpruntime.org \
+  --token-stdin --registry-host registry.mcpruntime.org < token.txt
 
-# Record the platform registry host too
-mcp-runtime auth login \
-  --api-url https://platform.example.com \
-  --token-stdin \
-  --registry-host registry.example.com < token.txt
-
-# Switch between saved profiles
+# Switch profiles
 mcp-runtime auth use admin
-mcp-runtime auth use globex
+mcp-runtime auth use acme-owner
 
-# Check current auth state
+# Check active credentials
 mcp-runtime auth status
 
-# Remove saved local credentials
+# Remove saved credentials
 mcp-runtime auth logout
 ```
 
 Notes:
+- Credentials live in `~/.mcpruntime/config.json` (mode 0600)
+- Each `auth login` saves a profile and makes it current
+- `MCP_PLATFORM_API_PROFILE` selects a profile for a single command without switching
 
-- saved credentials are local to the workstation
-- each login is saved as a named profile; `auth login` makes that profile current
-- `MCP_PLATFORM_API_PROFILE` selects a saved profile without changing the current profile
-- `MCP_PLATFORM_API_TOKEN` overrides any saved token when set; if
-  `MCP_PLATFORM_API_URL` is unset, the CLI reuses the API URL from the selected
-  saved profile
-- `MCP_PLATFORM_API_URL` overrides the saved API base URL when set
-- kubeconfig-based cluster commands are separate from platform auth
-
-## Platform API vs `--use-kube`
-
-Most `server` and `access` commands use the **platform API** by default. Run
-`mcp-runtime auth login --api-url <platform-url>` before those flows. You can
-also set `MCP_PLATFORM_API_TOKEN`; set `MCP_PLATFORM_API_URL` too only when you
-want to override the saved profile's API URL.
-
-`--use-kube` is **admin/dev/test only**. It bypasses platform auth and talks to
-the Kubernetes API through your kubeconfig. Use it only when you have
-admin/operator RBAC and intentionally want direct CRD/manifest operations.
-
-| Default (platform API) | Requires `--use-kube` (admin only) |
-|---|---|
-| `access grant/session` list, get, apply, delete, enable/disable, revoke/unrevoke | same commands with `--use-kube` for raw kubectl CRUD |
-| `server list`, `get`, `delete`, `status`, `policy inspect`, `deploy` | `server create`, `apply`, `export`, `patch`, `logs` |
-| `registry push` (always platform API) | `kubectl apply -f` for manifests (separate from CLI flag) |
-
-Notes:
-
-- `server get` without `--use-kube` returns a platform API summary; full
-  MCPServer YAML needs `--use-kube`.
-- `server status` without `--use-kube` lists servers from the platform API;
-  pod-level detail needs `--use-kube`.
-- `server logs` always requires `--use-kube`; use `kubectl logs` or
-  `sentinel logs gateway` when you only have platform credentials.
-- `access session apply` through the platform API is **admin-only**; agents
-  should use `adapter stdio|proxy --server … --agent …` or admins use
-  `--use-kube` / `kubectl apply` for explicit session manifests.
-- `--team` is a platform API resolver and is rejected with `--use-kube`.
+---
 
 ## status
 
+👤 **User** — reads from the platform API and from Kubernetes if kubeconfig is available.
+
 ```bash
-mcp-runtime status
-mcp-runtime cluster status
-mcp-runtime registry status
-mcp-runtime sentinel status
+mcp-runtime status           # aggregated: cluster, registry, operator, sentinel
+mcp-runtime cluster status   # cluster-level health
+mcp-runtime registry status  # registry deployment + endpoint
+mcp-runtime sentinel status  # sentinel stack (needs kubeconfig)
 ```
+
+---
+
+## server
+
+👤 **User** by default (platform API) · 🔑 **Admin** with `--use-kube`.
+
+Scaffold, build, push, and deploy `MCPServer` resources. Most day-to-day operations
+go through the platform API — only manifest-level operations (`create`, `apply`,
+`patch`, `logs`, `export`) require `--use-kube` and cluster-admin RBAC.
+
+> **Full guide:** [Publish an MCP Server](publish-mcp-server.md)
+
+### Platform API commands (👤 User)
+
+```bash
+mcp-runtime auth login --api-url https://platform.mcpruntime.org
+
+# List and inspect
+mcp-runtime server list
+mcp-runtime server get payments --namespace mcp-team-acme   # always pass --namespace for team servers
+mcp-runtime server status
+mcp-runtime server status --namespace mcp-team-acme
+mcp-runtime server policy inspect payments --namespace mcp-team-acme
+
+# Scaffold server metadata
+# Option A: manually specify tools (names MUST match your server implementation)
+mcp-runtime server init payments --tool list_invoices --tool refund_invoice
+mcp-runtime server init payments --tool-spec list_invoices:low:read --tool-spec refund_invoice:high:destructive
+
+# Option B: auto-discover tools from a locally running MCP server (recommended)
+# Run your server locally first, then:
+mcp-runtime server init payments --from-server http://localhost:8088
+
+# Validate metadata and grant/session YAML before deploying (catches tool name mismatches)
+mcp-runtime server validate --metadata-dir .mcp
+mcp-runtime server validate --metadata-dir .mcp --grant-file grant.yaml --session-file session.yaml
+mcp-runtime server validate --metadata-dir .mcp --from-server http://localhost:8088   # verify against live server
+
+# Build the image
+mcp-runtime server build image payments --tag v1 --platform linux/amd64
+
+# Deploy (after pushing the image)
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
+mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp --update   # redeploy
+
+# Delete
+mcp-runtime server delete payments
+
+# Generate GitOps manifests
+mcp-runtime server generate --metadata-dir .mcp --output manifests/
+```
+
+### Admin / operator commands (🔑 --use-kube)
+
+```bash
+# Direct CRD operations — requires cluster-admin RBAC
+mcp-runtime server create payments --image repo/payments --tag latest --use-kube
+mcp-runtime server create payments --file server.yaml --use-kube
+mcp-runtime server apply --file server.yaml --use-kube
+mcp-runtime server export payments --file payments.yaml --use-kube
+mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
+mcp-runtime server logs payments --follow --use-kube
+```
+
+`--scope` values: `tenant` (team namespace), `org` (`mcp-servers-org`), `public` (`mcp-servers-public`).
+`server deploy --update` is required for repeat deploys of the same server name.
+
+---
 
 ## registry
 
+👤 **User** for `push` · ⚙️ **Operator** for `provision` and `status`.
+
 ```bash
-# Inspect / configure
+# Inspect (operator)
 mcp-runtime registry status
 mcp-runtime registry info
+
+# Configure an external registry (operator)
 mcp-runtime registry provision --url registry.example.com
 mcp-runtime registry provision \
   --url registry.example.com \
   --operator-image registry.example.com/mcp-runtime-operator:latest
 
-# Push images through the platform API (multipart upload + in-cluster skopeo helper)
-mcp-runtime registry push --image <resolved-registry-host>/payments:v1
-mcp-runtime registry push --image payments:v1 --name payments-api
+# Push images (user — requires auth login)
+mcp-runtime registry push --image registry.mcpruntime.org/payments:v1
+mcp-runtime registry push --image payments:v1 --name payments-api --scope tenant
 mcp-runtime registry push --scope public --image payments:v1
-mcp-runtime registry push --scope tenant --image payments:v1
 ```
 
-`registry push` requires platform credentials from `mcp-runtime auth login` or
-`MCP_PLATFORM_API_TOKEN` with a saved or explicit `MCP_PLATFORM_API_URL`;
-unauthenticated pushes are
-rejected before the CLI saves the local image archive. The CLI uploads the docker
-save tar to `POST /api/runtime/registry/push`; the platform API pushes it to the
-registry from inside the cluster. When you use
-`server build image`, push the exact image ref it produced. That ref can include
-a resolved registry host instead of a short local name. `--scope public` and
-`--scope org` prefix the target repository with `public/` or `org/`; `--scope
-tenant` prefixes unscoped repositories with the authenticated user's active
-team slug. Explicit tenant repository prefixes must match one of the user's
-teams.
+`registry push` uploads via `POST /api/runtime/registry/push`; the platform API
+pushes the image from inside the cluster. Always push the **exact ref** produced
+by `server build image`.
 
-## server init
-
-```bash
-# Scaffold .mcp/servers.yaml for a metadata-driven server
-mcp-runtime server init payments --tool list_invoices --tool refund_invoice
-mcp-runtime server init payments \
-  --tool list_invoices \
-  --tool-spec refund_invoice:high:destructive
-```
-
-`server init` creates or appends to `.mcp/servers.yaml`. It defaults `image` to
-the server name, `imageTag` to `latest`, `scope` to `tenant`, and the route to
-`/<name>/mcp`. It enables the gateway, scaffolds allow-list/deny policy and a
-required session, and leaves platform-managed gateway wiring and auth/session
-header details out of the metadata file. Use `--policy-mode`,
-`--default-decision`, or `--session-required=false` when the initial governance
-shape should differ. Repeated `--tool` flags seed read/low tool metadata. Use repeated
-`--tool-spec name:low|medium|high:read|write|destructive` when tools need mixed
-trust levels or side-effect classes. If a metadata entry with the same server
-name already exists, `server init` fails unless `--force` is passed.
-
-Typical platform path after `server init`:
-
-```bash
-mcp-runtime auth login --api-url https://platform.example.com
-mcp-runtime server build image payments --tag v1
-mcp-runtime registry push --scope tenant --image <exact-image-ref-from-build>
-mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
-mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp --update   # repeat deploys
-```
-
-## server generate
-
-```bash
-# Generate MCPServer manifests from metadata for review/GitOps
-mcp-runtime server generate --metadata-dir .mcp --output manifests
-mcp-runtime server generate --metadata-file .mcp/payments.yaml --output manifests
-```
-
-For the full build, push, deploy, and verify flow, see [Publish an MCP Server](publish-mcp-server.md).
+---
 
 ## access
 
-Scaffold manifests with `init`, then apply through the platform API (default).
-Add `--use-kube` only for admin/operator direct Kubernetes flows.
+👤 **User** for grant read/write · 🔑 **Admin** for session `apply` and `--use-kube` flows.
+
+Manage `MCPAccessGrant` and `MCPAgentSession` CRDs that feed the gateway policy layer.
+Most developers scaffold a grant with `init`, review the YAML, then `apply` through
+the platform API. Session creation for agents is usually handled automatically by
+`adapter stdio/proxy --auto-refresh`.
+
+> **Full reference:** [API reference — access fields](api.md)
+
+> ⚠️ **Tool names must match exactly.** Grant `toolRules` reference tool names
+> from your server's `.mcp/servers.yaml`. If a grant rule names a tool that is
+> not in the metadata the gateway returns `tool_side_effect_unknown` and denies
+> the call. Run `server validate --grant-file grant.yaml` before applying to
+> catch mismatches early. Use `server init --from-server http://localhost:<port>`
+> to populate metadata with the real tool names from your running server.
 
 ```bash
-mcp-runtime auth login --api-url https://platform.example.com
+mcp-runtime auth login --api-url https://platform.mcpruntime.org
 
-# Grants
-mcp-runtime access grant init payments-globex-cursor \
-  --namespace mcp-team-acme \
-  --server payments \
-  --team-id <globex-team-id> \
-  --agent-id cursor \
-  --tool list_invoices \
-  --tool-rule refund_invoice:allow:high \
-  --tool-rule delete_invoice:deny:high \
-  --side-effect read \
-  --side-effect destructive \
+# Grants (👤 User)
+mcp-runtime access grant init payments-ops \
+  --server payments --agent-id ops-agent \
+  --tool list_invoices --tool-rule refund_invoice:allow:high \
   --output grant.yaml
+mcp-runtime access grant apply --file grant.yaml
 mcp-runtime access grant list
 mcp-runtime access grant list --namespace mcp-team-acme
-mcp-runtime access grant get payments-admin --namespace mcp-servers
-mcp-runtime access grant apply --file grant.yaml
-mcp-runtime access grant disable payments-admin
-mcp-runtime access grant enable payments-admin
+mcp-runtime access grant get payments-ops
+mcp-runtime access grant disable payments-ops
+mcp-runtime access grant enable payments-ops
+mcp-runtime access grant delete payments-ops
 
-# Sessions
+# Sessions (🔑 Admin — session apply via platform API requires admin role)
 mcp-runtime access session init cursor-session \
-  --namespace mcp-team-acme \
-  --server payments \
-  --human-id <user-id> \
-  --agent-id cursor \
-  --trust medium \
-  --expires-in 1h \
-  --output session.yaml
-mcp-runtime access session init cursor-session \
-  --namespace mcp-team-acme \
-  --server payments \
-  --team-id <team-id> \
-  --agent-id cursor \
-  --trust high \
-  --expires-at 2026-05-25T12:00:00Z \
-  --upstream-token-secret upstream-token \
-  --upstream-token-key token \
-  --output session.yaml
+  --server payments --human-id <user-id> --agent-id cursor \
+  --trust medium --expires-in 1h --output session.yaml
+mcp-runtime access session apply --file session.yaml   # admin only
 mcp-runtime access session list
-mcp-runtime access session get ops-agent --namespace mcp-servers
-mcp-runtime access session apply --file session.yaml
-mcp-runtime access session revoke ops-agent
-mcp-runtime access session unrevoke ops-agent
+mcp-runtime access session get cursor-session
+mcp-runtime access session revoke cursor-session
+mcp-runtime access session unrevoke cursor-session
 ```
 
-`grant list` and `session list` default to `--all-namespaces`; pass `--namespace` to narrow scope.
+`grant list` and `session list` default to `--all-namespaces`; pass `--namespace` to
+narrow scope.
 
-`access grant init` writes a reviewable YAML file with tool rules and
-`allowedSideEffects`. `--tool` is shorthand for an allow rule at `--trust`
-(default `low`). Use `--tool-rule name:allow|deny:low|medium|high` for mixed
-decisions. `access session init` is for explicit/admin session manifests; adapter
-`--auto-refresh` usually creates sessions automatically at runtime. Platform
-API `access session apply` requires an **admin** role; server/team owners use
-grant apply plus adapter-issued sessions for normal agent flows.
+**Cross-team access** — a Team A owner can grant Team B users access to Team A's servers.
+Set `--team-id <globex-team-uuid>` on `grant init` to scope the grant to Team B agents,
+then apply from Team A's credentials. Team B agents get sessions via `adapter --auto-refresh`
+or an admin applies a session using `session apply` with the same `teamID` in `spec.subject`.
 
-For multi-team deployments, namespace scoping controls who can write resources
-and `teamID` controls who can use them. Put each team's grants and sessions in
-the same namespace as its servers, set `subject.teamID`, and use `--namespace`
-when inspecting or operating one team's policy resources.
+```bash
+# acme-owner grants globex team's cursor agent access to payments
+MCP_PLATFORM_API_PROFILE=acme-owner \
+  mcp-runtime access grant init payments-globex \
+    --server payments --namespace mcp-team-acme \
+    --team-id <globex-team-uuid> --agent-id cursor \
+    --tool list_invoices --output grant.yaml
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant apply --file grant.yaml
+
+# Admin creates the cross-team session
+MCP_PLATFORM_API_PROFILE=admin \
+  mcp-runtime access session init globex-session \
+    --server payments --namespace mcp-team-acme \
+    --team-id <globex-team-uuid> --agent-id cursor \
+    --trust low --expires-in 2h --output session.yaml
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session apply --file session.yaml
+```
+
+See [Multi-team isolation](multi-team.md) for namespace layout and RBAC details.
+
+---
+
+## adapter
+
+👤 **User** — for agent runtimes that need platform-governed identity headers.
+
+Run an HTTP reverse proxy or a stdio shim that injects `x-mcp-human-id`,
+`x-mcp-agent-id`, `x-mcp-session-id`, and other governance headers before
+requests reach the MCP server. Adapters create agent sessions automatically
+when `--auto-refresh` is set.
+
+> **Full guide:** [Agent adapters](agent-adapters.md)
+
+```bash
+# HTTP reverse proxy
+mcp-runtime adapter proxy \
+  --runtime-url https://platform.mcpruntime.org/payments/mcp \
+  --server payments --agent my-agent \
+  --auto-refresh
+
+# stdio shim (for Claude Desktop / local agent processes)
+mcp-runtime adapter stdio \
+  --runtime-url https://platform.mcpruntime.org/payments/mcp \
+  --server payments --agent my-agent \
+  --auto-refresh
+```
+
+Both adapters use the active platform credentials (`auth login` profile or
+`MCP_PLATFORM_API_TOKEN`) to authenticate session creation with the platform API.
+
+---
 
 ## team
 
-```bash
-mcp-runtime team list
-mcp-runtime team create acme --name "Acme"
-mcp-runtime team user create globex \
-  --username globex@example.com \
-  --password '...' \
-  --role member
-mcp-runtime team user list globex
-```
+🔑 **Admin** — all `team` commands require platform API admin role.
 
-`team list`, `team create`, and `team user` use the platform API, so run
-`auth login` or set platform API credentials first. `team create` creates a
-platform team and managed namespace, including quota/limits, default-deny
-NetworkPolicy, service account, and repo-managed Traefik watch wiring when
-bundled Traefik is present. `team user create` is admin-only. It creates or
-updates a password-login user and adds that user to the team as `member` or
-`owner`; use `auth login --username/--email --password` for the user login.
+Create and manage platform teams. Each team gets a dedicated Kubernetes namespace
+with quota, NetworkPolicy, service account, and ingress wiring.
 
-`team init` is **deprecated** and rejects at runtime. Use `team create` for
-the normal platform-backed flow. See
-[Multi-team isolation](multi-team.md).
-
-## server
+> **Full guide:** [Multi-team isolation](multi-team.md)
 
 ```bash
-# Normal platform path
-mcp-runtime auth login --api-url https://platform.example.com
-mcp-runtime server list
-mcp-runtime server deploy payments --scope public --image payments --tag v1
-mcp-runtime server get payments
-mcp-runtime server policy inspect payments
+mcp-runtime auth login --api-url https://platform.mcpruntime.org --profile admin
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team list
 
-# Admin/operator direct Kubernetes path
-mcp-runtime server create payments --image repo/payments --tag latest --use-kube
-mcp-runtime server create payments --file server.yaml --use-kube
-mcp-runtime server apply --file server.yaml --use-kube
-mcp-runtime server export payments --file payments.yaml --use-kube
+# Create a team
+mcp-runtime team create acme --name "Acme Corp"
 
-# Patch / inspect (platform API)
-mcp-runtime server status --namespace mcp-servers
-mcp-runtime server policy inspect payments
-
-# Admin/operator only — requires --use-kube
-mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
-mcp-runtime server logs payments --follow --use-kube
-
-# Build (push lives under registry)
-mcp-runtime server build image payments --tag v1 --platform linux/amd64
-mcp-runtime registry push --scope public --image <exact-image-ref-from-build>
+# Add a password-login user to the team
+mcp-runtime team user create acme \
+  --username acme-dev@example.com --password '...' --role member
+mcp-runtime team user list acme
 ```
 
-When `--use-kube` is absent, the supported `server` and `access` commands above
-use the platform API and require `mcp-runtime auth login --api-url
-<platform-url>` or `MCP_PLATFORM_API_TOKEN` plus `MCP_PLATFORM_API_URL`.
-In `--use-kube` mode, use `--namespace` and expect kubeconfig/RBAC failures
-unless the current principal has admin/operator cluster access.
+`team user create` creates or updates a password user and adds them to the team as
+`member` or `owner`. Users then log in with `auth login --email ... --password ...`.
 
-`server patch` accepts inline `--patch` or `--patch-file` with `merge`, `json`, or `strategic` modes.
+> ⚠️ `team init` is **deprecated** and rejects at runtime. Use `team create`.
 
-`server build image` updates matching `.mcp` metadata. It defaults Docker builds to `linux/amd64` so images can run on typical amd64 Kubernetes nodes; override with `--platform` or `MCP_DOCKER_PLATFORM` for another node architecture. It prefers an explicit registry host, then the cluster's `registry/registry` Ingress host, before falling back to the registry Service address. That keeps metadata images on a node-pullable public host such as `registry.example.com/public/payments:v1` when the cluster exposes one. Tenant metadata still uses the authenticated team repository prefix when platform credentials are configured. Push that exact ref after logging in to the platform. The command does not deploy by itself; push and deploy are separate steps. `server deploy --scope public` and `--scope org` let the platform resolve the active catalog namespace; `--scope tenant` uses the authenticated user's team namespace unless `--team` or `--namespace` selects one explicitly. Deploy accepts a short image name and expands it through the platform API to the configured node-pullable registry endpoint plus the active scope prefix. `server deploy --metadata-dir .mcp` includes the matching server inventory, including tool side-effect metadata used by governed tool calls. A repeat deploy with the same server name fails by default; pass `--update` when you intentionally want to redeploy an existing server.
+---
 
 ## sentinel
 
-Admin/operator only — requires kubectl access to the cluster. Normal users
-should use the platform dashboard, `/api/*`, and top-level `mcp-runtime status`.
+⚙️ **Operator** — requires `KUBECONFIG` pointing at a cluster with admin RBAC.
+Normal users should use the platform dashboard or top-level `mcp-runtime status`.
+
+Inspect and operate the bundled analytics, gateway, and observability stack.
+
+> **Full guide:** [Sentinel](sentinel.md)
 
 ```bash
-# Health + recent Kubernetes events
-mcp-runtime sentinel status
-mcp-runtime sentinel events
-mcp-runtime sentinel restart gateway
-mcp-runtime sentinel restart --all
+# Health + events
+KUBECONFIG=~/.kube/config mcp-runtime sentinel status
+KUBECONFIG=~/.kube/config mcp-runtime sentinel events
 
-# Logs (--follow / --previous / --tail / --since)
-mcp-runtime sentinel logs ingest --since 15m --follow
-mcp-runtime sentinel logs grafana --tail 500
+# Logs (--follow / --tail / --since / --previous)
+KUBECONFIG=~/.kube/config mcp-runtime sentinel logs api --since 15m --follow
+KUBECONFIG=~/.kube/config mcp-runtime sentinel logs grafana --tail 500
 
-# Port-forward (--port / --address)
-mcp-runtime sentinel port-forward ui
-mcp-runtime sentinel port-forward api --port 18080
+# Restart a component
+KUBECONFIG=~/.kube/config mcp-runtime sentinel restart gateway
+KUBECONFIG=~/.kube/config mcp-runtime sentinel restart --all
+
+# Port-forward shortcuts
+KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward ui
+KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward api --port 18080
 ```
 
-**Component keys for `logs` and `restart`:** `clickhouse`, `zookeeper`, `kafka`, `ingest`, `api`, `processor`, `ui`, `gateway`, `prometheus`, `grafana`, `otel-collector`, `tempo`, `loki`, `promtail`.
+**Component keys** for `logs` and `restart`:
+`clickhouse`, `zookeeper`, `kafka`, `ingest`, `api`, `processor`, `ui`, `gateway`,
+`prometheus`, `grafana`, `otel-collector`, `tempo`, `loki`, `promtail`.
 
-**Port-forward shortcuts** are built in for: `api`, `ui`, `prometheus`, `grafana`.
+**Built-in port-forward shortcuts:** `api`, `ui`, `prometheus`, `grafana`.
+
+---
+
+## bootstrap
+
+⚙️ **Operator** — run on a fresh cluster before `setup`.
+
+Validate kubectl connectivity, CoreDNS, default `StorageClass`, Traefik
+`IngressClass`, and MetalLB availability. Missing pieces are reported as warnings
+so you can decide what to install.
+
+> **Full guide:** [Cluster readiness](cluster-readiness.md)
+
+```bash
+mcp-runtime bootstrap
+mcp-runtime bootstrap --provider k3s
+mcp-runtime bootstrap --apply --provider k3s   # automated fix — k3s only
+```
+
+---
+
+## setup
+
+⚙️ **Operator** — installs the full platform stack.
+
+Install the runtime namespace, internal registry, operator, ingress wiring, and
+the bundled sentinel analytics stack. Setup is reconcile-oriented and runs
+pre-flight checks before applying state.
+
+```bash
+# Minimal (all flags from env file)
+mcp-runtime setup --env-file config/deployments/mcpruntime-org.env
+
+# Common flags
+mcp-runtime setup --with-tls --tls-cluster-issuer letsencrypt-prod \
+  --registry-mode bundled-https --platform-mode tenant --ingress none
+
+mcp-runtime setup --with-tls --acme-email ops@example.com  # Let's Encrypt
+mcp-runtime setup --platform-mode public                   # anonymous catalog
+mcp-runtime setup --without-sentinel                       # skip analytics stack
+mcp-runtime setup --test-mode                              # local Kind dev path
+mcp-runtime setup --registry-mode external \
+  --external-registry-url registry.example.com
+```
+
+**Key env vars** (used with `--env-file`; see `config/deployments/mcpruntime-org.env.example`):
+
+| Variable | Flag equivalent |
+|---|---|
+| `MCP_SETUP_WITH_TLS=1` | `--with-tls` |
+| `MCP_SETUP_TLS_CLUSTER_ISSUER=letsencrypt-prod` | `--tls-cluster-issuer` |
+| `MCP_SETUP_REGISTRY_MODE=bundled-https` | `--registry-mode` |
+| `MCP_SETUP_PLATFORM_MODE=tenant` | `--platform-mode` |
+| `MCP_SETUP_INGRESS=none` | `--ingress` |
+| `MCP_SETUP_SKIP_CERT_MANAGER_INSTALL=1` | `--skip-cert-manager-install` |
+| `MCP_PLATFORM_DOMAIN=mcpruntime.org` | derives all three ingress hostnames |
+
+`--platform-mode` accepts `tenant` (default), `org`, or `public`.
+`--registry-mode` accepts `auto`, `bundled-http`, `bundled-https`, or `external`.
+
+---
 
 ## cluster
+
+⚙️ **Operator** — Kubernetes cluster operations.
+
+Initialize CRDs and namespaces, configure ingress, provision new clusters, and
+manage cert-manager. Most subcommands require a kubeconfig with cluster-admin RBAC.
+
+> **Full guide:** [Deployment targets](deployment-targets.md)
 
 ```bash
 # Initialize / re-target
 mcp-runtime cluster init
 mcp-runtime cluster init --kubeconfig ~/.kube/config --context dev
 
-# Configure ingress, kubeconfig, providers
+# Configure ingress
 mcp-runtime cluster config --ingress traefik
-mcp-runtime cluster config --provider eks --name mcp-runtime --region us-west-1
 
-# Provision
+# Provision a new cluster (kind / eks)
 mcp-runtime cluster provision --provider kind --nodes 3
-mcp-runtime cluster provision --provider eks --name prod-mcp
+mcp-runtime cluster provision --provider eks --name prod-mcp --region us-west-1
 
 # cert-manager helpers
 mcp-runtime cluster cert status
 mcp-runtime cluster cert apply
 mcp-runtime cluster cert wait --timeout 10m
 
-# Doctor — post-install diagnostics or setup preflight
-mcp-runtime cluster doctor
-mcp-runtime cluster doctor --for-setup
+# Post-install diagnostics (runs 37 checks)
+KUBECONFIG=~/.kube/config mcp-runtime cluster doctor
 ```
 
-**Provider status today:** `kind` and `eks` are active. `gke` and `aks` flags exist but their kubeconfig and provisioning helpers return planned/not-implemented paths in the current code.
+**Active providers:** `kind`, `eks`. (`gke` / `aks` flags exist but provisioning
+helpers are not yet implemented.)
 
-For `kind` provisioning, the CLI validates `--nodes`, checks that the Docker daemon is reachable when `KIND_EXPERIMENTAL_PROVIDER=docker` is set, lets kind auto-detect the container runtime when that env var is unset, and refuses to overwrite an existing kind cluster with the same `--name`.
+---
+
+## Platform API vs `--use-kube`
+
+Most `server` and `access` commands use the **platform API** by default.
+Set up credentials with `auth login` first.
+
+`--use-kube` is **admin/dev/test only** — it bypasses platform auth and talks
+directly to the Kubernetes API through your kubeconfig.
+
+| Default (platform API) 👤 | Requires `--use-kube` 🔑 |
+|---|---|
+| `server list`, `get`, `delete`, `status`, `policy inspect`, `deploy` | `server create`, `apply`, `export`, `patch`, `logs` |
+| `access grant/session` list, get, apply, delete, enable/disable, revoke | Same commands with `--use-kube` for raw CRD operations |
+| `registry push` | Direct `kubectl apply` for manifests |
+
+- `server get` without `--use-kube` returns a platform API summary; full MCPServer YAML needs `--use-kube`.
+- `server logs` always requires `--use-kube`; use `sentinel logs gateway` when you only have platform credentials.
+- `access session apply` via platform API is **admin-only**; agents normally get sessions automatically via `adapter --auto-refresh`.
+- `--team` is a platform API resolver and is rejected with `--use-kube`.
+
+---
 
 ## Common flows
 
 ```bash
-# Local kind cluster
-mcp-runtime cluster provision --provider kind --nodes 3
-mcp-runtime setup
-mcp-runtime auth login --api-url http://localhost:18080
+# ─── Operator: first-time cluster setup ───────────────────────────────────────
+KUBECONFIG=~/.kube/config mcp-runtime cluster provision --provider kind --nodes 3
+KUBECONFIG=~/.kube/config mcp-runtime bootstrap
+KUBECONFIG=~/.kube/config mcp-runtime setup --env-file config/deployments/mcpruntime-org.env
 
-# Push a server image
-mcp-runtime server init payments --tool list_invoices
-mcp-runtime server build image payments
-mcp-runtime registry push --scope tenant --image <exact-image-ref-from-build>
+# ─── Admin: create teams and users ────────────────────────────────────────────
+mcp-runtime auth login --api-url https://platform.mcpruntime.org \
+  --email admin@example.com --password '...' --profile admin
 
-# Deploy from metadata
-mcp-runtime server deploy payments --scope tenant --metadata-dir .mcp
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team create acme --name "Acme Corp"
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team user create acme \
+  --username acme-owner@example.com --password '...' --role owner
 
-# Scaffold and apply access policy (grant via platform API; session via adapter or admin)
-mcp-runtime access grant init payments-ops --server payments --agent-id ops-agent \
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team create globex --name "Globex Corp"
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime team user create globex \
+  --username globex-dev@example.com --password '...' --role member
+
+# ─── Developer (Team A): log in, deploy a server ──────────────────────────────
+mcp-runtime auth login --api-url https://platform.mcpruntime.org \
+  --email acme-owner@example.com --password '...' --profile acme-owner
+
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server init payments \
+  --tool list_invoices --tool refund_invoice
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server build image payments --tag v1
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime registry push \
+  --image <exact-image-ref-from-build> --scope tenant
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server deploy payments \
+  --scope tenant --metadata-dir .mcp
+
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server list
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server get payments --namespace mcp-team-acme
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime server policy inspect payments \
+  --namespace mcp-team-acme
+
+# ─── Access control: grant Team B access to Team A's server ───────────────────
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant init payments-globex \
+  --server payments --namespace mcp-team-acme \
+  --team-id <globex-team-uuid> --agent-id cursor \
   --tool list_invoices --output grant.yaml
-mcp-runtime access grant apply --file grant.yaml
-mcp-runtime adapter stdio --runtime-url http://localhost:18080/payments/mcp \
-  --server payments --agent ops-agent --auto-refresh
-mcp-runtime server policy inspect payments
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant apply --file grant.yaml
+MCP_PLATFORM_API_PROFILE=acme-owner mcp-runtime access grant list
 
-# Open the sentinel UI locally
-mcp-runtime sentinel port-forward ui
-mcp-runtime sentinel logs api --since 10m
+# ─── Admin applies a cross-team session ───────────────────────────────────────
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session init globex-session \
+  --server payments --namespace mcp-team-acme \
+  --team-id <globex-team-uuid> --agent-id cursor \
+  --trust low --expires-in 2h --output session.yaml
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session apply --file session.yaml
+MCP_PLATFORM_API_PROFILE=admin mcp-runtime access session list
 
-# Patch a running server (admin/operator — requires --use-kube)
-mcp-runtime server patch payments --patch '{"spec":{"imageTag":"v2"}}' --use-kube
-mcp-runtime server status
+# ─── Agent connects via adapter (uses auto-refresh for session) ───────────────
+mcp-runtime adapter stdio \
+  --runtime-url https://platform.mcpruntime.org/payments/mcp \
+  --server payments --agent cursor --auto-refresh
+
+# ─── Operator: inspect the stack ──────────────────────────────────────────────
 mcp-runtime status
+KUBECONFIG=~/.kube/config mcp-runtime sentinel status
+KUBECONFIG=~/.kube/config mcp-runtime sentinel logs api --since 10m
+KUBECONFIG=~/.kube/config mcp-runtime sentinel port-forward ui
+
+# ─── Admin: patch a running server (Kubernetes) ───────────────────────────────
+KUBECONFIG=~/.kube/config mcp-runtime server patch payments \
+  --namespace mcp-team-acme --patch '{"spec":{"imageTag":"v2"}}' --use-kube
+KUBECONFIG=~/.kube/config mcp-runtime server logs payments \
+  --namespace mcp-team-acme --tail 50 --use-kube
 ```
 
-## Next
+---
 
-- [API](api.md) — exact resource fields the CLI is wrapping.
-- [Publish an MCP Server](publish-mcp-server.md) — manifest, metadata, image push, deploy, and verification flow.
-- [Sentinel](sentinel.md) — how `sentinel logs / events / restart` map to the bundled stack.
-- [Cluster readiness](cluster-readiness.md) — distro-specific prerequisites.
+## Further reading
+
+| Topic | Link |
+|---|---|
+| Build, push, deploy, verify a server end-to-end (includes `server validate`) | [Publish an MCP Server](publish-mcp-server.md) |
+| Resource fields: MCPServer, MCPAccessGrant, MCPAgentSession | [API reference](api.md) |
+| HTTP proxy and stdio adapter configuration | [Agent adapters](agent-adapters.md) |
+| Multi-team namespaces, RBAC, isolation | [Multi-team isolation](multi-team.md) |
+| Sentinel logs, events, restart, port-forward | [Sentinel](sentinel.md) |
+| Distro-specific cluster prerequisites | [Cluster readiness](cluster-readiness.md) |
+| Kind, EKS, GKE, AKS, k3s deployment | [Deployment targets](deployment-targets.md) |

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -5704,6 +5704,7 @@ Package server owns routing for the server top-level command.
 ### Index
 
 - [`func BuildImage(ctx context.Context, logger *zap.Logger, serverName, dockerfile, metadataFile, metadataDir, registryURL, tag, platform, contextDir string) error`](#cli-server-func-buildimage-ctx-context-context-logger-zap-logger-servername-dockerfile-metadatafile-metadatadir-registryurl-tag-platform-contextdir-string-error)
+- [`func DiscoverToolsFromServer(serverURL string) ([]string, error)`](#cli-server-func-discovertoolsfromserver-serverurl-string-string-error)
 - [`func New(runtime *core.Runtime) *cobra.Command`](#cli-server-func-new-runtime-core-runtime-cobra-command)
 - [`func NewWithManager(mgr *ServerManager) *cobra.Command`](#cli-server-func-newwithmanager-mgr-servermanager-cobra-command)
 - [`type ServerManager struct`](#cli-server-type-servermanager-struct)
@@ -5733,6 +5734,19 @@ Package server owns routing for the server top-level command.
 ```text
 func BuildImage(ctx context.Context, logger *zap.Logger, serverName, dockerfile, metadataFile, metadataDir, registryURL, tag, platform, contextDir string) error
     BuildImage builds a Docker image and updates MCP metadata for the server.
+
+```
+
+<a id="cli-server-func-discovertoolsfromserver-serverurl-string-string-error"></a>
+```text
+func DiscoverToolsFromServer(serverURL string) ([]string, error)
+    DiscoverToolsFromServer connects to a running MCP server at url and returns
+    the tool names. They are returned as bare names; callers wrap them into
+    --tool flags or metadata.ToolConfig values.
+
+    If url does not end with an explicit path, /mcp is appended automatically
+    because that is the default MCP endpoint path used by the go-sdk and the
+    workspace-assistant-mcp example server.
 
 ```
 

--- a/docs/internals/go-package-reference.md
+++ b/docs/internals/go-package-reference.md
@@ -5740,13 +5740,12 @@ func BuildImage(ctx context.Context, logger *zap.Logger, serverName, dockerfile,
 <a id="cli-server-func-discovertoolsfromserver-serverurl-string-string-error"></a>
 ```text
 func DiscoverToolsFromServer(serverURL string) ([]string, error)
-    DiscoverToolsFromServer connects to a running MCP server at url and returns
-    the tool names. They are returned as bare names; callers wrap them into
-    --tool flags or metadata.ToolConfig values.
+    DiscoverToolsFromServer connects to a running MCP server at serverURL and
+    returns the tool names. They are returned as bare names; callers wrap them
+    into --tool flags or metadata.ToolConfig values.
 
-    If url does not end with an explicit path, /mcp is appended automatically
-    because that is the default MCP endpoint path used by the go-sdk and the
-    workspace-assistant-mcp example server.
+    If the URL has no explicit path, /mcp is appended automatically (the default
+    MCP endpoint path used by the go-sdk).
 
 ```
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -16,41 +16,19 @@ The runtime is the Kubernetes-native control plane for MCP servers. It owns the 
 
 ## Core resources
 
+| Resource | Key fields |
+|---|---|
+| **MCPServer** | `image`, `imageTag`, `teamID`, `port`, `publicPathPrefix`, `tools[]`, `gateway.enabled`, `rollout` |
+| **MCPAccessGrant** | `serverRef`, `subject` (humanID / agentID / teamID), `maxTrust`, `allowedSideEffects[]`, `toolRules[]`, `disabled` |
+| **MCPAgentSession** | `serverRef`, `subject`, `consentedTrust`, `expiresAt`, `revoked`, `upstreamTokenSecretRef` |
+
+`MCPServer` is referenced by many grants and sessions. Grant + session are evaluated together by the gateway policy layer.
+
 ```mermaid
-classDiagram
-    class MCPServer {
-      +teamID
-      +image, imageTag
-      +port, publicPathPrefix
-      +ingressHost, ingressPath
-      +tools[]
-      +auth, policy, session
-      +gateway.enabled
-      +analytics.disabled
-      +rollout
-      +status
-    }
-    class MCPAccessGrant {
-      +serverRef
-      +subject (humanID, agentID, teamID)
-      +maxTrust
-      +allowedSideEffects[]
-      +toolRules[]
-      +disabled
-      +status
-    }
-    class MCPAgentSession {
-      +serverRef
-      +subject
-      +consentedTrust
-      +expiresAt
-      +revoked
-      +upstreamTokenSecretRef
-      +status
-    }
-    MCPServer "1" o-- "many" MCPAccessGrant : referenced by
-    MCPServer "1" o-- "many" MCPAgentSession : referenced by
-    MCPAccessGrant "1" .. "1" MCPAgentSession : evaluated together
+flowchart LR
+    S[MCPServer] --> G[MCPAccessGrant]
+    S --> T[MCPAgentSession]
+    G -. evaluated together .-> T
 ```
 
 See the [API reference](api.md) for full field semantics.

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -68,7 +68,19 @@ For pushing images, use 'registry push'.`,
 					core.Warn("No tools returned by the server; metadata will have an empty tool list")
 				} else {
 					core.Info(fmt.Sprintf("Discovered %d tool(s): %s", len(discovered), strings.Join(discovered, ", ")))
-					initTools = append(discovered, initTools...)
+					// Merge: discovered tools first, then any manually specified --tool
+					// flags that are not already in the discovered set.
+					manualSet := make(map[string]struct{}, len(initTools))
+					for _, t := range discovered {
+						manualSet[t] = struct{}{}
+					}
+					merged := append([]string{}, discovered...)
+					for _, t := range initTools {
+						if _, exists := manualSet[strings.TrimSpace(t)]; !exists {
+							merged = append(merged, t)
+						}
+					}
+					initTools = merged
 				}
 			}
 			return mgr.InitServer(args[0], initMetadataDir, initImage, initTag, initScope, initPolicyMode, initDefaultDecision, initSessionRequired, initPort, initTools, initToolSpecs, initForce)

--- a/internal/cli/server/server.go
+++ b/internal/cli/server/server.go
@@ -2,7 +2,9 @@
 package server
 
 import (
+	"fmt"
 	"math"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -49,12 +51,26 @@ For pushing images, use 'registry push'.`,
 	var initTools []string
 	var initToolSpecs []string
 	var initForce bool
+	var initFromServer string
 	initCmd := &cobra.Command{
 		Use:   "init [name]",
 		Short: "Initialize .mcp metadata for a server",
-		Long:  "Initialize .mcp/servers.yaml metadata for a server. Use repeated --tool flags to seed governed tool metadata, then build, push, and deploy with server build image, registry push, and server deploy.",
+		Long:  "Initialize .mcp/servers.yaml metadata for a server. Use --tool flags to seed governed tool metadata, or --from-server to discover tools from a running MCP server automatically. Then build, push, and deploy with server build image, registry push, and server deploy.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if initFromServer != "" {
+				core.Info(fmt.Sprintf("Discovering tools from %s ...", initFromServer))
+				discovered, err := DiscoverToolsFromServer(initFromServer)
+				if err != nil {
+					return fmt.Errorf("--from-server %s: %w", initFromServer, err)
+				}
+				if len(discovered) == 0 {
+					core.Warn("No tools returned by the server; metadata will have an empty tool list")
+				} else {
+					core.Info(fmt.Sprintf("Discovered %d tool(s): %s", len(discovered), strings.Join(discovered, ", ")))
+					initTools = append(discovered, initTools...)
+				}
+			}
 			return mgr.InitServer(args[0], initMetadataDir, initImage, initTag, initScope, initPolicyMode, initDefaultDecision, initSessionRequired, initPort, initTools, initToolSpecs, initForce)
 		},
 	}
@@ -69,6 +85,7 @@ For pushing images, use 'registry push'.`,
 	initCmd.Flags().StringArrayVar(&initTools, "tool", nil, "Tool name to add with read side-effect metadata; repeat for multiple tools")
 	initCmd.Flags().StringArrayVar(&initToolSpecs, "tool-spec", nil, "Tool metadata as name:low|medium|high:read|write|destructive; repeat for mixed trust or side effects")
 	initCmd.Flags().BoolVar(&initForce, "force", false, "Replace an existing metadata entry with the same server name")
+	initCmd.Flags().StringVar(&initFromServer, "from-server", "", "Discover tools by calling tools/list on a running MCP server at this URL (e.g. http://localhost:8088); discovered names are merged with --tool flags")
 
 	var namespace string
 	var team string
@@ -269,7 +286,7 @@ For pushing images, use 'registry push'.`,
 	}
 	buildCmd.AddCommand(newBuildImageCmd(mgr.Logger()))
 
-	cmd.AddCommand(initCmd, listCmd, getCmd, createCmd, applyCmd, deployCmd, generateCmd, exportCmd, patchCmd, deleteCmd, logsCmd, statusCmd, policyCmd, buildCmd)
+	cmd.AddCommand(initCmd, listCmd, getCmd, createCmd, applyCmd, deployCmd, generateCmd, exportCmd, patchCmd, deleteCmd, logsCmd, statusCmd, policyCmd, buildCmd, newValidateCmd())
 	return cmd
 }
 

--- a/internal/cli/server/sync_tools.go
+++ b/internal/cli/server/sync_tools.go
@@ -1,31 +1,34 @@
 package server
 
 // discoverToolsFromServer calls tools/list on a running MCP server and returns
-// the discovered tools as --tool-spec strings (name:trust:sideEffect).
-// It performs a minimal initialize → notifications/initialized → tools/list
-// handshake so any server that follows the MCP spec will respond correctly.
+// the discovered tool names. It performs a minimal initialize →
+// notifications/initialized → tools/list handshake so any MCP-compliant server
+// will respond correctly.
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
 
 // decodeMCPResponse reads an HTTP response that is either plain JSON or
 // SSE (text/event-stream) and returns the first JSON-RPC message found.
+// It uses a 1 MiB per-line scanner buffer to safely handle large tool lists.
 func decodeMCPResponse(resp *http.Response) (*mcpResponse, error) {
 	ct := strings.ToLower(resp.Header.Get("Content-Type"))
 	if strings.Contains(ct, "text/event-stream") {
-		// Parse SSE: find the first "data: {...}" line that is a JSON-RPC response.
-		scanner := bufio.NewScanner(resp.Body)
-		for scanner.Scan() {
-			line := scanner.Text()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read SSE body: %w", err)
+		}
+		for _, line := range strings.Split(string(body), "\n") {
+			line = strings.TrimRight(line, "\r")
 			if !strings.HasPrefix(line, "data:") {
 				continue
 			}
@@ -41,13 +44,13 @@ func decodeMCPResponse(resp *http.Response) (*mcpResponse, error) {
 		return nil, fmt.Errorf("no JSON-RPC message found in SSE stream")
 	}
 	// Plain JSON (or unknown — try JSON first)
-	body, err := io.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 	var r mcpResponse
-	if err := json.Unmarshal(body, &r); err != nil {
-		return nil, fmt.Errorf("%w (body prefix: %.40s)", err, string(body))
+	if err := json.Unmarshal(b, &r); err != nil {
+		return nil, fmt.Errorf("%w (body prefix: %.40s)", err, string(b))
 	}
 	return &r, nil
 }
@@ -76,18 +79,33 @@ type mcpToolsListResult struct {
 	} `json:"tools"`
 }
 
-// DiscoverToolsFromServer connects to a running MCP server at url and returns
-// the tool names. They are returned as bare names; callers wrap them into
-// --tool flags or metadata.ToolConfig values.
+// normalizeMCPURL ensures the URL has an explicit path. If the parsed URL has
+// no path (or just "/"), "/mcp" is appended — the default endpoint used by the
+// go-sdk and the workspace-assistant-mcp example server.
+func normalizeMCPURL(raw string) (string, error) {
+	u, err := url.Parse(strings.TrimRight(raw, "/"))
+	if err != nil {
+		return "", fmt.Errorf("invalid server URL %q: %w", raw, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid server URL %q: must include scheme and host (e.g. http://localhost:8088)", raw)
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = "/mcp"
+	}
+	return u.String(), nil
+}
+
+// DiscoverToolsFromServer connects to a running MCP server at serverURL and
+// returns the tool names. They are returned as bare names; callers wrap them
+// into --tool flags or metadata.ToolConfig values.
 //
-// If url does not end with an explicit path, /mcp is appended automatically
-// because that is the default MCP endpoint path used by the go-sdk and the
-// workspace-assistant-mcp example server.
+// If the URL has no explicit path, /mcp is appended automatically (the default
+// MCP endpoint path used by the go-sdk).
 func DiscoverToolsFromServer(serverURL string) ([]string, error) {
-	serverURL = strings.TrimRight(serverURL, "/")
-	// Append /mcp if no path segment is present (e.g. http://localhost:8088)
-	if !strings.Contains(serverURL[strings.Index(serverURL, "://")+3:], "/") {
-		serverURL += "/mcp"
+	endpoint, err := normalizeMCPURL(serverURL)
+	if err != nil {
+		return nil, err
 	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -96,7 +114,7 @@ func DiscoverToolsFromServer(serverURL string) ([]string, error) {
 
 	post := func(req mcpRequest) (*mcpResponse, string, error) {
 		body, _ := json.Marshal(req)
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, bytes.NewReader(body))
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 		if err != nil {
 			return nil, "", err
 		}
@@ -105,7 +123,7 @@ func DiscoverToolsFromServer(serverURL string) ([]string, error) {
 		httpReq.Header.Set("Accept", "application/json, text/event-stream")
 		resp, err := client.Do(httpReq)
 		if err != nil {
-			return nil, "", fmt.Errorf("request to %s failed: %w", serverURL, err)
+			return nil, "", fmt.Errorf("request to %s failed: %w", endpoint, err)
 		}
 		defer resp.Body.Close()
 		sessionID := resp.Header.Get("Mcp-Session-Id")
@@ -118,7 +136,7 @@ func DiscoverToolsFromServer(serverURL string) ([]string, error) {
 
 	postWithSession := func(sessionID string, req mcpRequest) (*mcpResponse, error) {
 		body, _ := json.Marshal(req)
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, bytes.NewReader(body))
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -129,17 +147,11 @@ func DiscoverToolsFromServer(serverURL string) ([]string, error) {
 		}
 		resp, err := client.Do(httpReq)
 		if err != nil {
-			return nil, fmt.Errorf("request to %s failed: %w", serverURL, err)
+			return nil, fmt.Errorf("request to %s failed: %w", endpoint, err)
 		}
 		defer resp.Body.Close()
-		mcpResp, err := decodeMCPResponse(resp)
-		if err != nil {
-			return nil, fmt.Errorf("decode response: %w", err)
-		}
-		return mcpResp, nil
+		return decodeMCPResponse(resp)
 	}
-
-	// decodeMCPResponse is defined outside the closures to avoid redeclaration.
 
 	// Step 1: initialize
 	initResp, sessionID, err := post(mcpRequest{
@@ -159,7 +171,7 @@ func DiscoverToolsFromServer(serverURL string) ([]string, error) {
 		return nil, fmt.Errorf("initialize error: %s", initResp.Error.Message)
 	}
 
-	// Step 2: notifications/initialized (no response expected)
+	// Step 2: notifications/initialized (no response body expected)
 	_, _ = postWithSession(sessionID, mcpRequest{ //nolint:errcheck
 		JSONRPC: "2.0",
 		Method:  "notifications/initialized",
@@ -184,11 +196,18 @@ func DiscoverToolsFromServer(serverURL string) ([]string, error) {
 		return nil, fmt.Errorf("parse tools/list result: %w", err)
 	}
 
+	seen := make(map[string]struct{}, len(result.Tools))
 	names := make([]string, 0, len(result.Tools))
 	for _, t := range result.Tools {
-		if strings.TrimSpace(t.Name) != "" {
-			names = append(names, t.Name)
+		name := strings.TrimSpace(t.Name)
+		if name == "" {
+			continue
 		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
 	}
 	return names, nil
 }

--- a/internal/cli/server/sync_tools.go
+++ b/internal/cli/server/sync_tools.go
@@ -1,0 +1,194 @@
+package server
+
+// discoverToolsFromServer calls tools/list on a running MCP server and returns
+// the discovered tools as --tool-spec strings (name:trust:sideEffect).
+// It performs a minimal initialize → notifications/initialized → tools/list
+// handshake so any server that follows the MCP spec will respond correctly.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// decodeMCPResponse reads an HTTP response that is either plain JSON or
+// SSE (text/event-stream) and returns the first JSON-RPC message found.
+func decodeMCPResponse(resp *http.Response) (*mcpResponse, error) {
+	ct := strings.ToLower(resp.Header.Get("Content-Type"))
+	if strings.Contains(ct, "text/event-stream") {
+		// Parse SSE: find the first "data: {...}" line that is a JSON-RPC response.
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if payload == "" || payload == "[DONE]" {
+				continue
+			}
+			var r mcpResponse
+			if err := json.Unmarshal([]byte(payload), &r); err == nil {
+				return &r, nil
+			}
+		}
+		return nil, fmt.Errorf("no JSON-RPC message found in SSE stream")
+	}
+	// Plain JSON (or unknown — try JSON first)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var r mcpResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("%w (body prefix: %.40s)", err, string(body))
+	}
+	return &r, nil
+}
+
+type mcpRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id,omitempty"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+type mcpResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      any             `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type mcpToolsListResult struct {
+	Tools []struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	} `json:"tools"`
+}
+
+// DiscoverToolsFromServer connects to a running MCP server at url and returns
+// the tool names. They are returned as bare names; callers wrap them into
+// --tool flags or metadata.ToolConfig values.
+//
+// If url does not end with an explicit path, /mcp is appended automatically
+// because that is the default MCP endpoint path used by the go-sdk and the
+// workspace-assistant-mcp example server.
+func DiscoverToolsFromServer(serverURL string) ([]string, error) {
+	serverURL = strings.TrimRight(serverURL, "/")
+	// Append /mcp if no path segment is present (e.g. http://localhost:8088)
+	if !strings.Contains(serverURL[strings.Index(serverURL, "://")+3:], "/") {
+		serverURL += "/mcp"
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	post := func(req mcpRequest) (*mcpResponse, string, error) {
+		body, _ := json.Marshal(req)
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, "", err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		// MCP 2025-06-18 requires both application/json and text/event-stream.
+		httpReq.Header.Set("Accept", "application/json, text/event-stream")
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, "", fmt.Errorf("request to %s failed: %w", serverURL, err)
+		}
+		defer resp.Body.Close()
+		sessionID := resp.Header.Get("Mcp-Session-Id")
+		mcpResp, err := decodeMCPResponse(resp)
+		if err != nil {
+			return nil, sessionID, fmt.Errorf("decode response: %w", err)
+		}
+		return mcpResp, sessionID, nil
+	}
+
+	postWithSession := func(sessionID string, req mcpRequest) (*mcpResponse, error) {
+		body, _ := json.Marshal(req)
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, serverURL, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "application/json, text/event-stream")
+		if sessionID != "" {
+			httpReq.Header.Set("Mcp-Session-Id", sessionID)
+		}
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			return nil, fmt.Errorf("request to %s failed: %w", serverURL, err)
+		}
+		defer resp.Body.Close()
+		mcpResp, err := decodeMCPResponse(resp)
+		if err != nil {
+			return nil, fmt.Errorf("decode response: %w", err)
+		}
+		return mcpResp, nil
+	}
+
+	// decodeMCPResponse is defined outside the closures to avoid redeclaration.
+
+	// Step 1: initialize
+	initResp, sessionID, err := post(mcpRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]any{
+			"protocolVersion": "2025-06-18",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "mcp-runtime-discover", "version": "1.0"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("initialize: %w", err)
+	}
+	if initResp.Error != nil {
+		return nil, fmt.Errorf("initialize error: %s", initResp.Error.Message)
+	}
+
+	// Step 2: notifications/initialized (no response expected)
+	_, _ = postWithSession(sessionID, mcpRequest{ //nolint:errcheck
+		JSONRPC: "2.0",
+		Method:  "notifications/initialized",
+	})
+
+	// Step 3: tools/list
+	toolsResp, err := postWithSession(sessionID, mcpRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/list",
+		Params:  map[string]any{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("tools/list: %w", err)
+	}
+	if toolsResp.Error != nil {
+		return nil, fmt.Errorf("tools/list error: %s", toolsResp.Error.Message)
+	}
+
+	var result mcpToolsListResult
+	if err := json.Unmarshal(toolsResp.Result, &result); err != nil {
+		return nil, fmt.Errorf("parse tools/list result: %w", err)
+	}
+
+	names := make([]string, 0, len(result.Tools))
+	for _, t := range result.Tools {
+		if strings.TrimSpace(t.Name) != "" {
+			names = append(names, t.Name)
+		}
+	}
+	return names, nil
+}

--- a/internal/cli/server/validate.go
+++ b/internal/cli/server/validate.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -116,7 +117,7 @@ Use --from-server to also verify tool names against a locally running MCP server
 	return cmd
 }
 
-// validateServer checks a single ServerConfig entry.
+// validateServer checks a single ServerMetadata entry.
 func validateServer(srv metadata.ServerMetadata) []validateIssue {
 	var issues []validateIssue
 
@@ -175,38 +176,86 @@ func validateServer(srv metadata.ServerMetadata) []validateIssue {
 	return issues
 }
 
+// grantYAML is the subset of MCPAccessGrant fields we validate.
+type grantYAML struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		ServerRef struct {
+			Name      string `yaml:"name"`
+			Namespace string `yaml:"namespace"`
+		} `yaml:"serverRef"`
+		MaxTrust           string   `yaml:"maxTrust"`
+		AllowedSideEffects []string `yaml:"allowedSideEffects"`
+		ToolRules          []struct {
+			Name          string `yaml:"name"`
+			Decision      string `yaml:"decision"`
+			RequiredTrust string `yaml:"requiredTrust"`
+		} `yaml:"toolRules"`
+	} `yaml:"spec"`
+}
+
 // validateGrantFile reads an MCPAccessGrant YAML and checks that every tool
-// rule references a tool that is defined in the server metadata.
+// rule references a tool defined in the server metadata and that side effects
+// and trust levels are valid enum values.
 func validateGrantFile(path string, cfg *metadata.RegistryFile) ([]validateIssue, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- explicit CLI flag path
 	if err != nil {
 		return nil, err
 	}
 
-	var grant struct {
-		Spec struct {
-			ServerRef struct {
-				Name      string `yaml:"name" json:"name"`
-				Namespace string `yaml:"namespace" json:"namespace"`
-			} `yaml:"serverRef" json:"serverRef"`
-			AllowedSideEffects []string `yaml:"allowedSideEffects" json:"allowedSideEffects"`
-			ToolRules          []struct {
-				Name     string `yaml:"name" json:"name"`
-				Decision string `yaml:"decision" json:"decision"`
-			} `yaml:"toolRules" json:"toolRules"`
-		} `yaml:"spec" json:"spec"`
-		Metadata struct {
-			Name string `yaml:"name" json:"name"`
-		} `yaml:"metadata" json:"metadata"`
-	}
+	var grant grantYAML
 	if err := yaml.Unmarshal(data, &grant); err != nil {
 		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+
+	var issues []validateIssue
+
+	// Check resource kind so users don't accidentally pass the wrong file type.
+	if grant.Kind != "" && grant.Kind != "MCPAccessGrant" {
+		issues = append(issues, validateIssue{
+			fatal:   true,
+			message: fmt.Sprintf("%s: expected kind MCPAccessGrant, got %q — wrong file passed to --grant-file?", path, grant.Kind),
+		})
+		return issues, nil
 	}
 
 	grantName := grant.Metadata.Name
 	serverName := grant.Spec.ServerRef.Name
 
-	// Find the matching server in metadata
+	// Validate maxTrust if set.
+	if t := strings.ToLower(strings.TrimSpace(grant.Spec.MaxTrust)); t != "" {
+		switch metadata.TrustLevel(t) {
+		case metadata.TrustLevelLow, metadata.TrustLevelMedium, metadata.TrustLevelHigh:
+		default:
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("grant %q: invalid maxTrust %q", grantName, grant.Spec.MaxTrust),
+				hint:    "Valid values: low, medium, high",
+			})
+		}
+	}
+
+	// Validate allowedSideEffects enum values.
+	allowedEffects := map[string]struct{}{}
+	for _, e := range grant.Spec.AllowedSideEffects {
+		lower := strings.ToLower(strings.TrimSpace(e))
+		switch metadata.ToolSideEffect(lower) {
+		case metadata.ToolSideEffectRead, metadata.ToolSideEffectWrite, metadata.ToolSideEffectDestructive:
+			allowedEffects[lower] = struct{}{}
+		default:
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("grant %q: invalid allowedSideEffect %q", grantName, e),
+				hint:    "Valid values: read, write, destructive",
+			})
+		}
+	}
+
+	// Find the matching server in metadata.
 	var srv *metadata.ServerMetadata
 	for i := range cfg.Servers {
 		if cfg.Servers[i].Name == serverName {
@@ -214,9 +263,6 @@ func validateGrantFile(path string, cfg *metadata.RegistryFile) ([]validateIssue
 			break
 		}
 	}
-
-	var issues []validateIssue
-
 	if srv == nil {
 		issues = append(issues, validateIssue{
 			fatal:   false,
@@ -226,19 +272,36 @@ func validateGrantFile(path string, cfg *metadata.RegistryFile) ([]validateIssue
 		return issues, nil
 	}
 
-	// Build tool map from server metadata
+	// Build tool map from server metadata.
 	toolMap := map[string]metadata.ToolConfig{}
 	for _, t := range srv.Tools {
 		toolMap[t.Name] = t
 	}
 
-	// Build allowed side effects set
-	allowedEffects := map[string]struct{}{}
-	for _, e := range grant.Spec.AllowedSideEffects {
-		allowedEffects[strings.ToLower(e)] = struct{}{}
-	}
-
 	for _, rule := range grant.Spec.ToolRules {
+		// Validate decision enum.
+		switch strings.ToLower(rule.Decision) {
+		case "allow", "deny", "":
+		default:
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("grant %q toolRule %q: invalid decision %q", grantName, rule.Name, rule.Decision),
+				hint:    "Valid values: allow, deny",
+			})
+		}
+		// Validate requiredTrust enum.
+		if t := strings.ToLower(strings.TrimSpace(rule.RequiredTrust)); t != "" {
+			switch metadata.TrustLevel(t) {
+			case metadata.TrustLevelLow, metadata.TrustLevelMedium, metadata.TrustLevelHigh:
+			default:
+				issues = append(issues, validateIssue{
+					fatal:   true,
+					message: fmt.Sprintf("grant %q toolRule %q: invalid requiredTrust %q", grantName, rule.Name, rule.RequiredTrust),
+					hint:    "Valid values: low, medium, high",
+				})
+			}
+		}
+
 		toolCfg, exists := toolMap[rule.Name]
 		if !exists {
 			issues = append(issues, validateIssue{
@@ -255,7 +318,7 @@ func validateGrantFile(path string, cfg *metadata.RegistryFile) ([]validateIssue
 			continue
 		}
 
-		if rule.Decision == "allow" {
+		if strings.ToLower(rule.Decision) == "allow" {
 			effect := string(toolCfg.SideEffect)
 			if _, ok := allowedEffects[effect]; !ok {
 				issues = append(issues, validateIssue{
@@ -273,6 +336,25 @@ func validateGrantFile(path string, cfg *metadata.RegistryFile) ([]validateIssue
 	return issues, nil
 }
 
+// sessionYAML is the subset of MCPAgentSession fields we validate.
+type sessionYAML struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		ServerRef struct {
+			Name string `yaml:"name"`
+		} `yaml:"serverRef"`
+		Subject struct {
+			AgentID string `yaml:"agentID"`
+		} `yaml:"subject"`
+		ConsentedTrust string `yaml:"consentedTrust"`
+		ExpiresAt      string `yaml:"expiresAt"`
+	} `yaml:"spec"`
+}
+
 // validateSessionFile reads an MCPAgentSession YAML and checks basic consistency.
 func validateSessionFile(path string, cfg *metadata.RegistryFile) ([]validateIssue, error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- explicit CLI flag path
@@ -280,26 +362,22 @@ func validateSessionFile(path string, cfg *metadata.RegistryFile) ([]validateIss
 		return nil, err
 	}
 
-	var session struct {
-		Spec struct {
-			ServerRef struct {
-				Name string `yaml:"name" json:"name"`
-			} `yaml:"serverRef" json:"serverRef"`
-			Subject struct {
-				AgentID string `yaml:"agentID" json:"agentID"`
-			} `yaml:"subject" json:"subject"`
-			ConsentedTrust string `yaml:"consentedTrust" json:"consentedTrust"`
-			ExpiresAt      string `yaml:"expiresAt" json:"expiresAt"`
-		} `yaml:"spec" json:"spec"`
-		Metadata struct {
-			Name string `yaml:"name" json:"name"`
-		} `yaml:"metadata" json:"metadata"`
-	}
+	var session sessionYAML
 	if err := yaml.Unmarshal(data, &session); err != nil {
 		return nil, fmt.Errorf("parse YAML: %w", err)
 	}
 
 	var issues []validateIssue
+
+	// Check resource kind.
+	if session.Kind != "" && session.Kind != "MCPAgentSession" {
+		issues = append(issues, validateIssue{
+			fatal:   true,
+			message: fmt.Sprintf("%s: expected kind MCPAgentSession, got %q — wrong file passed to --session-file?", path, session.Kind),
+		})
+		return issues, nil
+	}
+
 	name := session.Metadata.Name
 	serverName := session.Spec.ServerRef.Name
 
@@ -321,19 +399,33 @@ func validateSessionFile(path string, cfg *metadata.RegistryFile) ([]validateIss
 		})
 	}
 
-	// Check that the referenced server exists in metadata
+	// Validate expiresAt is a valid RFC3339 timestamp if set.
+	if ts := strings.TrimSpace(session.Spec.ExpiresAt); ts != "" {
+		if _, err := time.Parse(time.RFC3339, ts); err != nil {
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("session %q: expiresAt %q is not a valid RFC3339 timestamp: %v", name, ts, err),
+				hint:    "Use the format 2006-01-02T15:04:05Z, e.g. 2026-06-01T12:00:00Z",
+			})
+		}
+	}
+
+	// Check that the referenced server exists in metadata.
 	found := false
 	for _, srv := range cfg.Servers {
-		if srv.Name == serverName {
-			found = true
-			if srv.Policy.DefaultDecision == metadata.PolicyDecisionDeny && len(srv.Tools) == 0 {
-				issues = append(issues, validateIssue{
-					fatal:   false,
-					message: fmt.Sprintf("session %q: server %q has default-deny policy but no tools — all tool calls will be denied", name, serverName),
-				})
-			}
-			break
+		if srv.Name != serverName {
+			continue
 		}
+		found = true
+		// Guard nil policy — PolicyConfig is an embedded struct, not a pointer,
+		// but DefaultDecision may be the zero value "".
+		if srv.Policy.DefaultDecision == metadata.PolicyDecisionDeny && len(srv.Tools) == 0 {
+			issues = append(issues, validateIssue{
+				fatal:   false,
+				message: fmt.Sprintf("session %q: server %q has default-deny policy but no tools — all tool calls will be denied", name, serverName),
+			})
+		}
+		break
 	}
 
 	if !found {
@@ -347,14 +439,27 @@ func validateSessionFile(path string, cfg *metadata.RegistryFile) ([]validateIss
 }
 
 // validateToolsAgainstServer calls tools/list on a running MCP server and
-// checks that each tool in the metadata actually exists there.
-func validateToolsAgainstServer(url string, cfg *metadata.RegistryFile) []validateIssue {
-	core.Info(fmt.Sprintf("Verifying tool names against running server: %s", url))
-	discovered, err := DiscoverToolsFromServer(url)
+// checks that each tool in the metadata actually exists there. When
+// servers.yaml contains multiple servers the check is skipped for all but the
+// first one because --from-server points at a single endpoint.
+func validateToolsAgainstServer(rawURL string, cfg *metadata.RegistryFile) []validateIssue {
+	if len(cfg.Servers) == 0 {
+		return nil
+	}
+	if len(cfg.Servers) > 1 {
+		return []validateIssue{{
+			fatal:   false,
+			message: fmt.Sprintf("--from-server: metadata has %d servers; only validating tools for the first server %q against %s", len(cfg.Servers), cfg.Servers[0].Name, rawURL),
+		}}
+	}
+	srv := cfg.Servers[0]
+
+	core.Info(fmt.Sprintf("Verifying tool names for server %q against running server: %s", srv.Name, rawURL))
+	discovered, err := DiscoverToolsFromServer(rawURL)
 	if err != nil {
 		return []validateIssue{{
 			fatal:   false,
-			message: fmt.Sprintf("--from-server %s: %v", url, err),
+			message: fmt.Sprintf("--from-server %s: %v", rawURL, err),
 			hint:    "Make sure the server is running and reachable before running validate.",
 		}}
 	}
@@ -365,32 +470,31 @@ func validateToolsAgainstServer(url string, cfg *metadata.RegistryFile) []valida
 	}
 
 	var issues []validateIssue
-	for _, srv := range cfg.Servers {
-		for _, tool := range srv.Tools {
-			if _, ok := serverSet[tool.Name]; !ok {
-				issues = append(issues, validateIssue{
-					fatal: true,
-					message: fmt.Sprintf(
-						"server %q tool %q is in metadata but not found in tools/list from %s — gateway will return tool_side_effect_unknown",
-						srv.Name, tool.Name, url,
-					),
-					hint: fmt.Sprintf("Server implements: %s", strings.Join(discovered, ", ")),
-				})
-			}
+	for _, tool := range srv.Tools {
+		if _, ok := serverSet[tool.Name]; !ok {
+			issues = append(issues, validateIssue{
+				fatal: true,
+				message: fmt.Sprintf(
+					"server %q tool %q is in metadata but not found in tools/list from %s — gateway will return tool_side_effect_unknown",
+					srv.Name, tool.Name, rawURL,
+				),
+				hint: fmt.Sprintf("Server implements: %s", strings.Join(discovered, ", ")),
+			})
 		}
-		// Warn about tools on the server that are not in metadata
-		metaSet := map[string]struct{}{}
-		for _, t := range srv.Tools {
-			metaSet[t.Name] = struct{}{}
-		}
-		for _, name := range discovered {
-			if _, ok := metaSet[name]; !ok {
-				issues = append(issues, validateIssue{
-					fatal:   false,
-					message: fmt.Sprintf("server %q: tool %q is exposed by the running server but not in metadata — it will be ungoverned (denied by default policy)", srv.Name, name),
-					hint:    fmt.Sprintf("Add to servers.yaml: --tool %s  or  --tool-spec %s:low:read", name, name),
-				})
-			}
+	}
+
+	// Warn about tools on the server that are not in metadata.
+	metaSet := map[string]struct{}{}
+	for _, t := range srv.Tools {
+		metaSet[t.Name] = struct{}{}
+	}
+	for _, name := range discovered {
+		if _, ok := metaSet[name]; !ok {
+			issues = append(issues, validateIssue{
+				fatal:   false,
+				message: fmt.Sprintf("server %q: tool %q is exposed by the running server but not in metadata — it will be ungoverned (denied by default policy)", srv.Name, name),
+				hint:    fmt.Sprintf("Add to servers.yaml: --tool %s  or  --tool-spec %s:low:read", name, name),
+			})
 		}
 	}
 	return issues

--- a/internal/cli/server/validate.go
+++ b/internal/cli/server/validate.go
@@ -1,0 +1,421 @@
+package server
+
+// validateCmd implements `server validate` — checks .mcp/servers.yaml and optional
+// grant/session YAML files for common errors before build/deploy so issues are
+// caught early rather than at policy-enforcement time in the cluster.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"mcp-runtime/internal/cli/core"
+	"mcp-runtime/pkg/metadata"
+)
+
+type validateIssue struct {
+	fatal   bool
+	message string
+	hint    string
+}
+
+func newValidateCmd() *cobra.Command {
+	var metadataDir string
+	var metadataFile string
+	var grantFiles []string
+	var sessionFiles []string
+	var discoverURL string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate .mcp metadata and optional grant/session YAML files",
+		Long: `Check .mcp/servers.yaml and optional MCPAccessGrant / MCPAgentSession YAML files
+for common errors before building or deploying a server.
+
+Catches:
+  - missing or duplicate tool names
+  - invalid trust levels and side-effect classes
+  - grant tool rules that reference tools not in the metadata (causes
+    tool_side_effect_unknown at the gateway)
+  - grant allowedSideEffects that don't cover the tools they allow
+  - session fields that are inconsistent with the server's policy
+
+Use --from-server to also verify tool names against a locally running MCP server.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, path, err := loadMetadataForValidate(metadataDir, metadataFile)
+			if err != nil {
+				return err
+			}
+			core.Info(fmt.Sprintf("Validating metadata: %s", path))
+
+			var issues []validateIssue
+
+			for _, srv := range cfg.Servers {
+				issues = append(issues, validateServer(srv)...)
+			}
+
+			for _, grantFile := range grantFiles {
+				more, err := validateGrantFile(grantFile, cfg)
+				if err != nil {
+					issues = append(issues, validateIssue{fatal: true, message: fmt.Sprintf("cannot read grant file %s: %v", grantFile, err)})
+					continue
+				}
+				issues = append(issues, more...)
+			}
+
+			for _, sessionFile := range sessionFiles {
+				more, err := validateSessionFile(sessionFile, cfg)
+				if err != nil {
+					issues = append(issues, validateIssue{fatal: true, message: fmt.Sprintf("cannot read session file %s: %v", sessionFile, err)})
+					continue
+				}
+				issues = append(issues, more...)
+			}
+
+			if discoverURL != "" {
+				more := validateToolsAgainstServer(discoverURL, cfg)
+				issues = append(issues, more...)
+			}
+
+			if len(issues) == 0 {
+				core.Success("Validation passed — no issues found")
+				return nil
+			}
+
+			hasFatal := false
+			for _, issue := range issues {
+				if issue.fatal {
+					hasFatal = true
+					core.Error(issue.message)
+				} else {
+					core.Warn(issue.message)
+				}
+				if issue.hint != "" {
+					fmt.Printf("         Hint: %s\n", issue.hint)
+				}
+			}
+			fmt.Println()
+			if hasFatal {
+				return fmt.Errorf("validation found %d issue(s) — fix them before deploying", len(issues))
+			}
+			fmt.Printf("Validation found %d warning(s)\n", len(issues))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&metadataDir, "metadata-dir", ".mcp", "Directory containing servers.yaml")
+	cmd.Flags().StringVar(&metadataFile, "metadata-file", "", "Explicit path to a servers.yaml file (overrides --metadata-dir)")
+	cmd.Flags().StringArrayVar(&grantFiles, "grant-file", nil, "MCPAccessGrant YAML to validate against the server metadata; repeat for multiple files")
+	cmd.Flags().StringArrayVar(&sessionFiles, "session-file", nil, "MCPAgentSession YAML to validate against the server metadata; repeat for multiple files")
+	cmd.Flags().StringVar(&discoverURL, "from-server", "", "Verify tool names against a locally running MCP server at this URL")
+
+	return cmd
+}
+
+// validateServer checks a single ServerConfig entry.
+func validateServer(srv metadata.ServerMetadata) []validateIssue {
+	var issues []validateIssue
+
+	if strings.TrimSpace(srv.Name) == "" {
+		issues = append(issues, validateIssue{fatal: true, message: "server entry has an empty name"})
+	}
+
+	seen := map[string]int{}
+	for i, tool := range srv.Tools {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("server %q: tool[%d] has an empty name", srv.Name, i),
+				hint:    "Every tool must have a name that matches the tool's registered name in your MCP server code.",
+			})
+			continue
+		}
+		if prev, dup := seen[name]; dup {
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("server %q: duplicate tool name %q (entries %d and %d)", srv.Name, name, prev, i),
+			})
+		}
+		seen[name] = i
+
+		switch tool.SideEffect {
+		case metadata.ToolSideEffectRead, metadata.ToolSideEffectWrite, metadata.ToolSideEffectDestructive:
+		default:
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("server %q tool %q: invalid sideEffect %q", srv.Name, name, tool.SideEffect),
+				hint:    "Valid values: read, write, destructive",
+			})
+		}
+
+		switch tool.RequiredTrust {
+		case metadata.TrustLevelLow, metadata.TrustLevelMedium, metadata.TrustLevelHigh, "":
+		default:
+			issues = append(issues, validateIssue{
+				fatal:   true,
+				message: fmt.Sprintf("server %q tool %q: invalid requiredTrust %q", srv.Name, name, tool.RequiredTrust),
+				hint:    "Valid values: low, medium, high",
+			})
+		}
+	}
+
+	if len(srv.Tools) == 0 {
+		issues = append(issues, validateIssue{
+			fatal:   false,
+			message: fmt.Sprintf("server %q: no tools defined — the gateway will deny all tool calls", srv.Name),
+			hint:    "Run server init --from-server http://localhost:<port> to discover tool names from a running server.",
+		})
+	}
+
+	return issues
+}
+
+// validateGrantFile reads an MCPAccessGrant YAML and checks that every tool
+// rule references a tool that is defined in the server metadata.
+func validateGrantFile(path string, cfg *metadata.RegistryFile) ([]validateIssue, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- explicit CLI flag path
+	if err != nil {
+		return nil, err
+	}
+
+	var grant struct {
+		Spec struct {
+			ServerRef struct {
+				Name      string `yaml:"name" json:"name"`
+				Namespace string `yaml:"namespace" json:"namespace"`
+			} `yaml:"serverRef" json:"serverRef"`
+			AllowedSideEffects []string `yaml:"allowedSideEffects" json:"allowedSideEffects"`
+			ToolRules          []struct {
+				Name     string `yaml:"name" json:"name"`
+				Decision string `yaml:"decision" json:"decision"`
+			} `yaml:"toolRules" json:"toolRules"`
+		} `yaml:"spec" json:"spec"`
+		Metadata struct {
+			Name string `yaml:"name" json:"name"`
+		} `yaml:"metadata" json:"metadata"`
+	}
+	if err := yaml.Unmarshal(data, &grant); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+
+	grantName := grant.Metadata.Name
+	serverName := grant.Spec.ServerRef.Name
+
+	// Find the matching server in metadata
+	var srv *metadata.ServerMetadata
+	for i := range cfg.Servers {
+		if cfg.Servers[i].Name == serverName {
+			srv = &cfg.Servers[i]
+			break
+		}
+	}
+
+	var issues []validateIssue
+
+	if srv == nil {
+		issues = append(issues, validateIssue{
+			fatal:   false,
+			message: fmt.Sprintf("grant %q: serverRef.name %q not found in metadata (may be in a different metadata file)", grantName, serverName),
+			hint:    "Pass --metadata-file pointing to the server's servers.yaml, or use the same --metadata-dir.",
+		})
+		return issues, nil
+	}
+
+	// Build tool map from server metadata
+	toolMap := map[string]metadata.ToolConfig{}
+	for _, t := range srv.Tools {
+		toolMap[t.Name] = t
+	}
+
+	// Build allowed side effects set
+	allowedEffects := map[string]struct{}{}
+	for _, e := range grant.Spec.AllowedSideEffects {
+		allowedEffects[strings.ToLower(e)] = struct{}{}
+	}
+
+	for _, rule := range grant.Spec.ToolRules {
+		toolCfg, exists := toolMap[rule.Name]
+		if !exists {
+			issues = append(issues, validateIssue{
+				fatal: true,
+				message: fmt.Sprintf(
+					"grant %q: toolRule %q references a tool not in server %q metadata — the gateway will return tool_side_effect_unknown",
+					grantName, rule.Name, serverName,
+				),
+				hint: fmt.Sprintf(
+					"Add %q to server %q tools in servers.yaml, or remove this rule from the grant. Known tools: %s",
+					rule.Name, serverName, joinToolNames(srv.Tools),
+				),
+			})
+			continue
+		}
+
+		if rule.Decision == "allow" {
+			effect := string(toolCfg.SideEffect)
+			if _, ok := allowedEffects[effect]; !ok {
+				issues = append(issues, validateIssue{
+					fatal: true,
+					message: fmt.Sprintf(
+						"grant %q: tool %q has sideEffect=%q but that side effect is not in allowedSideEffects %v — gateway will deny the call",
+						grantName, rule.Name, effect, grant.Spec.AllowedSideEffects,
+					),
+					hint: fmt.Sprintf("Add %q to spec.allowedSideEffects in the grant YAML.", effect),
+				})
+			}
+		}
+	}
+
+	return issues, nil
+}
+
+// validateSessionFile reads an MCPAgentSession YAML and checks basic consistency.
+func validateSessionFile(path string, cfg *metadata.RegistryFile) ([]validateIssue, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- explicit CLI flag path
+	if err != nil {
+		return nil, err
+	}
+
+	var session struct {
+		Spec struct {
+			ServerRef struct {
+				Name string `yaml:"name" json:"name"`
+			} `yaml:"serverRef" json:"serverRef"`
+			Subject struct {
+				AgentID string `yaml:"agentID" json:"agentID"`
+			} `yaml:"subject" json:"subject"`
+			ConsentedTrust string `yaml:"consentedTrust" json:"consentedTrust"`
+			ExpiresAt      string `yaml:"expiresAt" json:"expiresAt"`
+		} `yaml:"spec" json:"spec"`
+		Metadata struct {
+			Name string `yaml:"name" json:"name"`
+		} `yaml:"metadata" json:"metadata"`
+	}
+	if err := yaml.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("parse YAML: %w", err)
+	}
+
+	var issues []validateIssue
+	name := session.Metadata.Name
+	serverName := session.Spec.ServerRef.Name
+
+	if strings.TrimSpace(session.Spec.Subject.AgentID) == "" {
+		issues = append(issues, validateIssue{
+			fatal:   true,
+			message: fmt.Sprintf("session %q: spec.subject.agentID is empty", name),
+			hint:    "Set --agent-id on session init, or fill spec.subject.agentID in the YAML.",
+		})
+	}
+
+	switch strings.ToLower(session.Spec.ConsentedTrust) {
+	case "low", "medium", "high", "":
+	default:
+		issues = append(issues, validateIssue{
+			fatal:   true,
+			message: fmt.Sprintf("session %q: invalid consentedTrust %q", name, session.Spec.ConsentedTrust),
+			hint:    "Valid values: low, medium, high",
+		})
+	}
+
+	// Check that the referenced server exists in metadata
+	found := false
+	for _, srv := range cfg.Servers {
+		if srv.Name == serverName {
+			found = true
+			if srv.Policy.DefaultDecision == metadata.PolicyDecisionDeny && len(srv.Tools) == 0 {
+				issues = append(issues, validateIssue{
+					fatal:   false,
+					message: fmt.Sprintf("session %q: server %q has default-deny policy but no tools — all tool calls will be denied", name, serverName),
+				})
+			}
+			break
+		}
+	}
+
+	if !found {
+		issues = append(issues, validateIssue{
+			fatal:   false,
+			message: fmt.Sprintf("session %q: serverRef.name %q not found in metadata", name, serverName),
+		})
+	}
+
+	return issues, nil
+}
+
+// validateToolsAgainstServer calls tools/list on a running MCP server and
+// checks that each tool in the metadata actually exists there.
+func validateToolsAgainstServer(url string, cfg *metadata.RegistryFile) []validateIssue {
+	core.Info(fmt.Sprintf("Verifying tool names against running server: %s", url))
+	discovered, err := DiscoverToolsFromServer(url)
+	if err != nil {
+		return []validateIssue{{
+			fatal:   false,
+			message: fmt.Sprintf("--from-server %s: %v", url, err),
+			hint:    "Make sure the server is running and reachable before running validate.",
+		}}
+	}
+
+	serverSet := map[string]struct{}{}
+	for _, name := range discovered {
+		serverSet[name] = struct{}{}
+	}
+
+	var issues []validateIssue
+	for _, srv := range cfg.Servers {
+		for _, tool := range srv.Tools {
+			if _, ok := serverSet[tool.Name]; !ok {
+				issues = append(issues, validateIssue{
+					fatal: true,
+					message: fmt.Sprintf(
+						"server %q tool %q is in metadata but not found in tools/list from %s — gateway will return tool_side_effect_unknown",
+						srv.Name, tool.Name, url,
+					),
+					hint: fmt.Sprintf("Server implements: %s", strings.Join(discovered, ", ")),
+				})
+			}
+		}
+		// Warn about tools on the server that are not in metadata
+		metaSet := map[string]struct{}{}
+		for _, t := range srv.Tools {
+			metaSet[t.Name] = struct{}{}
+		}
+		for _, name := range discovered {
+			if _, ok := metaSet[name]; !ok {
+				issues = append(issues, validateIssue{
+					fatal:   false,
+					message: fmt.Sprintf("server %q: tool %q is exposed by the running server but not in metadata — it will be ungoverned (denied by default policy)", srv.Name, name),
+					hint:    fmt.Sprintf("Add to servers.yaml: --tool %s  or  --tool-spec %s:low:read", name, name),
+				})
+			}
+		}
+	}
+	return issues
+}
+
+func loadMetadataForValidate(dir, file string) (*metadata.RegistryFile, string, error) {
+	if file != "" {
+		cfg, err := metadata.LoadFromFile(file)
+		if err != nil {
+			return nil, "", err
+		}
+		return cfg, file, nil
+	}
+	path := filepath.Join(dir, "servers.yaml")
+	cfg, err := metadata.LoadFromFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	return cfg, path, nil
+}
+
+func joinToolNames(tools []metadata.ToolConfig) string {
+	names := make([]string, len(tools))
+	for i, t := range tools {
+		names[i] = t.Name
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/cli/setup/platform/analytics.go
+++ b/internal/cli/setup/platform/analytics.go
@@ -1630,11 +1630,22 @@ func restartAnalyticsDeploymentsClientGo() error {
 		"mcp-sentinel-gateway",
 		"grafana",
 	}
+	// Only restart deployments that pre-existed this setup run.
+	// On a fresh install all deployments were just created and already have the
+	// correct secret values — restarting them is unnecessary and doubles the
+	// image-pull time, increasing the risk of rollout-wait timeouts in CI.
+	// A deployment created less than freshDeploymentThreshold seconds ago was
+	// created during this run; its pods have current secret values.
+	const freshDeploymentThreshold = 5 * time.Minute
+
 	var errs []string
 	for _, name := range deployments {
-		exists, err := k8sclient.DeploymentExists(ctx, clients, core.DefaultAnalyticsNamespace, name)
-		if err != nil || !exists {
+		deploy, err := k8sclient.GetDeployment(ctx, clients, core.DefaultAnalyticsNamespace, name)
+		if err != nil || deploy == nil {
 			continue // not deployed yet — skip
+		}
+		if now.Sub(deploy.CreationTimestamp.Time) < freshDeploymentThreshold {
+			continue // brand new — pods already have current secret values
 		}
 		if err := k8sclient.RestartDeployment(ctx, clients, core.DefaultAnalyticsNamespace, name, now); err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", name, err))

--- a/internal/cli/setup/platform/preflight.go
+++ b/internal/cli/setup/platform/preflight.go
@@ -50,6 +50,13 @@ func (s preflightStep) Run(logger *zap.Logger, _ SetupDeps, ctx *SetupContext) e
 	issues = append(issues, checkTerminatingCRD(bg, clients)...)
 	issues = append(issues, checkStuckOperatorDeployment(bg, clients)...)
 
+	// Registry checks.
+	issues = append(issues, checkStuckRegistryPVC(bg, clients)...)
+	issues = append(issues, checkStuckRegistryDeployment(bg, clients)...)
+	if !ctx.Plan.TestMode {
+		issues = append(issues, checkStaleRegistryIngress(bg, clients)...)
+	}
+
 	if ctx.Plan.TLSEnabled {
 		// Host-based TLS checks are skipped in test mode: registry.local is
 		// intentional for local Kind clusters and these checks would always fire.
@@ -69,6 +76,7 @@ func (s preflightStep) Run(logger *zap.Logger, _ SetupDeps, ctx *SetupContext) e
 		issues = append(issues, checkStalePullSecrets(bg, clients)...)
 		issues = append(issues, checkPostgresPasswordSync(bg, clients)...)
 		issues = append(issues, checkKafkaZookeeperConsistency(bg, clients)...)
+		issues = append(issues, checkStuckAnalyticsStatefulSets(bg, clients)...)
 	}
 
 	if len(issues) == 0 {
@@ -493,6 +501,161 @@ func extractPostgresPassword(dsn string) string {
 		return ""
 	}
 	return userPass[colonIdx+1:]
+}
+
+// checkStuckRegistryPVC detects when the registry-storage PVC is stuck in
+// Pending. A Pending PVC prevents the registry pod from scheduling, so the
+// rollout-wait in verifySetup times out after 5+ minutes.
+func checkStuckRegistryPVC(ctx context.Context, clients *k8sclient.Clients) []preflightIssue {
+	pvc, err := clients.Clientset.CoreV1().PersistentVolumeClaims(core.NamespaceRegistry).Get(
+		ctx, "registry-storage", metav1.GetOptions{})
+	if err != nil {
+		return nil // PVC doesn't exist yet — fresh install
+	}
+	if pvc.Status.Phase != "Pending" {
+		return nil
+	}
+	return []preflightIssue{{
+		fatal: true,
+		message: fmt.Sprintf(
+			"PersistentVolumeClaim %s/registry-storage is stuck in Pending — storage provisioning may have failed. The registry pod cannot schedule until this is resolved.",
+			core.NamespaceRegistry,
+		),
+		cleanup: []string{
+			fmt.Sprintf("kubectl describe pvc registry-storage -n %s  # inspect the error", core.NamespaceRegistry),
+			fmt.Sprintf("kubectl delete pvc registry-storage -n %s    # delete to force re-creation", core.NamespaceRegistry),
+		},
+	}}
+}
+
+// checkStuckRegistryDeployment warns when the registry Deployment from a
+// previous run has pods stuck in ImagePullBackOff or CrashLoopBackOff.
+// Setup will update the image, but stuck pods slow the rollout.
+func checkStuckRegistryDeployment(ctx context.Context, clients *k8sclient.Clients) []preflightIssue {
+	deploy, err := k8sclient.GetDeployment(ctx, clients, core.NamespaceRegistry, core.RegistryServiceName)
+	if err != nil || deploy == nil {
+		return nil
+	}
+	pods, err := clients.Clientset.CoreV1().Pods(core.NamespaceRegistry).List(
+		ctx, metav1.ListOptions{LabelSelector: "app=registry"})
+	if err != nil || len(pods.Items) == 0 {
+		return nil
+	}
+	var stuck []string
+	for _, pod := range pods.Items {
+		for _, cs := range pod.Status.ContainerStatuses {
+			w := cs.State.Waiting
+			if w == nil {
+				continue
+			}
+			if w.Reason == "ImagePullBackOff" || w.Reason == "CrashLoopBackOff" || w.Reason == "ErrImagePull" {
+				stuck = append(stuck, fmt.Sprintf("%s (%s)", pod.Name, w.Reason))
+			}
+		}
+	}
+	if len(stuck) == 0 {
+		return nil
+	}
+	return []preflightIssue{{
+		fatal: false,
+		message: fmt.Sprintf(
+			"Registry pod(s) from a previous run are stuck: %s — setup will update the image, but cleaning up first speeds up the rollout.",
+			strings.Join(stuck, "; "),
+		),
+		cleanup: []string{
+			fmt.Sprintf("kubectl delete pod -n %s -l app=registry", core.NamespaceRegistry),
+		},
+	}}
+}
+
+// checkStaleRegistryIngress warns when the registry Ingress exists with a
+// host that does not match the expected registry hostname. This causes external
+// TLS validation to fail and the platform API to use the wrong pull URL.
+func checkStaleRegistryIngress(ctx context.Context, clients *k8sclient.Clients) []preflightIssue {
+	expectedHost := metadata.ResolveRegistryHost()
+	if expectedHost == "" {
+		return nil
+	}
+	ing, err := clients.Clientset.NetworkingV1().Ingresses(core.NamespaceRegistry).Get(
+		ctx, core.RegistryServiceName, metav1.GetOptions{})
+	if err != nil {
+		return nil // ingress not created yet — fresh install
+	}
+	for _, rule := range ing.Spec.Rules {
+		if rule.Host == expectedHost {
+			return nil
+		}
+	}
+	var current string
+	if len(ing.Spec.Rules) > 0 {
+		current = ing.Spec.Rules[0].Host
+	}
+	return []preflightIssue{{
+		fatal: false,
+		message: fmt.Sprintf(
+			"Registry Ingress %q has host %q but the expected registry host is %q — setup will overwrite it.",
+			core.RegistryServiceName, current, expectedHost,
+		),
+		cleanup: []string{
+			fmt.Sprintf("kubectl delete ingress %s -n %s  # setup will recreate with correct host", core.RegistryServiceName, core.NamespaceRegistry),
+		},
+	}}
+}
+
+// checkStuckAnalyticsStatefulSets warns when analytics StatefulSet pods are
+// stuck in CrashLoopBackOff, Error, or Terminating state. Stuck pods slow the
+// rollout-wait that setup runs after applying manifests.
+func checkStuckAnalyticsStatefulSets(ctx context.Context, clients *k8sclient.Clients) []preflightIssue {
+	type stsSpec struct {
+		name     string
+		selector string
+	}
+	targets := []stsSpec{
+		{"clickhouse", "app=clickhouse"},
+		{"mcp-sentinel-postgres", "app=mcp-sentinel-postgres"},
+		{"kafka", "app=kafka"},
+		{"tempo", "app=tempo"},
+		{"loki", "app=loki"},
+	}
+	var issues []preflightIssue
+	for _, t := range targets {
+		pods, err := clients.Clientset.CoreV1().Pods(core.DefaultAnalyticsNamespace).List(
+			ctx, metav1.ListOptions{LabelSelector: t.selector})
+		if err != nil || len(pods.Items) == 0 {
+			continue
+		}
+		var stuck []string
+		for _, pod := range pods.Items {
+			if pod.DeletionTimestamp != nil {
+				stuck = append(stuck, fmt.Sprintf("%s (Terminating)", pod.Name))
+				continue
+			}
+			for _, cs := range pod.Status.ContainerStatuses {
+				w := cs.State.Waiting
+				if w == nil {
+					continue
+				}
+				if w.Reason == "CrashLoopBackOff" || w.Reason == "Error" {
+					stuck = append(stuck, fmt.Sprintf("%s (%s)", pod.Name, w.Reason))
+				}
+			}
+		}
+		if len(stuck) == 0 {
+			continue
+		}
+		issues = append(issues, preflightIssue{
+			fatal: false,
+			message: fmt.Sprintf(
+				"Analytics StatefulSet %q has stuck pod(s): %s — this may cause the rollout wait to time out.",
+				t.name, strings.Join(stuck, "; "),
+			),
+			cleanup: []string{
+				fmt.Sprintf("kubectl delete pod -n %s -l %s --grace-period=0 --force",
+					core.DefaultAnalyticsNamespace, t.selector),
+			},
+		})
+	}
+	return issues
 }
 
 // checkKafkaZookeeperConsistency detects the classic InconsistentClusterIdException

--- a/internal/cli/setup/platform/preflight.go
+++ b/internal/cli/setup/platform/preflight.go
@@ -68,6 +68,7 @@ func (s preflightStep) Run(logger *zap.Logger, _ SetupDeps, ctx *SetupContext) e
 		issues = append(issues, checkStaleAnalyticsJob(bg, clients)...)
 		issues = append(issues, checkStalePullSecrets(bg, clients)...)
 		issues = append(issues, checkPostgresPasswordSync(bg, clients)...)
+		issues = append(issues, checkKafkaZookeeperConsistency(bg, clients)...)
 	}
 
 	if len(issues) == 0 {
@@ -492,6 +493,58 @@ func extractPostgresPassword(dsn string) string {
 		return ""
 	}
 	return userPass[colonIdx+1:]
+}
+
+// checkKafkaZookeeperConsistency detects the classic InconsistentClusterIdException
+// that occurs when ZooKeeper is restarted (losing its data) while Kafka's PVC still
+// holds an old cluster ID. Kafka will crash-loop with a fatal error on startup until
+// its meta.properties is cleared.
+func checkKafkaZookeeperConsistency(ctx context.Context, clients *k8sclient.Clients) []preflightIssue {
+	// Check if Kafka pod is in CrashLoopBackOff / Error state
+	pods, err := clients.Clientset.CoreV1().Pods(core.DefaultAnalyticsNamespace).List(ctx, metav1.ListOptions{LabelSelector: "app=kafka"})
+	if err != nil || len(pods.Items) == 0 {
+		return nil
+	}
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			waiting := cs.State.Waiting
+			if waiting == nil {
+				continue
+			}
+			if waiting.Reason == "CrashLoopBackOff" || waiting.Reason == "Error" {
+				// Check if last termination message mentions InconsistentClusterIdException
+				if cs.LastTerminationState.Terminated != nil &&
+					strings.Contains(cs.LastTerminationState.Terminated.Message, "InconsistentClusterIdException") {
+					return []preflightIssue{{
+						fatal: true,
+						message: fmt.Sprintf(
+							"Kafka pod %q is crash-looping with InconsistentClusterIdException — ZooKeeper was restarted and has a new cluster ID that conflicts with Kafka's stored cluster ID.",
+							pod.Name,
+						),
+						cleanup: []string{
+							"# Scale Kafka to 0, clear meta.properties from the PVC, then scale back up:",
+							fmt.Sprintf("kubectl scale statefulset kafka -n %s --replicas=0", core.DefaultAnalyticsNamespace),
+							fmt.Sprintf("kubectl run kafka-pvc-fix -n %s --rm --restart=Never --image=busybox --overrides='{\"spec\":{\"volumes\":[{\"name\":\"d\",\"persistentVolumeClaim\":{\"claimName\":\"kafka-data-kafka-0\"}}],\"containers\":[{\"name\":\"f\",\"image\":\"busybox\",\"command\":[\"find\",\"/d\",\"-name\",\"meta.properties\",\"-delete\"],\"volumeMounts\":[{\"name\":\"d\",\"mountPath\":\"/d\"}]}]}}' 2>&1", core.DefaultAnalyticsNamespace),
+							fmt.Sprintf("kubectl scale statefulset kafka -n %s --replicas=1", core.DefaultAnalyticsNamespace),
+						},
+					}}
+				}
+				// Generic Kafka crash — warn
+				return []preflightIssue{{
+					fatal:   false,
+					message: fmt.Sprintf("Kafka pod %q is crash-looping (%s) — analytics ingest will fail until Kafka recovers.", pod.Name, waiting.Reason),
+					cleanup: []string{
+						fmt.Sprintf("kubectl logs -n %s %s --previous  # check the crash reason", core.DefaultAnalyticsNamespace, pod.Name),
+						fmt.Sprintf("kubectl rollout restart statefulset/kafka -n %s", core.DefaultAnalyticsNamespace),
+					},
+				}}
+			}
+		}
+	}
+	return nil
 }
 
 func countFatal(issues []preflightIssue) int {

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -4020,6 +4020,7 @@ if checkpoint_enabled "oauth"; then
     wait_http "http://127.0.0.1:${PROMETHEUS_PORT}/prometheus/-/ready"
   fi
 
+  recover_traefik_port_forward_if_needed || true
   echo "[registry] checking public ingress admin auth"
   REGISTRY_PUBLIC_URL="http://127.0.0.1:${TRAEFIK_PORT}/v2/_catalog"
   REGISTRY_UNAUTH_STATUS=""

--- a/test/golden/cli/testdata/mcp-runtime_server_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_server_help.golden
@@ -31,6 +31,7 @@ Available Commands:
   patch       Patch an MCP server manifest
   policy      Inspect rendered gateway policy for an MCP server
   status      Show MCP server runtime status (pods, images, pull secrets)
+  validate    Validate .mcp metadata and optional grant/session YAML files
 
 Flags:
   -h, --help       help for server

--- a/test/golden/cli/testdata/mcp-runtime_server_init_help.golden
+++ b/test/golden/cli/testdata/mcp-runtime_server_init_help.golden
@@ -1,4 +1,4 @@
-Initialize .mcp/servers.yaml metadata for a server. Use repeated --tool flags to seed governed tool metadata, then build, push, and deploy with server build image, registry push, and server deploy.
+Initialize .mcp/servers.yaml metadata for a server. Use --tool flags to seed governed tool metadata, or --from-server to discover tools from a running MCP server automatically. Then build, push, and deploy with server build image, registry push, and server deploy.
 
 Usage:
   mcp-runtime server init [name] [flags]
@@ -6,6 +6,7 @@ Usage:
 Flags:
       --default-decision string   Default policy decision: allow or deny (default "deny")
       --force                     Replace an existing metadata entry with the same server name
+      --from-server string        Discover tools by calling tools/list on a running MCP server at this URL (e.g. http://localhost:8088); discovered names are merged with --tool flags
   -h, --help                      help for init
       --image string              Container image repository (default: server name)
       --metadata-dir string       Directory where servers.yaml will be written (default ".mcp")


### PR DESCRIPTION
## Summary

- **`server init --from-server <url>`** — discovers real tool names by calling `tools/list` on a locally running MCP server before writing `.mcp/servers.yaml`. Eliminates the hand-editing that caused `tool_side_effect_unknown` gateway errors. Handles JSON and SSE (MCP 2025-06-18) response formats; appends `/mcp` automatically when the URL has no path.

- **`server validate`** — new command that checks `.mcp/servers.yaml` and optional `MCPAccessGrant` / `MCPAgentSession` YAML files before deploy. Catches: empty/duplicate tool names, invalid trust/side-effect values, grant tool rules not in metadata (root cause of `tool_side_effect_unknown`), `allowedSideEffects` gaps, and inconsistent session config. `--from-server` also cross-checks names against a live server.

- **Preflight `checkKafkaZookeeperConsistency`** — detects Kafka crash-looping with `InconsistentClusterIdException` (happens when ZooKeeper restarts and wipes its cluster ID while Kafka's PVC retains the old one). Prints exact `kubectl` commands to fix it.

- **`docs/cli.md` complete rewrite** — role badges (👤 User / 🔑 Admin / ⚙️ Operator) on every section, credentials and profile section (`MCP_PLATFORM_API_PROFILE` per-command), `server validate` in the deploy flow, full `adapter` section, cross-team grant example, all commands verified against live mcpruntime.org cluster.

- **`docs/runtime.md`** — replace large `classDiagram` Mermaid (renders very large) with a compact reference table + minimal 3-node flowchart.

## Test plan

- [ ] `server init --from-server http://localhost:8088` on workspace-assistant-mcp → discovers 8 tools (echo, add, aaa-ping, create_task, draft_release_note, lower, slugify, upper)
- [ ] `server validate --grant-file bad-grant.yaml` catches tool name mismatches with `tool_side_effect_unknown` hint
- [ ] `server validate` passes on correctly scaffolded metadata
- [ ] Full deploy flow: init → validate → build → push → deploy → grant → session → tool calls verified (echo/add allowed, create_task denied by gateway policy)
- [ ] Kafka preflight check code path reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)