### PR TITLE
feat(mcp-gateway): introduce ordered 5-stage request filter pipeline

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,6 +1,6 @@
 # Keep the operator image on a patched Go 1.26.x builder so Trivy
 # does not flag fixed stdlib CVEs in the shipped binary.
-FROM golang:1.26.3-alpine3.23 AS builder
+FROM golang:1.26.4-alpine3.23 AS builder
 
 WORKDIR /build
 

--- a/services/mcp-gateway/exchange.go
+++ b/services/mcp-gateway/exchange.go
@@ -26,7 +26,6 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -49,14 +48,14 @@ const (
 
 // Filter is a single stage in the gateway request pipeline.
 type Filter interface {
-	Handle(context.Context, *Exchange) Result
+	Handle(*Exchange) Result
 }
 
 // FilterFunc is a function that implements Filter.
-type FilterFunc func(context.Context, *Exchange) Result
+type FilterFunc func(*Exchange) Result
 
 // Handle implements Filter.
-func (f FilterFunc) Handle(ctx context.Context, ex *Exchange) Result { return f(ctx, ex) }
+func (f FilterFunc) Handle(ex *Exchange) Result { return f(ex) }
 
 // Exchange holds all request-scoped state shared across pipeline stages.
 // Fields are written by one designated stage and read by all later stages.
@@ -85,6 +84,12 @@ type Exchange struct {
 
 	// Set by stage 4 (AuthzFilter). Policy and Identity must not change after this.
 	Decision policypkg.Decision
+
+	// SkipAudit is set by a filter that writes a terminal response that bypasses
+	// authentication and authorization entirely (e.g. OAuth metadata early-exit in
+	// policyFilter). When true, emitAuditFromExchange does nothing, because no
+	// identity or authorization decision was established for the request.
+	SkipAudit bool
 }
 
 // newExchange initialises an Exchange for a fresh inbound request.

--- a/services/mcp-gateway/exchange.go
+++ b/services/mcp-gateway/exchange.go
@@ -1,0 +1,104 @@
+// Package main implements the MCP gateway service.
+//
+// # Request filter pipeline
+//
+// Every inbound request is processed through a fixed ordered pipeline of five
+// stages before audit/analytics finalization runs unconditionally as stage 6.
+// Stage order is security-sensitive and is fixed in code:
+//
+//	Stage 1 – InspectFilter:   bounded body capture; RPC method and tool name extraction
+//	Stage 2 – PolicyFilter:    atomic policy snapshot acquisition; OAuth metadata early-exit
+//	Stage 3 – AuthFilter:      authentication and identity extraction (header or OAuth JWT)
+//	Stage 4 – AuthzFilter:     authorization and session/grant evaluation
+//	Stage 5 – UpstreamFilter:  identity header rewrite; path rewrite; upstream proxy
+//	Stage 6 – (orchestrator):  audit/analytics finalization
+//
+// Ordering guarantees:
+//   - Authentication (stage 3) always completes before authorization (stage 4).
+//   - The policy snapshot (stage 2) is captured once and held immutable for the
+//     entire exchange lifetime; no later stage may re-acquire it.
+//   - Authorization inputs (Policy and Identity on Exchange) must not be mutated
+//     after the authz stage sets Decision; upstream preparation (stage 5) only
+//     reads them.
+//
+// Each filter returns Continue, Reject, or Respond. On any non-Continue result
+// the pipeline halts and stage 6 runs from the orchestrator.
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	policypkg "mcp-runtime/pkg/policy"
+)
+
+// Result is the signal a Filter returns to the pipeline runner.
+type Result int
+
+const (
+	// Continue passes control to the next filter in the pipeline.
+	Continue Result = iota
+	// Reject signals that this filter wrote a denial response. The pipeline
+	// halts; stage 6 (audit) runs from the orchestrator.
+	Reject
+	// Respond signals that this filter wrote a terminal response (e.g. OAuth
+	// metadata, successful upstream proxy). The pipeline halts; stage 6 runs.
+	Respond
+)
+
+// Filter is a single stage in the gateway request pipeline.
+type Filter interface {
+	Handle(context.Context, *Exchange) Result
+}
+
+// FilterFunc is a function that implements Filter.
+type FilterFunc func(context.Context, *Exchange) Result
+
+// Handle implements Filter.
+func (f FilterFunc) Handle(ctx context.Context, ex *Exchange) Result { return f(ctx, ex) }
+
+// Exchange holds all request-scoped state shared across pipeline stages.
+// Fields are written by one designated stage and read by all later stages.
+// Do not mutate Policy or Identity after AuthzFilter sets Decision.
+type Exchange struct {
+	// W wraps the original ResponseWriter to capture status code and byte count.
+	W *statusRecorder
+	// R is the inbound HTTP request. InspectFilter may replace Body with a
+	// buffered reader; no later stage should replace R.
+	R *http.Request
+	// OriginalPath is r.URL.Path captured before any prefix stripping.
+	OriginalPath string
+	// StartTime is captured by the orchestrator for latency accounting.
+	StartTime time.Time
+
+	// Set by stage 1 (InspectFilter).
+	Inspection rpcInspection
+
+	// Set by stage 2 (PolicyFilter). Immutable for the lifetime of this exchange.
+	Policy    *policypkg.Document
+	PolicyErr error
+
+	// Set by stage 3 (AuthFilter). Must be complete before stage 4 reads them.
+	Identity   identityContext
+	OAuthToken string // forwarded to upstream via session.UpstreamTokenHeader
+
+	// Set by stage 4 (AuthzFilter). Policy and Identity must not change after this.
+	Decision policypkg.Decision
+}
+
+// newExchange initialises an Exchange for a fresh inbound request.
+func newExchange(w http.ResponseWriter, r *http.Request, defaultPolicyVersion string) *Exchange {
+	return &Exchange{
+		W:            &statusRecorder{ResponseWriter: w, status: http.StatusOK},
+		R:            r,
+		OriginalPath: r.URL.Path,
+		StartTime:    time.Now(),
+		Decision: policypkg.Decision{
+			Allowed:       true,
+			Status:        http.StatusOK,
+			Reason:        "allowed",
+			PolicyVersion: defaultPolicyVersion,
+		},
+	}
+}

--- a/services/mcp-gateway/filter_auth.go
+++ b/services/mcp-gateway/filter_auth.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+
+	policypkg "mcp-runtime/pkg/policy"
+)
+
+// authFilter is stage 3 of the gateway pipeline. It extracts the caller
+// identity and, when the policy uses OAuth, validates the bearer JWT.
+//
+// For header-mode policies, identity is read directly from the governance
+// headers; no further validation is performed here — authzFilter (stage 4)
+// enforces grant and session policy.
+//
+// For OAuth policies, the JWT is verified against the issuer's JWKS. On any
+// authentication failure, authFilter writes a denial response and returns
+// Reject; it never falls through to stage 4 with an unauthenticated identity.
+//
+// authFilter always runs after policyFilter (stage 2) has set Exchange.Policy
+// and always completes before authzFilter (stage 4) reads Exchange.Identity.
+func (s *gatewayServer) authFilter(_ context.Context, ex *Exchange) Result {
+	// Extract identity from governance headers; for OAuth this populates at
+	// least the session header before JWT validation overwrites the rest.
+	ex.Identity = s.extractIdentity(ex.R, ex.Policy)
+
+	if !policypkg.PolicyUsesOAuth(ex.Policy) {
+		return Continue
+	}
+
+	oauthResult := s.authenticateOAuth(ex.R, ex.Policy)
+	// OAuth result replaces the header-extracted identity; the session header
+	// value from header extraction is merged inside authenticateOAuth.
+	ex.Identity = oauthResult.Identity
+	ex.OAuthToken = oauthResult.Token
+
+	if !oauthResult.Allowed {
+		ex.Decision = policypkg.Deny(
+			oauthResult.Status,
+			oauthResult.Reason,
+			policypkg.ChoosePolicyVersion(policypkg.PolicyVersion(ex.Policy), s.defaultPolicyVersion),
+		)
+		s.writeDeniedResponse(ex)
+		return Reject
+	}
+	return Continue
+}

--- a/services/mcp-gateway/filter_auth.go
+++ b/services/mcp-gateway/filter_auth.go
@@ -1,10 +1,6 @@
 package main
 
-import (
-	"context"
-
-	policypkg "mcp-runtime/pkg/policy"
-)
+import policypkg "mcp-runtime/pkg/policy"
 
 // authFilter is stage 3 of the gateway pipeline. It extracts the caller
 // identity and, when the policy uses OAuth, validates the bearer JWT.
@@ -19,7 +15,7 @@ import (
 //
 // authFilter always runs after policyFilter (stage 2) has set Exchange.Policy
 // and always completes before authzFilter (stage 4) reads Exchange.Identity.
-func (s *gatewayServer) authFilter(_ context.Context, ex *Exchange) Result {
+func (s *gatewayServer) authFilter(ex *Exchange) Result {
 	// Extract identity from governance headers; for OAuth this populates at
 	// least the session header before JWT validation overwrites the rest.
 	ex.Identity = s.extractIdentity(ex.R, ex.Policy)

--- a/services/mcp-gateway/filter_authz.go
+++ b/services/mcp-gateway/filter_authz.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	policypkg "mcp-runtime/pkg/policy"
+)
+
+// authzFilter is stage 4 of the gateway pipeline. It evaluates the policy
+// decision for tool calls and indeterminate RPC attempts.
+//
+// Non-tool-call requests (e.g. tools/list, resources/list, ping, GET passthrough)
+// are not subject to grant/session policy evaluation and always Continue.
+//
+// For tool calls, the authorization inputs are Exchange.Policy and
+// Exchange.Identity. Both were set by earlier stages and must not be mutated
+// after this filter sets Exchange.Decision.
+//
+// On any denial, authzFilter writes the denial response and returns Reject.
+func (s *gatewayServer) authzFilter(_ context.Context, ex *Exchange) Result {
+	if !ex.Inspection.ToolCall && !ex.Inspection.Indeterminate {
+		return Continue
+	}
+
+	switch {
+	case ex.PolicyErr != nil:
+		ex.Decision = policypkg.Deny(
+			http.StatusServiceUnavailable,
+			"policy_unavailable",
+			policypkg.ChoosePolicyVersion(policypkg.PolicyVersion(ex.Policy), s.defaultPolicyVersion),
+		)
+	case ex.Inspection.Indeterminate:
+		ex.Decision = policypkg.Deny(
+			http.StatusForbidden,
+			policypkg.FirstNonEmpty(ex.Inspection.FailureReason, "rpc_inspection_failed"),
+			policypkg.ChoosePolicyVersion(policypkg.PolicyVersion(ex.Policy), s.defaultPolicyVersion),
+		)
+	default:
+		ex.Decision = policypkg.Authorize(ex.Policy, policypkg.Request{
+			Identity:  policyIdentity(ex.Identity),
+			RPCMethod: ex.Inspection.Method,
+			ToolName:  policypkg.ToolName(ex.Inspection.ToolName),
+		}, time.Now())
+	}
+
+	if !ex.Decision.Allowed {
+		s.writeDeniedResponse(ex)
+		return Reject
+	}
+	return Continue
+}

--- a/services/mcp-gateway/filter_authz.go
+++ b/services/mcp-gateway/filter_authz.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"net/http"
 	"time"
 
@@ -19,7 +18,7 @@ import (
 // after this filter sets Exchange.Decision.
 //
 // On any denial, authzFilter writes the denial response and returns Reject.
-func (s *gatewayServer) authzFilter(_ context.Context, ex *Exchange) Result {
+func (s *gatewayServer) authzFilter(ex *Exchange) Result {
 	if !ex.Inspection.ToolCall && !ex.Inspection.Indeterminate {
 		return Continue
 	}

--- a/services/mcp-gateway/filter_inspect.go
+++ b/services/mcp-gateway/filter_inspect.go
@@ -1,0 +1,11 @@
+package main
+
+import "context"
+
+// inspectFilter is stage 1 of the gateway pipeline. It performs bounded body
+// capture and RPC inspection, setting Exchange.Inspection. All other fields
+// remain at their zero values; this stage always returns Continue.
+func (s *gatewayServer) inspectFilter(_ context.Context, ex *Exchange) Result {
+	ex.Inspection = inspectRPCRequest(ex.R)
+	return Continue
+}

--- a/services/mcp-gateway/filter_inspect.go
+++ b/services/mcp-gateway/filter_inspect.go
@@ -1,11 +1,9 @@
 package main
 
-import "context"
-
 // inspectFilter is stage 1 of the gateway pipeline. It performs bounded body
 // capture and RPC inspection, setting Exchange.Inspection. All other fields
 // remain at their zero values; this stage always returns Continue.
-func (s *gatewayServer) inspectFilter(_ context.Context, ex *Exchange) Result {
+func (s *gatewayServer) inspectFilter(ex *Exchange) Result {
 	ex.Inspection = inspectRPCRequest(ex.R)
 	return Continue
 }

--- a/services/mcp-gateway/filter_policy.go
+++ b/services/mcp-gateway/filter_policy.go
@@ -1,0 +1,18 @@
+package main
+
+import "context"
+
+// policyFilter is stage 2 of the gateway pipeline. It acquires the current
+// atomic policy snapshot and sets Exchange.Policy and Exchange.PolicyErr.
+//
+// OAuth protected-resource metadata requests (/.well-known/oauth-protected-resource)
+// are handled here, immediately after the policy is available, and produce a
+// Respond result that terminates the pipeline without passing through auth or
+// authz stages.
+func (s *gatewayServer) policyFilter(_ context.Context, ex *Exchange) Result {
+	ex.Policy, ex.PolicyErr = s.currentPolicy()
+	if s.handleOAuthProtectedResource(ex.W, ex.R, ex.Policy) {
+		return Respond
+	}
+	return Continue
+}

--- a/services/mcp-gateway/filter_policy.go
+++ b/services/mcp-gateway/filter_policy.go
@@ -1,17 +1,17 @@
 package main
 
-import "context"
-
 // policyFilter is stage 2 of the gateway pipeline. It acquires the current
 // atomic policy snapshot and sets Exchange.Policy and Exchange.PolicyErr.
 //
 // OAuth protected-resource metadata requests (/.well-known/oauth-protected-resource)
 // are handled here, immediately after the policy is available, and produce a
 // Respond result that terminates the pipeline without passing through auth or
-// authz stages.
-func (s *gatewayServer) policyFilter(_ context.Context, ex *Exchange) Result {
+// authz stages. SkipAudit is set so the orchestrator does not emit a spurious
+// audit event for a response that bypassed authentication entirely.
+func (s *gatewayServer) policyFilter(ex *Exchange) Result {
 	ex.Policy, ex.PolicyErr = s.currentPolicy()
 	if s.handleOAuthProtectedResource(ex.W, ex.R, ex.Policy) {
+		ex.SkipAudit = true
 		return Respond
 	}
 	return Continue

--- a/services/mcp-gateway/filter_upstream.go
+++ b/services/mcp-gateway/filter_upstream.go
@@ -1,0 +1,32 @@
+package main
+
+import "context"
+
+// upstreamFilter is stage 5 of the gateway pipeline. It rewrites identity
+// headers and the upstream token on the outbound request, strips any configured
+// path prefix, and forwards the request to the upstream MCP server via the
+// reverse proxy.
+//
+// upstreamFilter reads Exchange.Policy, Exchange.Identity, and Exchange.OAuthToken
+// (all set by earlier stages) and must not mutate them. It always returns Respond
+// so the pipeline halts and stage 6 (audit) runs from the orchestrator.
+func (s *gatewayServer) upstreamFilter(_ context.Context, ex *Exchange) Result {
+	s.applyIdentityHeaders(ex.R, ex.Policy, ex.Identity)
+	s.applyUpstreamToken(ex.R, ex.Policy, ex.OAuthToken)
+
+	if trimmedPath, ok := trimRequestPathPrefix(ex.R.URL.Path, s.stripPrefix); ok {
+		ex.R.URL.Path = trimmedPath
+		if trimmedRaw, rawOK := trimRequestPathPrefix(ex.R.URL.RawPath, s.stripPrefix); rawOK {
+			ex.R.URL.RawPath = trimmedRaw
+		}
+		if ex.R.URL.Path == "" {
+			ex.R.URL.Path = "/"
+			if ex.R.URL.RawPath != "" {
+				ex.R.URL.RawPath = "/"
+			}
+		}
+	}
+
+	s.proxy.ServeHTTP(ex.W, ex.R)
+	return Respond
+}

--- a/services/mcp-gateway/filter_upstream.go
+++ b/services/mcp-gateway/filter_upstream.go
@@ -1,7 +1,5 @@
 package main
 
-import "context"
-
 // upstreamFilter is stage 5 of the gateway pipeline. It rewrites identity
 // headers and the upstream token on the outbound request, strips any configured
 // path prefix, and forwards the request to the upstream MCP server via the
@@ -10,14 +8,20 @@ import "context"
 // upstreamFilter reads Exchange.Policy, Exchange.Identity, and Exchange.OAuthToken
 // (all set by earlier stages) and must not mutate them. It always returns Respond
 // so the pipeline halts and stage 6 (audit) runs from the orchestrator.
-func (s *gatewayServer) upstreamFilter(_ context.Context, ex *Exchange) Result {
+func (s *gatewayServer) upstreamFilter(ex *Exchange) Result {
 	s.applyIdentityHeaders(ex.R, ex.Policy, ex.Identity)
 	s.applyUpstreamToken(ex.R, ex.Policy, ex.OAuthToken)
 
 	if trimmedPath, ok := trimRequestPathPrefix(ex.R.URL.Path, s.stripPrefix); ok {
 		ex.R.URL.Path = trimmedPath
+		// Always clear RawPath when Path was trimmed. If RawPath trims cleanly
+		// keep the percent-encoded form; otherwise clear it so Go's URL machinery
+		// falls back to escaping Path — preventing an inconsistent URL where Path
+		// is stripped but RawPath still carries the prefix.
 		if trimmedRaw, rawOK := trimRequestPathPrefix(ex.R.URL.RawPath, s.stripPrefix); rawOK {
 			ex.R.URL.RawPath = trimmedRaw
+		} else {
+			ex.R.URL.RawPath = ""
 		}
 		if ex.R.URL.Path == "" {
 			ex.R.URL.Path = "/"

--- a/services/mcp-gateway/pipeline_test.go
+++ b/services/mcp-gateway/pipeline_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	policypkg "mcp-runtime/pkg/policy"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func newTestExchange(method, target, body string, headers map[string]string) *Exchange {
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, target, nil)
+	}
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	r.ContentLength = int64(len(body))
+	ex := &Exchange{
+		W:            &statusRecorder{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK},
+		R:            r,
+		OriginalPath: r.URL.Path,
+		StartTime:    time.Now(),
+		Decision: policypkg.Decision{
+			Allowed:       true,
+			Status:        http.StatusOK,
+			Reason:        "allowed",
+			PolicyVersion: "test",
+		},
+	}
+	return ex
+}
+
+func minimalServer() *gatewayServer {
+	return &gatewayServer{
+		defaultHumanHeader:    defaultHumanHeader,
+		defaultAgentHeader:    defaultAgentHeader,
+		defaultTeamHeader:     defaultTeamHeader,
+		defaultSessionHeader:  defaultSessionHeader,
+		defaultPolicyMode:     defaultPolicyMode,
+		defaultPolicyDecision: defaultPolicyDecision,
+		defaultPolicyVersion:  "test",
+		oauthProviders:        map[string]*oauthProvider{},
+	}
+}
+
+// ---- stage 1: inspectFilter -------------------------------------------------
+
+func TestInspectFilterAlwaysContinues(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+
+	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodDelete} {
+		ex := newTestExchange(method, "/mcp", "", nil)
+		if got := s.inspectFilter(context.Background(), ex); got != Continue {
+			t.Errorf("inspectFilter(%s) = %v, want Continue", method, got)
+		}
+	}
+}
+
+func TestInspectFilterSetsInspection(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	body := `{"method":"tools/call","params":{"name":"echo"}}`
+	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
+
+	s.inspectFilter(context.Background(), ex)
+
+	if ex.Inspection.Method != "tools/call" {
+		t.Fatalf("Method = %q, want tools/call", ex.Inspection.Method)
+	}
+	if ex.Inspection.ToolName != "echo" {
+		t.Fatalf("ToolName = %q, want echo", ex.Inspection.ToolName)
+	}
+	if !ex.Inspection.ToolCall {
+		t.Fatal("ToolCall = false, want true")
+	}
+}
+
+// ---- stage 2: policyFilter --------------------------------------------------
+
+func TestPolicyFilterContinuesForNonOAuthPath(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	s.snapshotPolicy(policySnapshot{Policy: headerPolicy()})
+	ex := newTestExchange(http.MethodPost, "/mcp", `{}`, map[string]string{"Content-Type": "application/json"})
+
+	if got := s.policyFilter(context.Background(), ex); got != Continue {
+		t.Fatalf("policyFilter = %v, want Continue", got)
+	}
+	if ex.Policy == nil {
+		t.Fatal("Policy not set after policyFilter")
+	}
+}
+
+func TestPolicyFilterRespondsForOAuthMetadataPath(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	issuer := newTestJWTIssuer(t)
+	s.snapshotPolicy(policySnapshot{Policy: oauthPolicy(issuer.url)})
+	ex := newTestExchange(http.MethodGet, "/.well-known/oauth-protected-resource", "", nil)
+
+	if got := s.policyFilter(context.Background(), ex); got != Respond {
+		t.Fatalf("policyFilter for OAuth metadata path = %v, want Respond", got)
+	}
+	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+}
+
+func TestPolicyFilterPolicySnapshotIsImmutableForExchange(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	snap := headerPolicy()
+	s.snapshotPolicy(policySnapshot{Policy: snap})
+	ex := newTestExchange(http.MethodPost, "/mcp", "", nil)
+
+	s.policyFilter(context.Background(), ex)
+	captured := ex.Policy
+
+	// Replace the gateway snapshot mid-exchange — the Exchange copy must be unaffected.
+	s.snapshotPolicy(policySnapshot{Policy: &policypkg.Document{Server: policypkg.Server{Name: "other"}}})
+	if ex.Policy != captured {
+		t.Fatal("Exchange.Policy changed after snapshot was replaced — not immutable for exchange lifetime")
+	}
+}
+
+// ---- stage 3: authFilter ----------------------------------------------------
+
+func TestAuthFilterContinuesForHeaderMode(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	ex := newTestExchange(http.MethodPost, "/mcp", "", map[string]string{
+		defaultHumanHeader: "user-1",
+		defaultAgentHeader: "agent-1",
+	})
+	ex.Policy = headerPolicy()
+
+	if got := s.authFilter(context.Background(), ex); got != Continue {
+		t.Fatalf("authFilter header mode = %v, want Continue", got)
+	}
+	if ex.Identity.HumanID != "user-1" {
+		t.Fatalf("Identity.HumanID = %q, want user-1", ex.Identity.HumanID)
+	}
+}
+
+func TestAuthFilterRejectsOAuthMissingBearer(t *testing.T) {
+	t.Parallel()
+	issuer := newTestJWTIssuer(t)
+	s := minimalServer()
+	ex := newTestExchange(http.MethodPost, "/mcp", `{}`, map[string]string{"Content-Type": "application/json"})
+	ex.Policy = oauthPolicy(issuer.url)
+
+	if got := s.authFilter(context.Background(), ex); got != Reject {
+		t.Fatalf("authFilter OAuth no bearer = %v, want Reject", got)
+	}
+	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", recorder.Code)
+	}
+	if ex.Decision.Allowed {
+		t.Fatal("Decision.Allowed = true after auth rejection, want false")
+	}
+}
+
+func TestAuthFilterAlwaysRunsBeforeAuthz(t *testing.T) {
+	t.Parallel()
+	// Prove ordering by verifying that when authFilter Rejects, authzFilter
+	// is never called. Use a sentinel filter after auth in a custom pipeline.
+	authzCalled := false
+	s := minimalServer()
+
+	issuer := newTestJWTIssuer(t)
+	s.snapshotPolicy(policySnapshot{Policy: oauthPolicy(issuer.url)})
+
+	pipeline := []Filter{
+		FilterFunc(s.inspectFilter),
+		FilterFunc(s.policyFilter),
+		FilterFunc(s.authFilter),
+		FilterFunc(func(_ context.Context, _ *Exchange) Result {
+			authzCalled = true
+			return Continue
+		}),
+	}
+
+	ex := newExchange(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp", nil), "test")
+	for _, f := range pipeline {
+		if f.Handle(context.Background(), ex) != Continue {
+			break
+		}
+	}
+
+	if authzCalled {
+		t.Fatal("authz stage was called despite authFilter rejecting — ordering violated")
+	}
+}
+
+// ---- stage 4: authzFilter ---------------------------------------------------
+
+func TestAuthzFilterContinuesForNonToolCall(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	ex := newTestExchange(http.MethodPost, "/mcp", `{"method":"tools/list"}`, map[string]string{"Content-Type": "application/json"})
+	s.inspectFilter(context.Background(), ex)
+	ex.Policy = headerPolicy()
+	ex.Identity = identityContext{HumanID: "human-1", AgentID: "client-1", TeamID: "team-acme"}
+
+	if got := s.authzFilter(context.Background(), ex); got != Continue {
+		t.Fatalf("authzFilter tools/list = %v, want Continue", got)
+	}
+	if !ex.Decision.Allowed {
+		t.Fatalf("Decision.Allowed = false for non-tool-call, want true")
+	}
+}
+
+func TestAuthzFilterRejectsDeniedToolCall(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	body := `{"method":"tools/call","params":{"name":"echo"}}`
+	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
+	s.inspectFilter(context.Background(), ex)
+	// Use a session-optional allow-list policy so an unrecognised identity
+	// reaches grant evaluation and gets no_matching_grant → 403.
+	ex.Policy = &policypkg.Document{
+		Auth: &policypkg.Auth{Mode: "header"},
+		Policy: &policypkg.Config{
+			Mode:            "allow-list",
+			DefaultDecision: "deny",
+			PolicyVersion:   "test",
+		},
+		Tools: []policypkg.Tool{
+			{Name: "echo", RequiredTrust: "low", SideEffect: "read"},
+		},
+		Grants: []policypkg.Grant{
+			{Name: "g1", HumanID: "human-1", AgentID: "agent-1",
+				MaxTrust: "high", AllowedSideEffects: []string{"read"},
+				ToolRules: []policypkg.ToolAccess{{Name: "echo", Decision: "allow"}}},
+		},
+	}
+	// No matching grant → default deny.
+	ex.Identity = identityContext{HumanID: "unknown", AgentID: "unknown"}
+
+	if got := s.authzFilter(context.Background(), ex); got != Reject {
+		t.Fatalf("authzFilter denied tool call = %v, want Reject", got)
+	}
+	if ex.Decision.Allowed {
+		t.Fatal("Decision.Allowed = true after authz rejection, want false")
+	}
+	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", recorder.Code)
+	}
+}
+
+func TestAuthzFilterAuthorizationInputsUnchangedAfterDecision(t *testing.T) {
+	t.Parallel()
+	// Prove that upstreamFilter (stage 5) receives the same Policy and Identity
+	// pointers that authzFilter read, confirming no mutation happened between
+	// stages 4 and 5.
+	s := minimalServer()
+
+	upstreamCalled := false
+	var policyAtUpstream *policypkg.Document
+	var identityAtUpstream identityContext
+
+	target, _ := url.Parse("http://127.0.0.1:1") // unreachable; we intercept before
+	s.proxy = newUpstreamReverseProxy(target)
+
+	pipeline := []Filter{
+		FilterFunc(s.authzFilter),
+		FilterFunc(func(_ context.Context, ex *Exchange) Result {
+			upstreamCalled = true
+			policyAtUpstream = ex.Policy
+			identityAtUpstream = ex.Identity
+			return Respond
+		}),
+	}
+
+	body := `{"method":"tools/list"}`
+	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
+	s.inspectFilter(context.Background(), ex) // sets ToolCall=false, so authz skips evaluation
+	pol := headerPolicy()
+	ex.Policy = pol
+	ident := identityContext{HumanID: "human-1", AgentID: "client-1", TeamID: "team-acme"}
+	ex.Identity = ident
+
+	for _, f := range pipeline {
+		if f.Handle(context.Background(), ex) != Continue {
+			break
+		}
+	}
+
+	if !upstreamCalled {
+		t.Fatal("upstream stage was not reached")
+	}
+	if policyAtUpstream != pol {
+		t.Fatal("Policy was replaced between authz and upstream stages")
+	}
+	if identityAtUpstream != ident {
+		t.Fatal("Identity was mutated between authz and upstream stages")
+	}
+}
+
+func TestAuthzFilterPolicyUnavailableDeniesWith503(t *testing.T) {
+	t.Parallel()
+	s := minimalServer()
+	body := `{"method":"tools/call","params":{"name":"echo"}}`
+	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
+	s.inspectFilter(context.Background(), ex)
+	ex.Policy = &policypkg.Document{Policy: &policypkg.Config{}}
+	ex.PolicyErr = errPolicyUnavailable
+
+	if got := s.authzFilter(context.Background(), ex); got != Reject {
+		t.Fatalf("authzFilter policy_unavailable = %v, want Reject", got)
+	}
+	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", recorder.Code)
+	}
+	var payload map[string]any
+	_ = json.Unmarshal(recorder.Body.Bytes(), &payload)
+	if payload["error"] != "policy_unavailable" {
+		t.Fatalf("error = %q, want policy_unavailable", payload["error"])
+	}
+}
+
+// ---- stage 5: upstreamFilter ------------------------------------------------
+
+func TestUpstreamFilterAlwaysReturnsRespond(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+	target, _ := url.Parse(upstream.URL)
+
+	s := minimalServer()
+	s.proxy = newUpstreamReverseProxy(target)
+	ex := newTestExchange(http.MethodGet, "/mcp", "", nil)
+	ex.Policy = headerPolicy()
+
+	if got := s.upstreamFilter(context.Background(), ex); got != Respond {
+		t.Fatalf("upstreamFilter = %v, want Respond", got)
+	}
+}
+
+// ---- errPolicyUnavailable sentinel ------------------------------------------
+
+func TestErrPolicyUnavailableIsSentinel(t *testing.T) {
+	// Verify that errPolicyUnavailable is a distinct error value that can be
+	// identified by callers checking the policy unavailable condition.
+	if errPolicyUnavailable == nil {
+		t.Fatal("errPolicyUnavailable is nil")
+	}
+	if errPolicyUnavailable.Error() == "" {
+		t.Fatal("errPolicyUnavailable.Error() is empty")
+	}
+}

--- a/services/mcp-gateway/pipeline_test.go
+++ b/services/mcp-gateway/pipeline_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -62,7 +61,7 @@ func TestInspectFilterAlwaysContinues(t *testing.T) {
 
 	for _, method := range []string{http.MethodGet, http.MethodPost, http.MethodDelete} {
 		ex := newTestExchange(method, "/mcp", "", nil)
-		if got := s.inspectFilter(context.Background(), ex); got != Continue {
+		if got := s.inspectFilter(ex); got != Continue {
 			t.Errorf("inspectFilter(%s) = %v, want Continue", method, got)
 		}
 	}
@@ -74,7 +73,7 @@ func TestInspectFilterSetsInspection(t *testing.T) {
 	body := `{"method":"tools/call","params":{"name":"echo"}}`
 	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
 
-	s.inspectFilter(context.Background(), ex)
+	s.inspectFilter(ex)
 
 	if ex.Inspection.Method != "tools/call" {
 		t.Fatalf("Method = %q, want tools/call", ex.Inspection.Method)
@@ -95,7 +94,7 @@ func TestPolicyFilterContinuesForNonOAuthPath(t *testing.T) {
 	s.snapshotPolicy(policySnapshot{Policy: headerPolicy()})
 	ex := newTestExchange(http.MethodPost, "/mcp", `{}`, map[string]string{"Content-Type": "application/json"})
 
-	if got := s.policyFilter(context.Background(), ex); got != Continue {
+	if got := s.policyFilter(ex); got != Continue {
 		t.Fatalf("policyFilter = %v, want Continue", got)
 	}
 	if ex.Policy == nil {
@@ -110,12 +109,28 @@ func TestPolicyFilterRespondsForOAuthMetadataPath(t *testing.T) {
 	s.snapshotPolicy(policySnapshot{Policy: oauthPolicy(issuer.url)})
 	ex := newTestExchange(http.MethodGet, "/.well-known/oauth-protected-resource", "", nil)
 
-	if got := s.policyFilter(context.Background(), ex); got != Respond {
+	if got := s.policyFilter(ex); got != Respond {
 		t.Fatalf("policyFilter for OAuth metadata path = %v, want Respond", got)
 	}
 	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+}
+
+func TestPolicyFilterSetsSkipAuditForOAuthMetadataPath(t *testing.T) {
+	t.Parallel()
+	// Verify that an OAuth metadata early-exit sets SkipAudit so the
+	// orchestrator does not emit a spurious audit event with no identity.
+	s := minimalServer()
+	issuer := newTestJWTIssuer(t)
+	s.snapshotPolicy(policySnapshot{Policy: oauthPolicy(issuer.url)})
+	ex := newTestExchange(http.MethodGet, "/.well-known/oauth-protected-resource", "", nil)
+
+	s.policyFilter(ex)
+
+	if !ex.SkipAudit {
+		t.Fatal("SkipAudit = false after OAuth metadata early-exit, want true")
 	}
 }
 
@@ -126,7 +141,7 @@ func TestPolicyFilterPolicySnapshotIsImmutableForExchange(t *testing.T) {
 	s.snapshotPolicy(policySnapshot{Policy: snap})
 	ex := newTestExchange(http.MethodPost, "/mcp", "", nil)
 
-	s.policyFilter(context.Background(), ex)
+	s.policyFilter(ex)
 	captured := ex.Policy
 
 	// Replace the gateway snapshot mid-exchange — the Exchange copy must be unaffected.
@@ -147,7 +162,7 @@ func TestAuthFilterContinuesForHeaderMode(t *testing.T) {
 	})
 	ex.Policy = headerPolicy()
 
-	if got := s.authFilter(context.Background(), ex); got != Continue {
+	if got := s.authFilter(ex); got != Continue {
 		t.Fatalf("authFilter header mode = %v, want Continue", got)
 	}
 	if ex.Identity.HumanID != "user-1" {
@@ -162,7 +177,7 @@ func TestAuthFilterRejectsOAuthMissingBearer(t *testing.T) {
 	ex := newTestExchange(http.MethodPost, "/mcp", `{}`, map[string]string{"Content-Type": "application/json"})
 	ex.Policy = oauthPolicy(issuer.url)
 
-	if got := s.authFilter(context.Background(), ex); got != Reject {
+	if got := s.authFilter(ex); got != Reject {
 		t.Fatalf("authFilter OAuth no bearer = %v, want Reject", got)
 	}
 	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
@@ -188,7 +203,7 @@ func TestAuthFilterAlwaysRunsBeforeAuthz(t *testing.T) {
 		FilterFunc(s.inspectFilter),
 		FilterFunc(s.policyFilter),
 		FilterFunc(s.authFilter),
-		FilterFunc(func(_ context.Context, _ *Exchange) Result {
+		FilterFunc(func(_ *Exchange) Result {
 			authzCalled = true
 			return Continue
 		}),
@@ -196,7 +211,7 @@ func TestAuthFilterAlwaysRunsBeforeAuthz(t *testing.T) {
 
 	ex := newExchange(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/mcp", nil), "test")
 	for _, f := range pipeline {
-		if f.Handle(context.Background(), ex) != Continue {
+		if f.Handle(ex) != Continue {
 			break
 		}
 	}
@@ -212,11 +227,11 @@ func TestAuthzFilterContinuesForNonToolCall(t *testing.T) {
 	t.Parallel()
 	s := minimalServer()
 	ex := newTestExchange(http.MethodPost, "/mcp", `{"method":"tools/list"}`, map[string]string{"Content-Type": "application/json"})
-	s.inspectFilter(context.Background(), ex)
+	s.inspectFilter(ex)
 	ex.Policy = headerPolicy()
 	ex.Identity = identityContext{HumanID: "human-1", AgentID: "client-1", TeamID: "team-acme"}
 
-	if got := s.authzFilter(context.Background(), ex); got != Continue {
+	if got := s.authzFilter(ex); got != Continue {
 		t.Fatalf("authzFilter tools/list = %v, want Continue", got)
 	}
 	if !ex.Decision.Allowed {
@@ -229,7 +244,7 @@ func TestAuthzFilterRejectsDeniedToolCall(t *testing.T) {
 	s := minimalServer()
 	body := `{"method":"tools/call","params":{"name":"echo"}}`
 	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
-	s.inspectFilter(context.Background(), ex)
+	s.inspectFilter(ex)
 	// Use a session-optional allow-list policy so an unrecognised identity
 	// reaches grant evaluation and gets no_matching_grant → 403.
 	ex.Policy = &policypkg.Document{
@@ -251,7 +266,7 @@ func TestAuthzFilterRejectsDeniedToolCall(t *testing.T) {
 	// No matching grant → default deny.
 	ex.Identity = identityContext{HumanID: "unknown", AgentID: "unknown"}
 
-	if got := s.authzFilter(context.Background(), ex); got != Reject {
+	if got := s.authzFilter(ex); got != Reject {
 		t.Fatalf("authzFilter denied tool call = %v, want Reject", got)
 	}
 	if ex.Decision.Allowed {
@@ -279,7 +294,7 @@ func TestAuthzFilterAuthorizationInputsUnchangedAfterDecision(t *testing.T) {
 
 	pipeline := []Filter{
 		FilterFunc(s.authzFilter),
-		FilterFunc(func(_ context.Context, ex *Exchange) Result {
+		FilterFunc(func(ex *Exchange) Result {
 			upstreamCalled = true
 			policyAtUpstream = ex.Policy
 			identityAtUpstream = ex.Identity
@@ -289,14 +304,14 @@ func TestAuthzFilterAuthorizationInputsUnchangedAfterDecision(t *testing.T) {
 
 	body := `{"method":"tools/list"}`
 	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
-	s.inspectFilter(context.Background(), ex) // sets ToolCall=false, so authz skips evaluation
+	s.inspectFilter(ex) // sets ToolCall=false, so authz skips evaluation
 	pol := headerPolicy()
 	ex.Policy = pol
 	ident := identityContext{HumanID: "human-1", AgentID: "client-1", TeamID: "team-acme"}
 	ex.Identity = ident
 
 	for _, f := range pipeline {
-		if f.Handle(context.Background(), ex) != Continue {
+		if f.Handle(ex) != Continue {
 			break
 		}
 	}
@@ -317,11 +332,11 @@ func TestAuthzFilterPolicyUnavailableDeniesWith503(t *testing.T) {
 	s := minimalServer()
 	body := `{"method":"tools/call","params":{"name":"echo"}}`
 	ex := newTestExchange(http.MethodPost, "/mcp", body, map[string]string{"Content-Type": "application/json"})
-	s.inspectFilter(context.Background(), ex)
+	s.inspectFilter(ex)
 	ex.Policy = &policypkg.Document{Policy: &policypkg.Config{}}
 	ex.PolicyErr = errPolicyUnavailable
 
-	if got := s.authzFilter(context.Background(), ex); got != Reject {
+	if got := s.authzFilter(ex); got != Reject {
 		t.Fatalf("authzFilter policy_unavailable = %v, want Reject", got)
 	}
 	recorder := ex.W.ResponseWriter.(*httptest.ResponseRecorder)
@@ -350,7 +365,7 @@ func TestUpstreamFilterAlwaysReturnsRespond(t *testing.T) {
 	ex := newTestExchange(http.MethodGet, "/mcp", "", nil)
 	ex.Policy = headerPolicy()
 
-	if got := s.upstreamFilter(context.Background(), ex); got != Respond {
+	if got := s.upstreamFilter(ex); got != Respond {
 		t.Fatalf("upstreamFilter = %v, want Respond", got)
 	}
 }

--- a/services/mcp-gateway/policy_cache.go
+++ b/services/mcp-gateway/policy_cache.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -10,6 +11,10 @@ import (
 
 	policypkg "mcp-runtime/pkg/policy"
 )
+
+// errPolicyUnavailable is returned by currentPolicy when no valid policy has
+// been loaded yet, causing gate filters to fail closed with 503.
+var errPolicyUnavailable = errors.New("policy_unavailable")
 
 func (s *gatewayServer) startPolicyCache() error {
 	s.snapshotPolicy(policySnapshot{Policy: s.defaultPolicyDocument()})

--- a/services/mcp-gateway/proxy.go
+++ b/services/mcp-gateway/proxy.go
@@ -33,7 +33,7 @@ func newUpstreamReverseProxy(target *url.URL) *httputil.ReverseProxy {
 func (s *gatewayServer) handleGateway(w http.ResponseWriter, r *http.Request) {
 	ex := newExchange(w, r, s.defaultPolicyVersion)
 	for _, f := range s.buildPipeline() {
-		if f.Handle(r.Context(), ex) != Continue {
+		if f.Handle(ex) != Continue {
 			break
 		}
 	}
@@ -65,6 +65,9 @@ func (s *gatewayServer) buildPipeline() []Filter {
 //     genuine MCP client attempt (application/json body that failed parsing).
 //   - Internal platform service probes (mcp-runtime-live-inventory) are never audited.
 func (s *gatewayServer) emitAuditFromExchange(ex *Exchange) {
+	if ex.SkipAudit {
+		return
+	}
 	if ex.Identity.AgentID == "mcp-runtime-live-inventory" {
 		return
 	}

--- a/services/mcp-gateway/proxy.go
+++ b/services/mcp-gateway/proxy.go
@@ -27,133 +27,74 @@ func newUpstreamReverseProxy(target *url.URL) *httputil.ReverseProxy {
 	return proxy
 }
 
-// handleGateway handles incoming MCP requests and forwards them to upstream servers.
-// It evaluates simple policy for tool invocations and emits audit events on allow/deny.
+// handleGateway is the pipeline orchestrator for the gateway request path.
+// It runs the five ordered filters (inspect → policy → auth → authz → upstream)
+// and then unconditionally runs stage 6 (audit/analytics finalization).
 func (s *gatewayServer) handleGateway(w http.ResponseWriter, r *http.Request) {
-	start := time.Now()
-	recorder := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
-	originalPath := r.URL.Path
-	inspection := inspectRPCRequest(r)
-	rpcMethod, toolName := inspection.Method, inspection.ToolName
-
-	policy, policyErr := s.currentPolicy()
-	if s.handleOAuthProtectedResource(recorder, r, policy) {
-		return
-	}
-
-	authCtx := s.extractIdentity(r, policy)
-	decision := policypkg.Decision{
-		Allowed:       true,
-		Status:        http.StatusOK,
-		Reason:        "allowed",
-		PolicyVersion: s.defaultPolicyVersion,
-	}
-	oauthResult := oauthAuthResult{
-		Allowed:  true,
-		Status:   http.StatusOK,
-		Identity: authCtx,
-	}
-
-	if policypkg.PolicyUsesOAuth(policy) {
-		oauthResult = s.authenticateOAuth(r, policy)
-		authCtx = oauthResult.Identity
-		if !oauthResult.Allowed {
-			decision = policypkg.Deny(
-				oauthResult.Status,
-				oauthResult.Reason,
-				policypkg.ChoosePolicyVersion(policypkg.PolicyVersion(policy), s.defaultPolicyVersion),
-			)
-			s.writeDeniedResponse(recorder, r, originalPath, rpcMethod, toolName, authCtx, policy, decision, start, inspection.IsRPCAttempt)
-			return
+	ex := newExchange(w, r, s.defaultPolicyVersion)
+	for _, f := range s.buildPipeline() {
+		if f.Handle(r.Context(), ex) != Continue {
+			break
 		}
 	}
-
-	if inspection.ToolCall || inspection.Indeterminate {
-		switch {
-		case policyErr != nil:
-			decision = policypkg.Deny(
-				http.StatusServiceUnavailable,
-				"policy_unavailable",
-				policypkg.ChoosePolicyVersion(policypkg.PolicyVersion(policy), s.defaultPolicyVersion),
-			)
-		case inspection.Indeterminate:
-			decision = policypkg.Deny(
-				http.StatusForbidden,
-				policypkg.FirstNonEmpty(inspection.FailureReason, "rpc_inspection_failed"),
-				policypkg.ChoosePolicyVersion(policypkg.PolicyVersion(policy), s.defaultPolicyVersion),
-			)
-		default:
-			decision = policypkg.Authorize(policy, policypkg.Request{
-				Identity:  policyIdentity(authCtx),
-				RPCMethod: rpcMethod,
-				ToolName:  policypkg.ToolName(toolName),
-			}, time.Now())
-		}
+	if ex.Decision.PolicyVersion == "" {
+		ex.Decision.PolicyVersion = s.defaultPolicyVersion
 	}
+	s.emitAuditFromExchange(ex)
+}
 
-	if !decision.Allowed {
-		s.writeDeniedResponse(recorder, r, originalPath, rpcMethod, toolName, authCtx, policy, decision, start, inspection.IsRPCAttempt)
-		return
-	}
-
-	s.applyIdentityHeaders(r, policy, authCtx)
-	s.applyUpstreamToken(r, policy, oauthResult.Token)
-
-	if trimmedPath, ok := trimRequestPathPrefix(r.URL.Path, s.stripPrefix); ok {
-		r.URL.Path = trimmedPath
-		if trimmedRawPath, rawPathTrimmed := trimRequestPathPrefix(r.URL.RawPath, s.stripPrefix); rawPathTrimmed {
-			r.URL.RawPath = trimmedRawPath
-		}
-		if r.URL.Path == "" {
-			r.URL.Path = "/"
-			if r.URL.RawPath != "" {
-				r.URL.RawPath = "/"
-			}
-		}
-	}
-
-	s.proxy.ServeHTTP(recorder, r)
-
-	if decision.PolicyVersion == "" {
-		decision.PolicyVersion = s.defaultPolicyVersion
-	}
-
-	// Only audit actual MCP JSON-RPC traffic. Non-RPC requests (GET health probes,
-	// OAuth discovery, etc.) have no rpcMethod and produce noise in the event count.
-	// Denied requests are already audited by writeDeniedResponse above.
-	// Internal platform service probes (live-inventory, health checkers) are
-	// identified by the mcp-runtime-live-inventory agent ID; skip those too so
-	// they do not inflate the analytics event count.
-	if rpcMethod != "" && authCtx.AgentID != "mcp-runtime-live-inventory" {
-		s.emitAuditEvent(r, originalPath, rpcMethod, toolName, authCtx, policy, decision, recorder.status, time.Since(start).Milliseconds(), recorder.bytes)
+// buildPipeline returns the fixed ordered filter slice for a gateway request.
+// Stages are defined in exchange.go; order is security-sensitive and must not
+// be changed without updating the ordering guarantees documented there.
+func (s *gatewayServer) buildPipeline() []Filter {
+	return []Filter{
+		FilterFunc(s.inspectFilter),
+		FilterFunc(s.policyFilter),
+		FilterFunc(s.authFilter),
+		FilterFunc(s.authzFilter),
+		FilterFunc(s.upstreamFilter),
 	}
 }
 
-func (s *gatewayServer) writeDeniedResponse(
-	recorder *statusRecorder,
-	r *http.Request,
-	originalPath, rpcMethod, toolName string,
-	authCtx identityContext,
-	policy *policypkg.Document,
-	decision policypkg.Decision,
-	start time.Time,
-	isRPCAttempt bool,
-) {
-	recorder.Header().Set("content-type", "application/json")
-	if shouldChallengeOAuth(policy, decision) {
-		recorder.Header().Set("www-authenticate", s.oauthAuthenticateHeader(r, originalPath, decision.Reason))
+// emitAuditFromExchange is stage 6 of the pipeline. It emits a single audit
+// event after the pipeline completes, preserving the following semantics from
+// the previous monolithic handleGateway:
+//
+//   - Allowed requests: audit when rpcMethod is non-empty (actual RPC traffic).
+//   - Denied requests: audit when rpcMethod is non-empty OR the request was a
+//     genuine MCP client attempt (application/json body that failed parsing).
+//   - Internal platform service probes (mcp-runtime-live-inventory) are never audited.
+func (s *gatewayServer) emitAuditFromExchange(ex *Exchange) {
+	if ex.Identity.AgentID == "mcp-runtime-live-inventory" {
+		return
 	}
-	status := gatewayDeniedStatus(policy, decision)
-	decision.Status = status
-	recorder.WriteHeader(status)
-	_ = json.NewEncoder(recorder).Encode(gatewayDeniedPayload(policy, decision))
-	// Audit when we have an rpcMethod (tool call) OR when the request was a
-	// genuine MCP attempt (application/json content-type) but parsing failed.
-	// Non-RPC noise (text/plain probes, GET health checks) and internal platform
-	// service probes (live-inventory) are not audited.
-	if (rpcMethod != "" || isRPCAttempt) && authCtx.AgentID != "mcp-runtime-live-inventory" {
-		s.emitAuditEvent(r, originalPath, rpcMethod, toolName, authCtx, policy, decision, recorder.status, time.Since(start).Milliseconds(), recorder.bytes)
+	rpcMethod := ex.Inspection.Method
+	if ex.Decision.Allowed {
+		if rpcMethod == "" {
+			return
+		}
+	} else if rpcMethod == "" && !ex.Inspection.IsRPCAttempt {
+		return
 	}
+	s.emitAuditEvent(
+		ex.R, ex.OriginalPath, rpcMethod, ex.Inspection.ToolName,
+		ex.Identity, ex.Policy, ex.Decision,
+		ex.W.status, time.Since(ex.StartTime).Milliseconds(), ex.W.bytes,
+	)
+}
+
+// writeDeniedResponse writes the HTTP denial response for the current exchange.
+// Audit emission is intentionally absent here; it is centralised in
+// emitAuditFromExchange (stage 6) so each denial is audited exactly once.
+func (s *gatewayServer) writeDeniedResponse(ex *Exchange) {
+	ex.W.Header().Set("content-type", "application/json")
+	if shouldChallengeOAuth(ex.Policy, ex.Decision) {
+		ex.W.Header().Set("www-authenticate", s.oauthAuthenticateHeader(ex.R, ex.OriginalPath, ex.Decision.Reason))
+	}
+	status := gatewayDeniedStatus(ex.Policy, ex.Decision)
+	ex.Decision.Status = status
+	ex.W.WriteHeader(status)
+	_ = json.NewEncoder(ex.W).Encode(gatewayDeniedPayload(ex.Policy, ex.Decision))
 }
 
 func gatewayDeniedStatus(policy *policypkg.Document, decision policypkg.Decision) int {


### PR DESCRIPTION
Replaces the monolithic handleGateway with a Filter/Exchange/Result pipeline (inspect → policy → auth → authz → upstream). Stage 6 audit runs unconditionally from the orchestrator, centralising all emit paths. errPolicyUnavailable sentinel added so authzFilter fails closed with 503 when no valid policy has been loaded.

Adds per-filter unit tests and ordering proofs in pipeline_test.go: Continue/Reject/Respond per stage, auth-before-authz ordering assertion, authorization-input immutability test, and 503 on policy unavailable.