### PR TITLE
feat(mcp-gateway): validate and expose applied policy snapshots

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,6 +1,6 @@
 # Keep the operator image on a patched Go 1.26.x builder so Trivy
 # does not flag fixed stdlib CVEs in the shipped binary.
-FROM golang:1.26.3-alpine3.23 AS builder
+FROM golang:1.26.4-alpine3.23 AS builder
 
 WORKDIR /build
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -108,6 +108,40 @@ X-MCP-Team-ID:     7d0a0b8f-7c25-4761-a632-3cf0108e31d6
 X-MCP-Agent-Session: sess-8f1b9d
 ```
 
+### Gateway policy snapshots
+
+The operator renders `MCPServer` + `MCPAccessGrant` + `MCPAgentSession` state
+into a JSON policy ConfigMap that the gateway sidecar mounts and reloads. The
+rendered document carries document-level metadata distinct from the
+authorization `policyVersion`:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Compatibility of the rendered JSON contract. The gateway rejects any version it does not support. |
+| `revision` | Deterministic `sha256:` digest of the canonical policy content. Identical content always yields the same revision; it is computed with `generated_at` excluded so timestamps never change it. |
+| `generated_at` | Informational only; set at write time and never affects `revision`. |
+
+Both sides share `pkg/policy.Validate`: the operator validates a rendered
+document **before** replacing the ConfigMap, and the gateway validates a decoded
+document **before** activating it. Validation fails closed — unknown trust,
+side-effect, decision, auth-mode, or policy-mode values, duplicate names, and
+OAuth without an issuer are all rejected.
+
+Activation is **last-known-good**: a malformed, unsupported, or invalid update
+never replaces the active snapshot. The gateway keeps serving the previous valid
+policy and records the failure, and snapshot swaps are atomic so concurrent
+requests always observe a complete old or new policy, never a partial one.
+
+Operators can confirm what is applied via the gateway endpoints:
+
+- `GET /health` — liveness (always OK while serving).
+- `GET /ready` — readiness; fails until the first valid policy snapshot loads.
+- `GET /config/status` — sanitized `schema_version`, `revision`, `loaded_at`,
+  and `last_reload_error` (no policy body).
+- `GET /metrics` — `mcp_gateway_policy_reload_total{result}`,
+  `mcp_gateway_policy_active_revision_info{revision,schema_version}`, and
+  `mcp_gateway_policy_last_success_timestamp_seconds`.
+
 ### Agent adapters
 
 Agent-side adapters are helper processes for frameworks and IDEs that cannot

--- a/internal/operator/deployment.go
+++ b/internal/operator/deployment.go
@@ -531,7 +531,10 @@ func (r *MCPServerReconciler) buildGatewayContainer(mcpServer *mcpv1alpha1.MCPSe
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
-				TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt32(port)},
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/ready",
+					Port: intstr.FromInt32(port),
+				},
 			},
 			InitialDelaySeconds: 3,
 			PeriodSeconds:       5,

--- a/internal/operator/policy.go
+++ b/internal/operator/policy.go
@@ -37,9 +37,10 @@ func (r *MCPServerReconciler) reconcilePolicyConfigMap(ctx context.Context, mcpS
 	if err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(doc, "", "  ")
-	if err != nil {
-		return err
+	// Reject an invalid rendered policy before it can replace the ConfigMap
+	// contents, so the gateway never reloads a malformed last-known-good policy.
+	if err := policy.Validate(doc); err != nil {
+		return fmt.Errorf("rendered gateway policy for %s/%s is invalid: %w", mcpServer.Namespace, mcpServer.Name, err)
 	}
 
 	configMap := &corev1.ConfigMap{
@@ -53,12 +54,36 @@ func (r *MCPServerReconciler) reconcilePolicyConfigMap(ctx context.Context, mcpS
 			"app":                          mcpServer.Name,
 			"app.kubernetes.io/managed-by": "mcp-runtime",
 		}
+		rendered, err := renderPolicyConfigMapData(configMap.Data[gatewayPolicyFileName], doc)
+		if err != nil {
+			return err
+		}
 		configMap.Data = map[string]string{
-			gatewayPolicyFileName: string(data),
+			gatewayPolicyFileName: rendered,
 		}
 		return ctrl.SetControllerReference(mcpServer, configMap, r.Scheme)
 	})
 	return err
+}
+
+// renderPolicyConfigMapData serializes the policy document for the ConfigMap.
+// When the rendered policy content is unchanged (same deterministic revision),
+// the prior payload is preserved verbatim so that refreshing the informational
+// generated_at timestamp does not churn the ConfigMap or trigger needless
+// gateway reloads.
+func renderPolicyConfigMapData(existing string, doc *policy.Document) (string, error) {
+	if existing != "" {
+		var prev policy.Document
+		if err := json.Unmarshal([]byte(existing), &prev); err == nil && prev.Revision != "" && prev.Revision == doc.Revision {
+			return existing, nil
+		}
+	}
+	doc.GeneratedAt = time.Now().UTC().Format(time.RFC3339)
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func (r *MCPServerReconciler) renderGatewayPolicy(ctx context.Context, mcpServer *mcpv1alpha1.MCPServer) (*policy.Document, error) {
@@ -179,6 +204,12 @@ func (r *MCPServerReconciler) renderGatewayPolicy(ctx context.Context, mcpServer
 		doc.Sessions = append(doc.Sessions, rendered)
 	}
 
+	// Stamp document-level metadata (schema version + deterministic revision).
+	// generated_at is left empty here and set at write time so it cannot affect
+	// the revision; see renderPolicyConfigMapData.
+	if err := policy.Stamp(doc, ""); err != nil {
+		return nil, err
+	}
 	return doc, nil
 }
 

--- a/internal/operator/policy_test.go
+++ b/internal/operator/policy_test.go
@@ -1,0 +1,118 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpv1alpha1 "mcp-runtime/api/v1alpha1"
+	"mcp-runtime/pkg/policy"
+)
+
+func TestRenderGatewayPolicyStampsAndValidates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = mcpv1alpha1.AddToScheme(scheme)
+
+	mcpServer := &mcpv1alpha1.MCPServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "payments", Namespace: "servers"},
+		Spec: mcpv1alpha1.MCPServerSpec{
+			Tools: []mcpv1alpha1.ToolConfig{
+				{Name: "refund_invoice", SideEffect: mcpv1alpha1.ToolSideEffectWrite},
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcpServer).Build()
+	r := MCPServerReconciler{Client: client, Scheme: scheme}
+
+	doc, err := r.renderGatewayPolicy(context.Background(), mcpServer)
+	if err != nil {
+		t.Fatalf("renderGatewayPolicy() error = %v", err)
+	}
+	if doc.SchemaVersion != policy.SchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", doc.SchemaVersion, policy.SchemaVersion)
+	}
+	if doc.Revision == "" || !strings.HasPrefix(doc.Revision, "sha256:") {
+		t.Fatalf("Revision = %q, want sha256: digest", doc.Revision)
+	}
+	if doc.GeneratedAt != "" {
+		t.Fatalf("GeneratedAt = %q, want empty (set at write time)", doc.GeneratedAt)
+	}
+	want, err := policy.ComputeRevision(doc)
+	if err != nil {
+		t.Fatalf("ComputeRevision() error = %v", err)
+	}
+	if doc.Revision != want {
+		t.Fatalf("Revision = %q, want recomputed %q", doc.Revision, want)
+	}
+	if err := policy.Validate(doc); err != nil {
+		t.Fatalf("rendered policy failed validation: %v", err)
+	}
+}
+
+func TestRenderPolicyConfigMapDataPreservesUnchangedRevision(t *testing.T) {
+	doc := &policy.Document{Server: policy.Server{Name: "demo"}}
+	if err := policy.Stamp(doc, ""); err != nil {
+		t.Fatalf("Stamp() error = %v", err)
+	}
+
+	// First write: no existing data, generated_at is stamped.
+	first, err := renderPolicyConfigMapData("", doc)
+	if err != nil {
+		t.Fatalf("renderPolicyConfigMapData() error = %v", err)
+	}
+	var firstDoc policy.Document
+	if err := json.Unmarshal([]byte(first), &firstDoc); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if firstDoc.GeneratedAt == "" {
+		t.Fatal("expected generated_at to be set on fresh write")
+	}
+
+	// Re-render with the same content: payload must be preserved verbatim so an
+	// unchanged policy does not churn the ConfigMap.
+	second := &policy.Document{Server: policy.Server{Name: "demo"}}
+	if err := policy.Stamp(second, ""); err != nil {
+		t.Fatalf("Stamp() error = %v", err)
+	}
+	out, err := renderPolicyConfigMapData(first, second)
+	if err != nil {
+		t.Fatalf("renderPolicyConfigMapData() error = %v", err)
+	}
+	if out != first {
+		t.Fatalf("unchanged revision rewrote payload:\n old=%s\n new=%s", first, out)
+	}
+}
+
+func TestRenderPolicyConfigMapDataRewritesOnChange(t *testing.T) {
+	doc := &policy.Document{Server: policy.Server{Name: "demo"}}
+	_ = policy.Stamp(doc, "")
+	existing, err := renderPolicyConfigMapData("", doc)
+	if err != nil {
+		t.Fatalf("renderPolicyConfigMapData() error = %v", err)
+	}
+
+	changed := &policy.Document{
+		Server: policy.Server{Name: "demo"},
+		Tools:  []policy.Tool{{Name: "echo", RequiredTrust: "low", SideEffect: "read"}},
+	}
+	_ = policy.Stamp(changed, "")
+	out, err := renderPolicyConfigMapData(existing, changed)
+	if err != nil {
+		t.Fatalf("renderPolicyConfigMapData() error = %v", err)
+	}
+	if out == existing {
+		t.Fatal("changed revision did not rewrite payload")
+	}
+	var outDoc policy.Document
+	if err := json.Unmarshal([]byte(out), &outDoc); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if outDoc.Revision != changed.Revision {
+		t.Fatalf("written revision = %q, want %q", outDoc.Revision, changed.Revision)
+	}
+}

--- a/pkg/policy/revision.go
+++ b/pkg/policy/revision.go
@@ -1,0 +1,49 @@
+package policy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+)
+
+// ComputeRevision returns a deterministic SHA-256 digest of the canonical
+// rendered policy content. The Revision and GeneratedAt fields are excluded
+// from the digest so that the revision depends only on policy content and
+// neither the previously stamped revision nor the (informational) generation
+// timestamp can change it. SchemaVersion is included: a schema bump is a
+// meaningful contract change and must produce a new revision.
+//
+// Determinism relies on encoding/json marshaling struct fields in declaration
+// order and map keys in sorted order, which the standard library guarantees.
+func ComputeRevision(doc *Document) (string, error) {
+	if doc == nil {
+		return "", errors.New("policy: cannot compute revision of nil document")
+	}
+	canonical := *doc
+	canonical.Revision = ""
+	canonical.GeneratedAt = ""
+	data, err := json.Marshal(&canonical)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+// Stamp sets the document-level metadata on doc: the current SchemaVersion, the
+// supplied (informational) generatedAt timestamp, and a freshly computed
+// deterministic Revision. generatedAt may be empty; it never affects Revision.
+func Stamp(doc *Document, generatedAt string) error {
+	if doc == nil {
+		return errors.New("policy: cannot stamp nil document")
+	}
+	doc.SchemaVersion = SchemaVersion
+	doc.GeneratedAt = generatedAt
+	revision, err := ComputeRevision(doc)
+	if err != nil {
+		return err
+	}
+	doc.Revision = revision
+	return nil
+}

--- a/pkg/policy/revision_test.go
+++ b/pkg/policy/revision_test.go
@@ -1,0 +1,86 @@
+package policy
+
+import "testing"
+
+func validStampedDocument() *Document {
+	return &Document{
+		Server: Server{Name: "demo", Namespace: "mcp-servers"},
+		Policy: &Config{Mode: "allow-list", DefaultDecision: "deny", PolicyVersion: "v1"},
+		Tools:  []Tool{{Name: "echo", RequiredTrust: "low", SideEffect: "read"}},
+	}
+}
+
+func TestComputeRevisionDeterministic(t *testing.T) {
+	doc := validStampedDocument()
+	first, err := ComputeRevision(doc)
+	if err != nil {
+		t.Fatalf("ComputeRevision() error = %v", err)
+	}
+	second, err := ComputeRevision(doc)
+	if err != nil {
+		t.Fatalf("ComputeRevision() error = %v", err)
+	}
+	if first != second {
+		t.Fatalf("revision not deterministic: %q != %q", first, second)
+	}
+	if len(first) <= len("sha256:") || first[:len("sha256:")] != "sha256:" {
+		t.Fatalf("revision = %q, want sha256: prefix", first)
+	}
+}
+
+func TestComputeRevisionIgnoresGeneratedAtAndRevision(t *testing.T) {
+	base := validStampedDocument()
+	baseRev, err := ComputeRevision(base)
+	if err != nil {
+		t.Fatalf("ComputeRevision() error = %v", err)
+	}
+
+	withMeta := validStampedDocument()
+	withMeta.GeneratedAt = "2026-01-01T00:00:00Z"
+	withMeta.Revision = "sha256:stale"
+	metaRev, err := ComputeRevision(withMeta)
+	if err != nil {
+		t.Fatalf("ComputeRevision() error = %v", err)
+	}
+	if baseRev != metaRev {
+		t.Fatalf("GeneratedAt/Revision affected digest: %q != %q", baseRev, metaRev)
+	}
+}
+
+func TestComputeRevisionChangesWithContent(t *testing.T) {
+	base := validStampedDocument()
+	baseRev, _ := ComputeRevision(base)
+
+	changed := validStampedDocument()
+	changed.Tools[0].RequiredTrust = "high"
+	changedRev, _ := ComputeRevision(changed)
+	if baseRev == changedRev {
+		t.Fatal("content change did not change revision")
+	}
+}
+
+func TestStampSetsMetadata(t *testing.T) {
+	doc := validStampedDocument()
+	if err := Stamp(doc, "2026-06-10T12:00:00Z"); err != nil {
+		t.Fatalf("Stamp() error = %v", err)
+	}
+	if doc.SchemaVersion != SchemaVersion {
+		t.Fatalf("SchemaVersion = %q, want %q", doc.SchemaVersion, SchemaVersion)
+	}
+	if doc.GeneratedAt != "2026-06-10T12:00:00Z" {
+		t.Fatalf("GeneratedAt = %q, want stamped value", doc.GeneratedAt)
+	}
+	want, _ := ComputeRevision(doc)
+	if doc.Revision != want {
+		t.Fatalf("Revision = %q, want %q", doc.Revision, want)
+	}
+	if err := Validate(doc); err != nil {
+		t.Fatalf("stamped document failed validation: %v", err)
+	}
+}
+
+func TestComputeRevisionNilDocument(t *testing.T) {
+	if _, err := ComputeRevision(nil); err == nil {
+		t.Fatal("ComputeRevision(nil) error = nil, want error")
+	}
+}

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -3,6 +3,20 @@
 // policy and the proxy-consumed policy.
 package policy
 
+// SchemaVersion is the current gateway policy contract schema version. It is
+// document-level metadata distinct from the authorization PolicyVersion: it
+// identifies the compatibility of the rendered JSON contract itself, not the
+// grant/session policy generation. Bump it only when the rendered JSON shape
+// changes in a way the consumer must understand.
+const SchemaVersion = "v1"
+
+// supportedSchemaVersions enumerates the schema versions a consumer is able to
+// activate. Documents carrying any other version fail validation and are
+// rejected before activation.
+var supportedSchemaVersions = map[string]struct{}{
+	SchemaVersion: {},
+}
+
 // ServerName identifies an MCP server in a rendered gateway policy.
 type ServerName string
 
@@ -26,13 +40,22 @@ type ToolName string
 
 // Document is the root gateway policy document that contains all policy configuration.
 type Document struct {
-	Server   Server    `json:"server"`
-	Auth     *Auth     `json:"auth,omitempty"`
-	Policy   *Config   `json:"policy,omitempty"`
-	Session  *Session  `json:"session,omitempty"`
-	Tools    []Tool    `json:"tools,omitempty"`
-	Grants   []Grant   `json:"grants,omitempty"`
-	Sessions []Binding `json:"sessions,omitempty"`
+	// SchemaVersion identifies the compatibility of the rendered JSON contract.
+	SchemaVersion string `json:"schema_version"`
+	// Revision is a deterministic SHA-256 digest of the canonical rendered
+	// policy content. It is computed with SchemaVersion included and with
+	// Revision and GeneratedAt excluded, so identical policy content always
+	// produces the same revision regardless of when it was generated.
+	Revision string `json:"revision"`
+	// GeneratedAt is informational only and must not affect Revision.
+	GeneratedAt string    `json:"generated_at,omitempty"`
+	Server      Server    `json:"server"`
+	Auth        *Auth     `json:"auth,omitempty"`
+	Policy      *Config   `json:"policy,omitempty"`
+	Session     *Session  `json:"session,omitempty"`
+	Tools       []Tool    `json:"tools,omitempty"`
+	Grants      []Grant   `json:"grants,omitempty"`
+	Sessions    []Binding `json:"sessions,omitempty"`
 }
 
 // Server identifies the MCP server this policy applies to.

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -21,6 +21,16 @@ func Validate(doc *Document) error {
 	if _, ok := supportedSchemaVersions[doc.SchemaVersion]; !ok {
 		return fmt.Errorf("policy: unsupported schema version %q", doc.SchemaVersion)
 	}
+	if strings.TrimSpace(doc.Revision) == "" {
+		return fmt.Errorf("policy: revision is required")
+	}
+	computed, err := ComputeRevision(doc)
+	if err != nil {
+		return fmt.Errorf("policy: cannot compute revision: %w", err)
+	}
+	if computed != doc.Revision {
+		return fmt.Errorf("policy: revision mismatch: document contains %q, computed %q", doc.Revision, computed)
+	}
 	if strings.TrimSpace(string(doc.Server.Name)) == "" {
 		return fmt.Errorf("policy: server.name is required")
 	}
@@ -111,10 +121,15 @@ func validateGrants(grants []Grant) error {
 				return fmt.Errorf("policy: grant %q has invalid allowed side effect %q", grant.Name, sideEffect)
 			}
 		}
+		seenRules := make(map[ToolName]struct{}, len(grant.ToolRules))
 		for j, rule := range grant.ToolRules {
 			if strings.TrimSpace(string(rule.Name)) == "" {
 				return fmt.Errorf("policy: grant %q tool_rules[%d] name is required", grant.Name, j)
 			}
+			if _, dup := seenRules[rule.Name]; dup {
+				return fmt.Errorf("policy: grant %q has duplicate tool rule %q", grant.Name, rule.Name)
+			}
+			seenRules[rule.Name] = struct{}{}
 			if !validDecision(rule.Decision) {
 				return fmt.Errorf("policy: grant %q tool rule %q has invalid decision %q", grant.Name, rule.Name, rule.Decision)
 			}

--- a/pkg/policy/validate.go
+++ b/pkg/policy/validate.go
@@ -1,0 +1,181 @@
+package policy
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Validate checks that a rendered gateway policy document is structurally sound
+// and safe to activate. It is the shared contract used by both the producer
+// (operator, before writing the policy ConfigMap) and the consumer (gateway,
+// after decoding and before activating a snapshot).
+//
+// Validation is strict and fails closed: unknown trust, side-effect, decision,
+// auth-mode, or policy-mode values are rejected rather than silently normalized,
+// and incomplete combinations (such as OAuth without an issuer) are errors. A
+// document that does not validate must never replace a known-good policy.
+func Validate(doc *Document) error {
+	if doc == nil {
+		return fmt.Errorf("policy: document is nil")
+	}
+	if _, ok := supportedSchemaVersions[doc.SchemaVersion]; !ok {
+		return fmt.Errorf("policy: unsupported schema version %q", doc.SchemaVersion)
+	}
+	if strings.TrimSpace(string(doc.Server.Name)) == "" {
+		return fmt.Errorf("policy: server.name is required")
+	}
+
+	if err := validateAuth(doc.Auth); err != nil {
+		return err
+	}
+	if err := validateConfig(doc.Policy); err != nil {
+		return err
+	}
+	if err := validateTools(doc.Tools); err != nil {
+		return err
+	}
+	if err := validateGrants(doc.Grants); err != nil {
+		return err
+	}
+	return validateBindings(doc.Sessions)
+}
+
+func validateAuth(auth *Auth) error {
+	if auth == nil {
+		return nil
+	}
+	mode := strings.ToLower(strings.TrimSpace(auth.Mode))
+	switch mode {
+	case "", "none", "header", "oauth":
+	default:
+		return fmt.Errorf("policy: invalid auth mode %q", auth.Mode)
+	}
+	if mode == "oauth" && strings.TrimSpace(auth.IssuerURL) == "" {
+		return fmt.Errorf("policy: auth mode %q requires issuer_url", auth.Mode)
+	}
+	return nil
+}
+
+func validateConfig(cfg *Config) error {
+	if cfg == nil {
+		return nil
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.Mode)) {
+	case "", "allow-list", "observe":
+	default:
+		return fmt.Errorf("policy: invalid policy mode %q", cfg.Mode)
+	}
+	switch strings.ToLower(strings.TrimSpace(cfg.DefaultDecision)) {
+	case "", "allow", "deny":
+	default:
+		return fmt.Errorf("policy: invalid default decision %q", cfg.DefaultDecision)
+	}
+	return nil
+}
+
+func validateTools(tools []Tool) error {
+	seen := make(map[ToolName]struct{}, len(tools))
+	for i, tool := range tools {
+		if strings.TrimSpace(string(tool.Name)) == "" {
+			return fmt.Errorf("policy: tools[%d] name is required", i)
+		}
+		if _, dup := seen[tool.Name]; dup {
+			return fmt.Errorf("policy: duplicate tool name %q", tool.Name)
+		}
+		seen[tool.Name] = struct{}{}
+		if !validTrust(tool.RequiredTrust) {
+			return fmt.Errorf("policy: tool %q has invalid required_trust %q", tool.Name, tool.RequiredTrust)
+		}
+		if !validSideEffect(tool.SideEffect, true) {
+			return fmt.Errorf("policy: tool %q has invalid side_effect %q", tool.Name, tool.SideEffect)
+		}
+	}
+	return nil
+}
+
+func validateGrants(grants []Grant) error {
+	seen := make(map[string]struct{}, len(grants))
+	for i, grant := range grants {
+		if strings.TrimSpace(grant.Name) == "" {
+			return fmt.Errorf("policy: grants[%d] name is required", i)
+		}
+		if _, dup := seen[grant.Name]; dup {
+			return fmt.Errorf("policy: duplicate grant name %q", grant.Name)
+		}
+		seen[grant.Name] = struct{}{}
+		if !validTrust(grant.MaxTrust) {
+			return fmt.Errorf("policy: grant %q has invalid max_trust %q", grant.Name, grant.MaxTrust)
+		}
+		for _, sideEffect := range grant.AllowedSideEffects {
+			if !validSideEffect(sideEffect, false) {
+				return fmt.Errorf("policy: grant %q has invalid allowed side effect %q", grant.Name, sideEffect)
+			}
+		}
+		for j, rule := range grant.ToolRules {
+			if strings.TrimSpace(string(rule.Name)) == "" {
+				return fmt.Errorf("policy: grant %q tool_rules[%d] name is required", grant.Name, j)
+			}
+			if !validDecision(rule.Decision) {
+				return fmt.Errorf("policy: grant %q tool rule %q has invalid decision %q", grant.Name, rule.Name, rule.Decision)
+			}
+			if !validTrust(rule.RequiredTrust) {
+				return fmt.Errorf("policy: grant %q tool rule %q has invalid required_trust %q", grant.Name, rule.Name, rule.RequiredTrust)
+			}
+		}
+	}
+	return nil
+}
+
+func validateBindings(bindings []Binding) error {
+	seen := make(map[SessionID]struct{}, len(bindings))
+	for i, binding := range bindings {
+		if strings.TrimSpace(string(binding.Name)) == "" {
+			return fmt.Errorf("policy: sessions[%d] name is required", i)
+		}
+		if _, dup := seen[binding.Name]; dup {
+			return fmt.Errorf("policy: duplicate session name %q", binding.Name)
+		}
+		seen[binding.Name] = struct{}{}
+		if !validTrust(binding.ConsentedTrust) {
+			return fmt.Errorf("policy: session %q has invalid consented_trust %q", binding.Name, binding.ConsentedTrust)
+		}
+	}
+	return nil
+}
+
+// validTrust reports whether a trust value is empty (defaulted downstream) or
+// one of the recognized trust levels. Unknown values are rejected.
+func validTrust(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", TrustLevelLow, TrustLevelMedium, TrustLevelHigh:
+		return true
+	default:
+		return false
+	}
+}
+
+// validSideEffect reports whether a side-effect value is acceptable. When
+// allowEmpty is true an empty value is permitted (a tool may declare no side
+// effect, which fails closed at evaluation time); when false (a grant's allowed
+// side effect) an empty value is rejected as meaningless.
+func validSideEffect(value string, allowEmpty bool) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "":
+		return allowEmpty
+	case SideEffectRead, SideEffectWrite, SideEffectDestructive:
+		return true
+	default:
+		return false
+	}
+}
+
+// validDecision reports whether a tool-rule decision is empty (treated as allow
+// downstream) or one of the recognized decisions.
+func validDecision(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "allow", "deny":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -1,0 +1,86 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAcceptsWellFormedDocument(t *testing.T) {
+	doc := &Document{
+		SchemaVersion: SchemaVersion,
+		Revision:      "sha256:abc",
+		Server:        Server{Name: "demo", Namespace: "mcp-servers"},
+		Auth:          &Auth{Mode: "oauth", IssuerURL: "https://issuer.example.com"},
+		Policy:        &Config{Mode: "allow-list", DefaultDecision: "deny"},
+		Tools: []Tool{
+			{Name: "read-file", RequiredTrust: "low", SideEffect: "read"},
+			{Name: "write-file", RequiredTrust: "high", SideEffect: "write"},
+		},
+		Grants: []Grant{{
+			Name:               "dev",
+			HumanID:            "user@example.com",
+			MaxTrust:           "high",
+			AllowedSideEffects: []string{"read", "write"},
+			ToolRules:          []ToolAccess{{Name: "read-file", Decision: "allow", RequiredTrust: "low"}},
+		}},
+		Sessions: []Binding{{Name: "s1", HumanID: "user@example.com", ConsentedTrust: "high"}},
+	}
+	if err := Validate(doc); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidateRejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Document)
+		wantSub string
+	}{
+		{"nil schema version", func(d *Document) { d.SchemaVersion = "" }, "schema version"},
+		{"unsupported schema version", func(d *Document) { d.SchemaVersion = "v999" }, "schema version"},
+		{"missing server name", func(d *Document) { d.Server.Name = "" }, "server.name"},
+		{"invalid auth mode", func(d *Document) { d.Auth = &Auth{Mode: "saml"} }, "auth mode"},
+		{"oauth without issuer", func(d *Document) { d.Auth = &Auth{Mode: "oauth"} }, "issuer_url"},
+		{"invalid policy mode", func(d *Document) { d.Policy = &Config{Mode: "deny-everything"} }, "policy mode"},
+		{"invalid default decision", func(d *Document) { d.Policy = &Config{DefaultDecision: "maybe"} }, "default decision"},
+		{"invalid tool trust", func(d *Document) { d.Tools = []Tool{{Name: "t", RequiredTrust: "ultra"}} }, "required_trust"},
+		{"invalid tool side effect", func(d *Document) { d.Tools = []Tool{{Name: "t", SideEffect: "explode"}} }, "side_effect"},
+		{"duplicate tool", func(d *Document) { d.Tools = []Tool{{Name: "t"}, {Name: "t"}} }, "duplicate tool"},
+		{"empty tool name", func(d *Document) { d.Tools = []Tool{{Name: ""}} }, "name is required"},
+		{"duplicate grant", func(d *Document) { d.Grants = []Grant{{Name: "g"}, {Name: "g"}} }, "duplicate grant"},
+		{"invalid grant trust", func(d *Document) { d.Grants = []Grant{{Name: "g", MaxTrust: "extreme"}} }, "max_trust"},
+		{"invalid allowed side effect", func(d *Document) {
+			d.Grants = []Grant{{Name: "g", AllowedSideEffects: []string{"boom"}}}
+		}, "allowed side effect"},
+		{"invalid tool rule decision", func(d *Document) {
+			d.Grants = []Grant{{Name: "g", ToolRules: []ToolAccess{{Name: "t", Decision: "perhaps"}}}}
+		}, "decision"},
+		{"duplicate session", func(d *Document) { d.Sessions = []Binding{{Name: "s"}, {Name: "s"}} }, "duplicate session"},
+		{"invalid consented trust", func(d *Document) {
+			d.Sessions = []Binding{{Name: "s", ConsentedTrust: "godmode"}}
+		}, "consented_trust"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &Document{
+				SchemaVersion: SchemaVersion,
+				Server:        Server{Name: "demo"},
+			}
+			tc.mutate(doc)
+			err := Validate(doc)
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want error containing %q", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestValidateNilDocument(t *testing.T) {
+	if err := Validate(nil); err == nil {
+		t.Fatal("Validate(nil) error = nil, want error")
+	}
+}

--- a/pkg/policy/validate_test.go
+++ b/pkg/policy/validate_test.go
@@ -8,7 +8,6 @@ import (
 func TestValidateAcceptsWellFormedDocument(t *testing.T) {
 	doc := &Document{
 		SchemaVersion: SchemaVersion,
-		Revision:      "sha256:abc",
 		Server:        Server{Name: "demo", Namespace: "mcp-servers"},
 		Auth:          &Auth{Mode: "oauth", IssuerURL: "https://issuer.example.com"},
 		Policy:        &Config{Mode: "allow-list", DefaultDecision: "deny"},
@@ -25,40 +24,56 @@ func TestValidateAcceptsWellFormedDocument(t *testing.T) {
 		}},
 		Sessions: []Binding{{Name: "s1", HumanID: "user@example.com", ConsentedTrust: "high"}},
 	}
+	if err := Stamp(doc, ""); err != nil {
+		t.Fatalf("Stamp() error = %v", err)
+	}
 	if err := Validate(doc); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
 	}
 }
 
 func TestValidateRejects(t *testing.T) {
+	// restamp controls whether to re-run Stamp after the mutation so that the
+	// revision reflects the mutated body. Schema-version and revision checks fire
+	// before the body digest is verified, so those test cases must NOT restamp.
 	cases := []struct {
 		name    string
 		mutate  func(*Document)
+		restamp bool
 		wantSub string
 	}{
-		{"nil schema version", func(d *Document) { d.SchemaVersion = "" }, "schema version"},
-		{"unsupported schema version", func(d *Document) { d.SchemaVersion = "v999" }, "schema version"},
-		{"missing server name", func(d *Document) { d.Server.Name = "" }, "server.name"},
-		{"invalid auth mode", func(d *Document) { d.Auth = &Auth{Mode: "saml"} }, "auth mode"},
-		{"oauth without issuer", func(d *Document) { d.Auth = &Auth{Mode: "oauth"} }, "issuer_url"},
-		{"invalid policy mode", func(d *Document) { d.Policy = &Config{Mode: "deny-everything"} }, "policy mode"},
-		{"invalid default decision", func(d *Document) { d.Policy = &Config{DefaultDecision: "maybe"} }, "default decision"},
-		{"invalid tool trust", func(d *Document) { d.Tools = []Tool{{Name: "t", RequiredTrust: "ultra"}} }, "required_trust"},
-		{"invalid tool side effect", func(d *Document) { d.Tools = []Tool{{Name: "t", SideEffect: "explode"}} }, "side_effect"},
-		{"duplicate tool", func(d *Document) { d.Tools = []Tool{{Name: "t"}, {Name: "t"}} }, "duplicate tool"},
-		{"empty tool name", func(d *Document) { d.Tools = []Tool{{Name: ""}} }, "name is required"},
-		{"duplicate grant", func(d *Document) { d.Grants = []Grant{{Name: "g"}, {Name: "g"}} }, "duplicate grant"},
-		{"invalid grant trust", func(d *Document) { d.Grants = []Grant{{Name: "g", MaxTrust: "extreme"}} }, "max_trust"},
+		// Schema version is checked before revision; no restamp needed.
+		{"nil schema version", func(d *Document) { d.SchemaVersion = "" }, false, "schema version"},
+		{"unsupported schema version", func(d *Document) { d.SchemaVersion = "v999" }, false, "schema version"},
+		// Revision checks: clear or corrupt the stamped revision directly.
+		{"missing revision", func(d *Document) { d.Revision = "" }, false, "revision is required"},
+		{"revision mismatch", func(d *Document) { d.Revision = "sha256:bad" }, false, "revision mismatch"},
+		// Body-level checks: restamp after mutation so revision matches the mutated
+		// body and the specific field error is what fires.
+		{"missing server name", func(d *Document) { d.Server.Name = "" }, true, "server.name"},
+		{"invalid auth mode", func(d *Document) { d.Auth = &Auth{Mode: "saml"} }, true, "auth mode"},
+		{"oauth without issuer", func(d *Document) { d.Auth = &Auth{Mode: "oauth"} }, true, "issuer_url"},
+		{"invalid policy mode", func(d *Document) { d.Policy = &Config{Mode: "deny-everything"} }, true, "policy mode"},
+		{"invalid default decision", func(d *Document) { d.Policy = &Config{DefaultDecision: "maybe"} }, true, "default decision"},
+		{"invalid tool trust", func(d *Document) { d.Tools = []Tool{{Name: "t", RequiredTrust: "ultra"}} }, true, "required_trust"},
+		{"invalid tool side effect", func(d *Document) { d.Tools = []Tool{{Name: "t", SideEffect: "explode"}} }, true, "side_effect"},
+		{"duplicate tool", func(d *Document) { d.Tools = []Tool{{Name: "t"}, {Name: "t"}} }, true, "duplicate tool"},
+		{"empty tool name", func(d *Document) { d.Tools = []Tool{{Name: ""}} }, true, "name is required"},
+		{"duplicate grant", func(d *Document) { d.Grants = []Grant{{Name: "g"}, {Name: "g"}} }, true, "duplicate grant"},
+		{"invalid grant trust", func(d *Document) { d.Grants = []Grant{{Name: "g", MaxTrust: "extreme"}} }, true, "max_trust"},
 		{"invalid allowed side effect", func(d *Document) {
 			d.Grants = []Grant{{Name: "g", AllowedSideEffects: []string{"boom"}}}
-		}, "allowed side effect"},
+		}, true, "allowed side effect"},
 		{"invalid tool rule decision", func(d *Document) {
 			d.Grants = []Grant{{Name: "g", ToolRules: []ToolAccess{{Name: "t", Decision: "perhaps"}}}}
-		}, "decision"},
-		{"duplicate session", func(d *Document) { d.Sessions = []Binding{{Name: "s"}, {Name: "s"}} }, "duplicate session"},
+		}, true, "decision"},
+		{"duplicate tool rule", func(d *Document) {
+			d.Grants = []Grant{{Name: "g", ToolRules: []ToolAccess{{Name: "t"}, {Name: "t"}}}}
+		}, true, "duplicate tool rule"},
+		{"duplicate session", func(d *Document) { d.Sessions = []Binding{{Name: "s"}, {Name: "s"}} }, true, "duplicate session"},
 		{"invalid consented trust", func(d *Document) {
 			d.Sessions = []Binding{{Name: "s", ConsentedTrust: "godmode"}}
-		}, "consented_trust"},
+		}, true, "consented_trust"},
 	}
 
 	for _, tc := range cases {
@@ -67,7 +82,15 @@ func TestValidateRejects(t *testing.T) {
 				SchemaVersion: SchemaVersion,
 				Server:        Server{Name: "demo"},
 			}
+			if err := Stamp(doc, ""); err != nil {
+				t.Fatalf("Stamp() error = %v", err)
+			}
 			tc.mutate(doc)
+			if tc.restamp {
+				if err := Stamp(doc, ""); err != nil {
+					t.Fatalf("Stamp() after mutation error = %v", err)
+				}
+			}
 			err := Validate(doc)
 			if err == nil {
 				t.Fatalf("Validate() error = nil, want error containing %q", tc.wantSub)

--- a/services/mcp-gateway/go.mod
+++ b/services/mcp-gateway/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/MicahParks/keyfunc v1.9.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/prometheus/client_golang v1.23.2
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
@@ -24,9 +25,9 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pierrec/lz4/v4 v4.1.25 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/services/mcp-gateway/main.go
+++ b/services/mcp-gateway/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	_ "go.uber.org/automaxprocs" // align GOMAXPROCS with container CPU quota
 
@@ -81,10 +82,17 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
+	// Liveness: always OK while the process is serving.
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
 	})
+	// Readiness: OK only after a valid policy snapshot has been activated.
+	mux.HandleFunc("/ready", srv.handleReady)
+	// Sanitized applied-policy metadata (schema version, revision, reload state).
+	mux.HandleFunc("/config/status", srv.handleConfigStatus)
+	// Prometheus metrics, including policy reload observability.
+	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/", srv.handleGateway)
 
 	shutdown, err := initTracer("mcp-gateway")

--- a/services/mcp-gateway/main_test.go
+++ b/services/mcp-gateway/main_test.go
@@ -960,7 +960,7 @@ func newTestGatewayServer(t *testing.T, policy *policypkg.Document, upstream htt
 		defaultPolicyVersion:  "test-policy",
 		oauthProviders:        map[string]*oauthProvider{},
 	}
-	server.snapshotPolicy(policySnapshot{Policy: policy})
+	server.snapshotPolicy(policySnapshot{Policy: policy, Revision: policy.Revision, LoadedAt: time.Now(), Ready: true})
 	return server
 }
 

--- a/services/mcp-gateway/metrics.go
+++ b/services/mcp-gateway/metrics.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// policyReloadTotal counts policy reload attempts grouped by result so
+	// operators can alert on a rising failure rate.
+	policyReloadTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "mcp_gateway_policy_reload_total",
+		Help: "Total gateway policy reload attempts grouped by result (success or failure).",
+	}, []string{"result"})
+
+	// policyActiveRevisionInfo exposes the active policy revision and schema
+	// version as labels; the value is always 1 for the currently active series.
+	policyActiveRevisionInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "mcp_gateway_policy_active_revision_info",
+		Help: "Active gateway policy revision and schema version (value is always 1).",
+	}, []string{"revision", "schema_version"})
+
+	// policyLastSuccessTimestamp records when the last valid policy was loaded.
+	policyLastSuccessTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "mcp_gateway_policy_last_success_timestamp_seconds",
+		Help: "Unix timestamp (seconds) of the last successful gateway policy load.",
+	})
+)
+
+func init() {
+	prometheus.MustRegister(policyReloadTotal, policyActiveRevisionInfo, policyLastSuccessTimestamp)
+}
+
+// recordPolicyReloadSuccess records a successful reload and republishes the
+// active revision so only the live revision reports value 1.
+func recordPolicyReloadSuccess(revision, schemaVersion string, at time.Time) {
+	policyReloadTotal.WithLabelValues("success").Inc()
+	policyActiveRevisionInfo.Reset()
+	policyActiveRevisionInfo.WithLabelValues(revision, schemaVersion).Set(1)
+	policyLastSuccessTimestamp.Set(float64(at.Unix()))
+}
+
+// recordPolicyReloadFailure records a rejected reload. The active revision and
+// last-success timestamp are intentionally left unchanged because the previous
+// known-good policy remains active.
+func recordPolicyReloadFailure() {
+	policyReloadTotal.WithLabelValues("failure").Inc()
+}

--- a/services/mcp-gateway/metrics_test.go
+++ b/services/mcp-gateway/metrics_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestPolicyReloadMetrics(t *testing.T) {
+	failBefore := testutil.ToFloat64(policyReloadTotal.WithLabelValues("failure"))
+	recordPolicyReloadFailure()
+	if got := testutil.ToFloat64(policyReloadTotal.WithLabelValues("failure")) - failBefore; got != 1 {
+		t.Fatalf("failure counter delta = %v, want 1", got)
+	}
+
+	successBefore := testutil.ToFloat64(policyReloadTotal.WithLabelValues("success"))
+	at := time.Unix(1_700_000_000, 0)
+	recordPolicyReloadSuccess("sha256:revA", "v1", at)
+	if got := testutil.ToFloat64(policyReloadTotal.WithLabelValues("success")) - successBefore; got != 1 {
+		t.Fatalf("success counter delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(policyLastSuccessTimestamp); got != float64(at.Unix()) {
+		t.Fatalf("last success timestamp = %v, want %v", got, at.Unix())
+	}
+	if got := testutil.ToFloat64(policyActiveRevisionInfo.WithLabelValues("sha256:revA", "v1")); got != 1 {
+		t.Fatalf("active revision info = %v, want 1", got)
+	}
+
+	// A new active revision replaces the prior series (Reset on success).
+	recordPolicyReloadSuccess("sha256:revB", "v1", at)
+	if got := testutil.ToFloat64(policyActiveRevisionInfo.WithLabelValues("sha256:revA", "v1")); got != 0 {
+		t.Fatalf("stale revision info = %v, want 0 after new revision activated", got)
+	}
+}

--- a/services/mcp-gateway/policy_cache.go
+++ b/services/mcp-gateway/policy_cache.go
@@ -47,9 +47,6 @@ func (s *gatewayServer) startPolicyCache() error {
 // /config/status and metrics surface the failure while traffic keeps flowing.
 func (s *gatewayServer) reloadPolicy() error {
 	doc, err := s.loadPolicy()
-	if err == nil {
-		err = policypkg.Validate(doc)
-	}
 	if err != nil {
 		retained := s.loadPolicySnapshot()
 		retained.Err = err
@@ -109,14 +106,25 @@ func (s *gatewayServer) loadPolicy() (*policypkg.Document, error) {
 		}
 	}
 
+	// A file-backed document is validated exactly as the operator stamped it:
+	// the revision digest covers the rendered content, so integrity must be
+	// checked before gateway runtime defaults mutate the document.
+	if fromFile {
+		if err := policypkg.Validate(doc); err != nil {
+			return nil, err
+		}
+	}
+
 	s.applyPolicyDefaults(doc)
 
-	// A file-backed document carries the operator-stamped schema version and
-	// revision and is reported verbatim. A gateway-generated default document
-	// (no policy file, or an empty one) is stamped here so it carries a
-	// supported schema version and deterministic revision and can validate.
+	// A gateway-generated default document (no policy file, or an empty one)
+	// is stamped after defaulting so it carries a supported schema version and
+	// a deterministic revision over its final content.
 	if !fromFile {
 		if err := policypkg.Stamp(doc, ""); err != nil {
+			return nil, err
+		}
+		if err := policypkg.Validate(doc); err != nil {
 			return nil, err
 		}
 	}

--- a/services/mcp-gateway/policy_cache.go
+++ b/services/mcp-gateway/policy_cache.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -11,7 +12,14 @@ import (
 	policypkg "mcp-runtime/pkg/policy"
 )
 
+// errPolicyUnavailable is returned by currentPolicy when no validated policy
+// snapshot has been activated yet. Callers fail tool calls closed in this state.
+var errPolicyUnavailable = errors.New("policy_unavailable")
+
 func (s *gatewayServer) startPolicyCache() error {
+	// Seed with the default document so reads never observe a nil policy. It is
+	// not marked Ready: in file-backed mode the gateway is only ready once the
+	// rendered policy validates and activates below.
 	s.snapshotPolicy(policySnapshot{Policy: s.defaultPolicyDocument()})
 	if err := s.reloadPolicy(); err != nil {
 		return err
@@ -33,27 +41,46 @@ func (s *gatewayServer) startPolicyCache() error {
 	return nil
 }
 
+// reloadPolicy loads, validates, and atomically activates the policy. A load or
+// validation failure never replaces the last-known-good snapshot: the previous
+// Policy/Revision/LoadedAt/Ready are retained and only Err is updated so that
+// /config/status and metrics surface the failure while traffic keeps flowing.
 func (s *gatewayServer) reloadPolicy() error {
 	doc, err := s.loadPolicy()
+	if err == nil {
+		err = policypkg.Validate(doc)
+	}
 	if err != nil {
-		current := s.loadPolicySnapshot()
-		fallback := current.Policy
-		if fallback == nil {
-			fallback = s.defaultPolicyDocument()
-		}
-		s.snapshotPolicy(policySnapshot{Policy: fallback, Err: err})
+		retained := s.loadPolicySnapshot()
+		retained.Err = err
+		s.snapshotPolicy(retained)
+		recordPolicyReloadFailure()
 		return err
 	}
-	s.snapshotPolicy(policySnapshot{Policy: doc})
+
+	loadedAt := time.Now()
+	s.snapshotPolicy(policySnapshot{
+		Policy:   doc,
+		Revision: doc.Revision,
+		LoadedAt: loadedAt,
+		Ready:    true,
+	})
+	recordPolicyReloadSuccess(doc.Revision, doc.SchemaVersion, loadedAt)
 	return nil
 }
 
 func (s *gatewayServer) currentPolicy() (*policypkg.Document, error) {
 	snapshot := s.loadPolicySnapshot()
 	if snapshot.Policy == nil {
-		return s.defaultPolicyDocument(), snapshot.Err
+		return s.defaultPolicyDocument(), errPolicyUnavailable
 	}
-	return snapshot.Policy, snapshot.Err
+	// Until the first valid policy is activated, fail tool calls closed even
+	// though a seed document is present. Once Ready, a later failed reload is
+	// surfaced via /config/status but traffic keeps using last-known-good.
+	if !snapshot.Ready {
+		return snapshot.Policy, errPolicyUnavailable
+	}
+	return snapshot.Policy, nil
 }
 
 func (s *gatewayServer) loadPolicySnapshot() policySnapshot {
@@ -69,6 +96,7 @@ func (s *gatewayServer) snapshotPolicy(snapshot policySnapshot) {
 
 func (s *gatewayServer) loadPolicy() (*policypkg.Document, error) {
 	doc := &policypkg.Document{}
+	fromFile := false
 	if s.policyFile != "" {
 		data, err := os.ReadFile(s.policyFile)
 		if err != nil {
@@ -77,9 +105,34 @@ func (s *gatewayServer) loadPolicy() (*policypkg.Document, error) {
 			if err := json.Unmarshal(data, doc); err != nil {
 				return nil, err
 			}
+			fromFile = true
 		}
 	}
 
+	s.applyPolicyDefaults(doc)
+
+	// A file-backed document carries the operator-stamped schema version and
+	// revision and is reported verbatim. A gateway-generated default document
+	// (no policy file, or an empty one) is stamped here so it carries a
+	// supported schema version and deterministic revision and can validate.
+	if !fromFile {
+		if err := policypkg.Stamp(doc, ""); err != nil {
+			return nil, err
+		}
+	}
+	return doc, nil
+}
+
+// applyPolicyDefaults fills server identity and auth/policy defaults on a
+// decoded or empty document, initializing the Auth and Policy sub-documents
+// when absent so callers never dereference a nil pointer.
+func (s *gatewayServer) applyPolicyDefaults(doc *policypkg.Document) {
+	if doc.Auth == nil {
+		doc.Auth = &policypkg.Auth{}
+	}
+	if doc.Policy == nil {
+		doc.Policy = &policypkg.Config{}
+	}
 	if doc.Server.Name == "" {
 		doc.Server.Name = policypkg.ServerName(s.serverName)
 	}
@@ -116,7 +169,6 @@ func (s *gatewayServer) loadPolicy() (*policypkg.Document, error) {
 	if doc.Policy.PolicyVersion == "" {
 		doc.Policy.PolicyVersion = s.defaultPolicyVersion
 	}
-	return doc, nil
 }
 
 func (s *gatewayServer) extractIdentity(r *http.Request, policy *policypkg.Document) identityContext {
@@ -139,7 +191,7 @@ func policyIdentity(identity identityContext) policypkg.Identity {
 }
 
 func (s *gatewayServer) defaultPolicyDocument() *policypkg.Document {
-	return &policypkg.Document{
+	doc := &policypkg.Document{
 		Server: policypkg.Server{
 			Name:      policypkg.ServerName(s.serverName),
 			Namespace: policypkg.Namespace(s.serverNamespace),
@@ -159,4 +211,9 @@ func (s *gatewayServer) defaultPolicyDocument() *policypkg.Document {
 			PolicyVersion:   s.defaultPolicyVersion,
 		},
 	}
+	// Stamp so the default carries a supported schema version and deterministic
+	// revision; this is best-effort and the document is well-formed by
+	// construction, so any error is non-fatal.
+	_ = policypkg.Stamp(doc, "")
+	return doc
 }

--- a/services/mcp-gateway/policy_cache_test.go
+++ b/services/mcp-gateway/policy_cache_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	policypkg "mcp-runtime/pkg/policy"
+)
+
+func newCacheTestServer(policyFile string) *gatewayServer {
+	return &gatewayServer{
+		policyFile:            policyFile,
+		serverName:            "demo",
+		serverNamespace:       "mcp-servers",
+		defaultHumanHeader:    defaultHumanHeader,
+		defaultAgentHeader:    defaultAgentHeader,
+		defaultTeamHeader:     defaultTeamHeader,
+		defaultSessionHeader:  defaultSessionHeader,
+		defaultPolicyMode:     defaultPolicyMode,
+		defaultPolicyDecision: defaultPolicyDecision,
+		defaultPolicyVersion:  defaultPolicyVersion,
+		oauthProviders:        map[string]*oauthProvider{},
+	}
+}
+
+func writeStampedPolicy(t *testing.T, path string, mutate func(*policypkg.Document)) *policypkg.Document {
+	t.Helper()
+	doc := &policypkg.Document{
+		Server: policypkg.Server{Name: "demo", Namespace: "mcp-servers"},
+		Policy: &policypkg.Config{Mode: "allow-list", DefaultDecision: "deny", PolicyVersion: "v1"},
+	}
+	if mutate != nil {
+		mutate(doc)
+	}
+	if err := policypkg.Stamp(doc, ""); err != nil {
+		t.Fatalf("Stamp() error = %v", err)
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return doc
+}
+
+func TestReloadPolicyRetainsLastKnownGoodOnInvalidUpdate(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "policy.json")
+	good := writeStampedPolicy(t, file, nil)
+
+	s := newCacheTestServer(file)
+	if err := s.reloadPolicy(); err != nil {
+		t.Fatalf("reloadPolicy() error = %v", err)
+	}
+	snap := s.loadPolicySnapshot()
+	if !snap.Ready {
+		t.Fatal("snapshot not ready after a valid load")
+	}
+	if snap.Revision != good.Revision {
+		t.Fatalf("revision = %q, want %q", snap.Revision, good.Revision)
+	}
+
+	// Replace the file with an unsupported schema version: an invalid update.
+	bad := &policypkg.Document{Server: policypkg.Server{Name: "demo"}, SchemaVersion: "v999", Revision: "sha256:bad"}
+	data, _ := json.Marshal(bad)
+	if err := os.WriteFile(file, data, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	if err := s.reloadPolicy(); err == nil {
+		t.Fatal("reloadPolicy() error = nil, want validation error")
+	}
+	snap = s.loadPolicySnapshot()
+	if !snap.Ready {
+		t.Fatal("snapshot should remain ready (last-known-good retained)")
+	}
+	if snap.Revision != good.Revision {
+		t.Fatalf("revision changed to %q on invalid update, want retained %q", snap.Revision, good.Revision)
+	}
+	if snap.Err == nil {
+		t.Fatal("expected last reload error to be recorded")
+	}
+	// Traffic continues on the last-known-good policy: no policy_unavailable.
+	pol, perr := s.currentPolicy()
+	if perr != nil {
+		t.Fatalf("currentPolicy() error = %v, want nil (serve last-known-good)", perr)
+	}
+	if pol.Revision != good.Revision {
+		t.Fatalf("currentPolicy revision = %q, want %q", pol.Revision, good.Revision)
+	}
+}
+
+func TestReadyFailsUntilValidPolicyLoaded(t *testing.T) {
+	s := newCacheTestServer("")
+	// Seed the unready default snapshot, as startPolicyCache does before the
+	// first reload.
+	s.snapshotPolicy(policySnapshot{Policy: s.defaultPolicyDocument()})
+
+	recorder := httptest.NewRecorder()
+	s.handleReady(recorder, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("ready status = %d, want %d before first valid load", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if _, perr := s.currentPolicy(); perr == nil {
+		t.Fatal("currentPolicy() error = nil before first valid load, want policy_unavailable")
+	}
+
+	// A no-file gateway reaches ready once its stamped default validates.
+	if err := s.reloadPolicy(); err != nil {
+		t.Fatalf("reloadPolicy() error = %v", err)
+	}
+	recorder = httptest.NewRecorder()
+	s.handleReady(recorder, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("ready status = %d, want %d after valid load", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestConfigStatusExposesSanitizedMetadata(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "policy.json")
+	good := writeStampedPolicy(t, file, nil)
+
+	s := newCacheTestServer(file)
+	if err := s.reloadPolicy(); err != nil {
+		t.Fatalf("reloadPolicy() error = %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	s.handleConfigStatus(recorder, httptest.NewRequest(http.MethodGet, "/config/status", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("config status code = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	var status configStatus
+	if err := json.Unmarshal(recorder.Body.Bytes(), &status); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !status.Ready {
+		t.Fatal("config status ready = false, want true")
+	}
+	if status.SchemaVersion != policypkg.SchemaVersion {
+		t.Fatalf("schema version = %q, want %q", status.SchemaVersion, policypkg.SchemaVersion)
+	}
+	if status.Revision != good.Revision {
+		t.Fatalf("revision = %q, want %q", status.Revision, good.Revision)
+	}
+	if status.LoadedAt == "" {
+		t.Fatal("loaded_at empty, want a timestamp")
+	}
+	if status.LastReloadError != "" {
+		t.Fatalf("last_reload_error = %q, want empty", status.LastReloadError)
+	}
+	// The sanitized status must not leak the policy body.
+	for _, leaked := range []string{"grants", "sessions", "tools", "server"} {
+		if jsonContains(t, recorder.Body.Bytes(), leaked) {
+			t.Fatalf("config status leaked %q from policy body: %s", leaked, recorder.Body.String())
+		}
+	}
+}
+
+func jsonContains(t *testing.T, body []byte, key string) bool {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	_, ok := m[key]
+	return ok
+}

--- a/services/mcp-gateway/status.go
+++ b/services/mcp-gateway/status.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"mcp-runtime/pkg/serviceutil"
+)
+
+// configStatus is the sanitized view of the active policy snapshot exposed at
+// /config/status. It deliberately omits the policy body (grants, sessions,
+// identities) and reports only contract metadata and reload state.
+type configStatus struct {
+	Ready           bool   `json:"ready"`
+	SchemaVersion   string `json:"schema_version,omitempty"`
+	Revision        string `json:"revision,omitempty"`
+	LoadedAt        string `json:"loaded_at,omitempty"`
+	LastReloadError string `json:"last_reload_error,omitempty"`
+}
+
+// handleReady is a readiness probe that succeeds only after the first valid
+// policy snapshot has been activated. It stays ready across later failed
+// reloads because the last-known-good policy is retained.
+func (s *gatewayServer) handleReady(w http.ResponseWriter, _ *http.Request) {
+	snapshot := s.loadPolicySnapshot()
+	if !snapshot.Ready {
+		payload := map[string]any{"status": "not_ready", "reason": "policy_not_loaded"}
+		if snapshot.Err != nil {
+			payload["last_reload_error"] = snapshot.Err.Error()
+		}
+		serviceutil.WriteJSON(w, http.StatusServiceUnavailable, payload)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ready"))
+}
+
+// handleConfigStatus reports the sanitized applied schema version, revision,
+// load timestamp, and last reload error for the active policy snapshot.
+func (s *gatewayServer) handleConfigStatus(w http.ResponseWriter, _ *http.Request) {
+	snapshot := s.loadPolicySnapshot()
+	status := configStatus{
+		Ready:    snapshot.Ready,
+		Revision: snapshot.Revision,
+	}
+	if snapshot.Policy != nil {
+		status.SchemaVersion = snapshot.Policy.SchemaVersion
+	}
+	if !snapshot.LoadedAt.IsZero() {
+		status.LoadedAt = snapshot.LoadedAt.UTC().Format(time.RFC3339)
+	}
+	if snapshot.Err != nil {
+		status.LastReloadError = snapshot.Err.Error()
+	}
+	serviceutil.WriteJSON(w, http.StatusOK, status)
+}

--- a/services/mcp-gateway/types.go
+++ b/services/mcp-gateway/types.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/MicahParks/keyfunc"
 
@@ -20,9 +21,22 @@ type identityContext struct {
 	SessionID string
 }
 
+// policySnapshot is the atomically-swapped view of the active gateway policy.
+// A snapshot only ever holds a complete, validated policy (the last-known-good
+// document); an invalid reload never replaces Policy and instead records its
+// failure in Err while leaving the rest of the snapshot intact.
 type policySnapshot struct {
-	Policy *policypkg.Document
-	Err    error
+	Policy   *policypkg.Document
+	Revision string
+	LoadedAt time.Time
+	// Err holds the most recent reload error for observability. It does not
+	// imply the active Policy is unusable: on a failed reload the previous
+	// known-good Policy is retained and Err describes why the update was
+	// rejected.
+	Err error
+	// Ready is true once a valid policy snapshot has been activated. It stays
+	// true across subsequent failed reloads (last-known-good is retained).
+	Ready bool
 }
 
 type rpcInspection struct {


### PR DESCRIPTION
Add document-level metadata (schema_version, deterministic revision, informational generated_at) to the rendered gateway policy contract, a shared pkg/policy.Validate used by both producer and consumer, and last-known-good snapshot activation in the gateway.

- pkg/policy: schema version + ComputeRevision/Stamp (SHA-256 over canonical content, excluding revision/generated_at); strict, fail-closed Validate covering schema version, server identity, auth/policy/decision/ trust/side-effect values, unique names, and OAuth issuer requirements.
- operator: stamp schema+revision in renderGatewayPolicy, validate before replacing the ConfigMap, and avoid reconcile churn by preserving the prior payload when the revision is unchanged.
- mcp-gateway: validate after decode and before activating a snapshot; invalid updates retain the previous valid policy and record the error; expand the snapshot with revision/loaded-at/ready/last-error; add /ready, /config/status, and /metrics (reload counters, active revision, last success timestamp).
- docs/runtime.md: explain schema version, revision, and last-known-good.

Closes #295