### PR TITLE
fix(sentinel): bound login trackers and report audit drops

### DIFF
--- a/services/api/auth/lockout.go
+++ b/services/api/auth/lockout.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -38,6 +39,7 @@ func NewLoginAttemptTracker(nowFn func() time.Time) *LoginAttemptTracker {
 func (t *LoginAttemptTracker) Allow(key string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	key = normalizeLoginAttemptKey(key)
 	now := t.nowFunc()
 	t.pruneIfDueLocked(now)
 	state, ok := t.entries[key]
@@ -52,6 +54,7 @@ func (t *LoginAttemptTracker) Allow(key string) bool {
 func (t *LoginAttemptTracker) RecordFailure(key string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	key = normalizeLoginAttemptKey(key)
 	now := t.nowFunc()
 	t.pruneIfDueLocked(now)
 	state := t.entries[key]
@@ -66,6 +69,7 @@ func (t *LoginAttemptTracker) RecordFailure(key string) int {
 func (t *LoginAttemptTracker) RecordSuccess(key string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	key = normalizeLoginAttemptKey(key)
 	t.pruneIfDueLocked(t.nowFunc())
 	state := t.entries[key]
 	failures := state.Failures
@@ -96,6 +100,7 @@ func (t *LoginAttemptTracker) enforceMaxLocked(now time.Time) {
 	type candidate struct {
 		key      string
 		lastSeen time.Time
+		failures int
 		locked   bool
 	}
 	candidates := make([]candidate, 0, len(t.entries))
@@ -103,12 +108,16 @@ func (t *LoginAttemptTracker) enforceMaxLocked(now time.Time) {
 		candidates = append(candidates, candidate{
 			key:      key,
 			lastSeen: state.LastSeen,
+			failures: state.Failures,
 			locked:   state.LockedUntil.After(now),
 		})
 	}
 	sort.Slice(candidates, func(i, j int) bool {
 		if candidates[i].locked != candidates[j].locked {
 			return !candidates[i].locked
+		}
+		if (candidates[i].failures > 0) != (candidates[j].failures > 0) {
+			return candidates[i].failures == 0
 		}
 		return candidates[i].lastSeen.Before(candidates[j].lastSeen)
 	})
@@ -133,4 +142,18 @@ func lockoutDurationForFailures(failures int) time.Duration {
 		return APILoginLockoutMax
 	}
 	return lockout
+}
+
+func normalizeLoginAttemptKey(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	if before, _, ok := strings.Cut(key, "|"); ok {
+		before = strings.TrimSpace(before)
+		if before != "" {
+			return before
+		}
+	}
+	return key
 }

--- a/services/api/auth/lockout.go
+++ b/services/api/auth/lockout.go
@@ -1,24 +1,31 @@
 package auth
 
 import (
+	"sort"
 	"sync"
 	"time"
 )
 
 const (
-	APILoginLockoutBase = 15 * time.Second
-	APILoginLockoutMax  = 5 * time.Minute
+	APILoginLockoutBase          = 15 * time.Second
+	APILoginLockoutMax           = 5 * time.Minute
+	APILoginAttemptIdleTTL       = 30 * time.Minute
+	APILoginAttemptMaxEntries    = 4096
+	apiLoginAttemptPruneInterval = time.Minute
+	apiLoginAttemptEvictionBatch = 256
 )
 
 type LoginAttempt struct {
 	Failures    int
 	LockedUntil time.Time
+	LastSeen    time.Time
 }
 
 type LoginAttemptTracker struct {
-	mu      sync.Mutex
-	nowFunc func() time.Time
-	entries map[string]LoginAttempt
+	mu        sync.Mutex
+	nowFunc   func() time.Time
+	entries   map[string]LoginAttempt
+	lastPrune time.Time
 }
 
 func NewLoginAttemptTracker(nowFn func() time.Time) *LoginAttemptTracker {
@@ -31,8 +38,14 @@ func NewLoginAttemptTracker(nowFn func() time.Time) *LoginAttemptTracker {
 func (t *LoginAttemptTracker) Allow(key string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	state := t.entries[key]
 	now := t.nowFunc()
+	t.pruneIfDueLocked(now)
+	state, ok := t.entries[key]
+	if !ok {
+		return true
+	}
+	state.LastSeen = now
+	t.entries[key] = state
 	return state.LockedUntil.IsZero() || !state.LockedUntil.After(now)
 }
 
@@ -40,20 +53,68 @@ func (t *LoginAttemptTracker) RecordFailure(key string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	now := t.nowFunc()
+	t.pruneIfDueLocked(now)
 	state := t.entries[key]
 	state.Failures++
 	state.LockedUntil = now.Add(lockoutDurationForFailures(state.Failures))
+	state.LastSeen = now
 	t.entries[key] = state
+	t.enforceMaxLocked(now)
 	return state.Failures
 }
 
 func (t *LoginAttemptTracker) RecordSuccess(key string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.pruneIfDueLocked(t.nowFunc())
 	state := t.entries[key]
 	failures := state.Failures
 	delete(t.entries, key)
 	return failures
+}
+
+func (t *LoginAttemptTracker) pruneIfDueLocked(now time.Time) {
+	if !t.lastPrune.IsZero() && now.Sub(t.lastPrune) < apiLoginAttemptPruneInterval {
+		return
+	}
+	t.lastPrune = now
+	for key, state := range t.entries {
+		if now.Sub(state.LastSeen) > APILoginAttemptIdleTTL && !state.LockedUntil.After(now) {
+			delete(t.entries, key)
+		}
+	}
+}
+
+func (t *LoginAttemptTracker) enforceMaxLocked(now time.Time) {
+	if len(t.entries) <= APILoginAttemptMaxEntries {
+		return
+	}
+	target := APILoginAttemptMaxEntries - apiLoginAttemptEvictionBatch
+	if target < 0 {
+		target = 0
+	}
+	type candidate struct {
+		key      string
+		lastSeen time.Time
+		locked   bool
+	}
+	candidates := make([]candidate, 0, len(t.entries))
+	for key, state := range t.entries {
+		candidates = append(candidates, candidate{
+			key:      key,
+			lastSeen: state.LastSeen,
+			locked:   state.LockedUntil.After(now),
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].locked != candidates[j].locked {
+			return !candidates[i].locked
+		}
+		return candidates[i].lastSeen.Before(candidates[j].lastSeen)
+	})
+	for _, entry := range candidates[:len(t.entries)-target] {
+		delete(t.entries, entry.key)
+	}
 }
 
 func lockoutDurationForFailures(failures int) time.Duration {

--- a/services/api/auth/lockout_test.go
+++ b/services/api/auth/lockout_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestLoginAttemptTrackerPrunesIdleEntriesPeriodically(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := NewLoginAttemptTracker(func() time.Time { return now })
+
+	tracker.RecordFailure("client-old")
+	now = now.Add(APILoginAttemptIdleTTL + time.Second)
+	tracker.RecordFailure("client-new")
+
+	if _, ok := tracker.entries["client-old"]; ok {
+		t.Fatal("idle login attempt entry was not pruned")
+	}
+	if _, ok := tracker.entries["client-new"]; !ok {
+		t.Fatal("new login attempt entry missing")
+	}
+}
+
+func TestLoginAttemptTrackerDoesNotPruneOnEveryRequest(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := NewLoginAttemptTracker(func() time.Time { return now })
+	tracker.RecordFailure("client")
+	firstPrune := tracker.lastPrune
+
+	now = now.Add(apiLoginAttemptPruneInterval / 2)
+	tracker.RecordFailure("client")
+
+	if !tracker.lastPrune.Equal(firstPrune) {
+		t.Fatalf("last prune = %s, want %s", tracker.lastPrune, firstPrune)
+	}
+}
+
+func TestLoginAttemptTrackerCapsEntriesAndPreservesLockedEntries(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := NewLoginAttemptTracker(func() time.Time { return now })
+
+	for i := 0; i < 3; i++ {
+		tracker.RecordFailure("locked")
+	}
+	for i := 0; i < APILoginAttemptMaxEntries; i++ {
+		now = now.Add(time.Millisecond)
+		tracker.RecordFailure(fmt.Sprintf("client-%d", i))
+	}
+
+	if got := len(tracker.entries); got > APILoginAttemptMaxEntries {
+		t.Fatalf("login attempt entries = %d, want <= %d", got, APILoginAttemptMaxEntries)
+	}
+	if _, ok := tracker.entries["locked"]; !ok {
+		t.Fatal("active lockout was evicted before unlocked entries")
+	}
+	if _, ok := tracker.entries["client-0"]; ok {
+		t.Fatal("oldest unlocked entry was not evicted")
+	}
+}
+
+func TestLoginAttemptTrackerAllowDoesNotCreateEntry(t *testing.T) {
+	tracker := NewLoginAttemptTracker(time.Now)
+	if !tracker.Allow("new-client") {
+		t.Fatal("new client should be allowed")
+	}
+	if got := len(tracker.entries); got != 0 {
+		t.Fatalf("login attempt entries = %d, want 0", got)
+	}
+}

--- a/services/api/auth/lockout_test.go
+++ b/services/api/auth/lockout_test.go
@@ -59,6 +59,30 @@ func TestLoginAttemptTrackerCapsEntriesAndPreservesLockedEntries(t *testing.T) {
 	}
 }
 
+func TestLoginAttemptTrackerNormalizesEmailSprayToIPBucket(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := NewLoginAttemptTracker(func() time.Time { return now })
+
+	for i := 0; i < 2; i++ {
+		tracker.RecordFailure("203.0.113.10|target@example.com")
+	}
+	for i := 0; i < APILoginAttemptMaxEntries; i++ {
+		now = now.Add(time.Millisecond)
+		tracker.RecordFailure(fmt.Sprintf("203.0.113.10|dummy-%d@example.com", i))
+	}
+
+	state, ok := tracker.entries["203.0.113.10"]
+	if !ok {
+		t.Fatal("ip bucket entry was evicted")
+	}
+	if len(tracker.entries) != 1 {
+		t.Fatalf("login attempt entries = %d, want 1 ip bucket", len(tracker.entries))
+	}
+	if state.Failures != APILoginAttemptMaxEntries+2 {
+		t.Fatalf("ip bucket failures = %d, want %d", state.Failures, APILoginAttemptMaxEntries+2)
+	}
+}
+
 func TestLoginAttemptTrackerAllowDoesNotCreateEntry(t *testing.T) {
 	tracker := NewLoginAttemptTracker(time.Now)
 	if !tracker.Allow("new-client") {

--- a/services/mcp-gateway/analytics.go
+++ b/services/mcp-gateway/analytics.go
@@ -86,7 +86,9 @@ func (s *gatewayServer) emitIfEnabled(ctx context.Context, event events.Envelope
 	default:
 		dropped := s.analyticsDropped.Add(1)
 		s.analyticsMu.Unlock()
-		log.Printf("gateway analytics queue full; dropped event total=%d source=%q event_type=%q", dropped, event.Source, event.EventType)
+		if shouldLogAnalyticsDrop(dropped) {
+			log.Printf("gateway analytics queue full; dropped event total=%d source=%q event_type=%q", dropped, event.Source, event.EventType)
+		}
 	}
 }
 
@@ -107,6 +109,13 @@ func (s *gatewayServer) analyticsEventQueue() chan analyticsEvent {
 		return nil
 	}
 	return s.analyticsQueue
+}
+
+func shouldLogAnalyticsDrop(dropped uint64) bool {
+	if dropped == 1 {
+		return true
+	}
+	return dropped != 0 && dropped&(dropped-1) == 0
 }
 
 // emit sends analytics events to the ingest service.

--- a/services/mcp-gateway/analytics.go
+++ b/services/mcp-gateway/analytics.go
@@ -72,8 +72,8 @@ func (s *gatewayServer) emitIfEnabled(ctx context.Context, event events.Envelope
 		return
 	}
 	s.analyticsMu.Lock()
-	defer s.analyticsMu.Unlock()
 	if s.analyticsClosed {
+		s.analyticsMu.Unlock()
 		return
 	}
 	item := analyticsEvent{
@@ -82,7 +82,11 @@ func (s *gatewayServer) emitIfEnabled(ctx context.Context, event events.Envelope
 	}
 	select {
 	case queue <- item:
+		s.analyticsMu.Unlock()
 	default:
+		dropped := s.analyticsDropped.Add(1)
+		s.analyticsMu.Unlock()
+		log.Printf("gateway analytics queue full; dropped event total=%d source=%q event_type=%q", dropped, event.Source, event.EventType)
 	}
 }
 

--- a/services/mcp-gateway/main_test.go
+++ b/services/mcp-gateway/main_test.go
@@ -575,6 +575,27 @@ func TestEmitIfEnabledDropsWhenQueueIsFull(t *testing.T) {
 	}
 }
 
+func TestShouldLogAnalyticsDropSamples(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		dropped uint64
+		want    bool
+	}{
+		{dropped: 0, want: false},
+		{dropped: 1, want: true},
+		{dropped: 2, want: true},
+		{dropped: 3, want: false},
+		{dropped: 4, want: true},
+		{dropped: 7, want: false},
+		{dropped: 8, want: true},
+	} {
+		if got := shouldLogAnalyticsDrop(tc.dropped); got != tc.want {
+			t.Fatalf("shouldLogAnalyticsDrop(%d) = %v, want %v", tc.dropped, got, tc.want)
+		}
+	}
+}
+
 func TestStopAnalyticsDispatcherDrainsQueue(t *testing.T) {
 	t.Parallel()
 

--- a/services/mcp-gateway/main_test.go
+++ b/services/mcp-gateway/main_test.go
@@ -570,6 +570,9 @@ func TestEmitIfEnabledDropsWhenQueueIsFull(t *testing.T) {
 	default:
 		t.Fatal("analytics queue unexpectedly drained")
 	}
+	if got := proxy.analyticsDropped.Load(); got != 1 {
+		t.Fatalf("analytics dropped count = %d, want 1", got)
+	}
 }
 
 func TestStopAnalyticsDispatcherDrainsQueue(t *testing.T) {

--- a/services/mcp-gateway/types.go
+++ b/services/mcp-gateway/types.go
@@ -83,6 +83,7 @@ type gatewayServer struct {
 	analyticsOnce         sync.Once
 	analyticsWG           sync.WaitGroup
 	analyticsClosed       bool
+	analyticsDropped      atomic.Uint64
 	oauthMu               sync.Mutex
 	oauthProviders        map[string]*oauthProvider
 	policyState           atomic.Value

--- a/services/ui/main.go
+++ b/services/ui/main.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -40,6 +41,10 @@ const (
 	defaultLoginFailureWindow     = 15 * time.Minute
 	defaultLoginFailureThreshold  = 5
 	defaultLoginLockoutDuration   = 5 * time.Minute
+	loginAttemptIdleTTL           = 30 * time.Minute
+	loginAttemptMaxClients        = 4096
+	loginAttemptPruneInterval     = time.Minute
+	loginAttemptEvictionBatch     = 256
 	loginFailureLogEvery          = 3
 	loginRequestMaxBytes          = 8 * 1024
 )
@@ -77,14 +82,16 @@ type uiSessionStore struct {
 }
 
 type loginAttemptTracker struct {
-	mu      sync.Mutex
-	clients map[string]*loginClientState
-	now     func() time.Time
+	mu        sync.Mutex
+	clients   map[string]*loginClientState
+	now       func() time.Time
+	lastPrune time.Time
 }
 
 type loginClientState struct {
 	tokens         int
 	lastRefill     time.Time
+	lastSeen       time.Time
 	failures       int
 	failuresExpire time.Time
 	lockedUntil    time.Time
@@ -737,8 +744,10 @@ func (t *loginAttemptTracker) allow(clientID string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	state := t.stateForLocked(clientID)
 	now := t.now()
+	t.pruneIfDueLocked(now)
+	state := t.stateForLocked(clientID, now)
+	state.lastSeen = now
 	refillLoginTokens(state, now)
 	if now.Before(state.lockedUntil) {
 		return false
@@ -747,6 +756,7 @@ func (t *loginAttemptTracker) allow(clientID string) bool {
 		return false
 	}
 	state.tokens--
+	t.enforceMaxLocked(now)
 	return true
 }
 
@@ -754,8 +764,10 @@ func (t *loginAttemptTracker) recordFailure(clientID string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	state := t.stateForLocked(clientID)
 	now := t.now()
+	t.pruneIfDueLocked(now)
+	state := t.stateForLocked(clientID, now)
+	state.lastSeen = now
 	if now.After(state.failuresExpire) {
 		state.failures = 0
 	}
@@ -764,6 +776,7 @@ func (t *loginAttemptTracker) recordFailure(clientID string) int {
 	if state.failures >= loginFailureThreshold {
 		state.lockedUntil = now.Add(loginLockoutDuration)
 	}
+	t.enforceMaxLocked(now)
 	return state.failures
 }
 
@@ -771,7 +784,13 @@ func (t *loginAttemptTracker) recordSuccess(clientID string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	state := t.stateForLocked(clientID)
+	now := t.now()
+	t.pruneIfDueLocked(now)
+	state := t.clients[clientID]
+	if state == nil {
+		return 0
+	}
+	state.lastSeen = now
 	prior := state.failures
 	state.failures = 0
 	state.failuresExpire = time.Time{}
@@ -779,14 +798,57 @@ func (t *loginAttemptTracker) recordSuccess(clientID string) int {
 	return prior
 }
 
-func (t *loginAttemptTracker) stateForLocked(clientID string) *loginClientState {
+func (t *loginAttemptTracker) stateForLocked(clientID string, now time.Time) *loginClientState {
 	state := t.clients[clientID]
 	if state == nil {
-		now := t.now()
-		state = &loginClientState{tokens: loginRateLimitCapacity, lastRefill: now}
+		state = &loginClientState{tokens: loginRateLimitCapacity, lastRefill: now, lastSeen: now}
 		t.clients[clientID] = state
 	}
 	return state
+}
+
+func (t *loginAttemptTracker) pruneIfDueLocked(now time.Time) {
+	if !t.lastPrune.IsZero() && now.Sub(t.lastPrune) < loginAttemptPruneInterval {
+		return
+	}
+	t.lastPrune = now
+	for clientID, state := range t.clients {
+		if now.Sub(state.lastSeen) > loginAttemptIdleTTL && !now.Before(state.lockedUntil) {
+			delete(t.clients, clientID)
+		}
+	}
+}
+
+func (t *loginAttemptTracker) enforceMaxLocked(now time.Time) {
+	if len(t.clients) <= loginAttemptMaxClients {
+		return
+	}
+	target := loginAttemptMaxClients - loginAttemptEvictionBatch
+	if target < 0 {
+		target = 0
+	}
+	type candidate struct {
+		clientID string
+		lastSeen time.Time
+		locked   bool
+	}
+	candidates := make([]candidate, 0, len(t.clients))
+	for clientID, state := range t.clients {
+		candidates = append(candidates, candidate{
+			clientID: clientID,
+			lastSeen: state.lastSeen,
+			locked:   now.Before(state.lockedUntil),
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].locked != candidates[j].locked {
+			return !candidates[i].locked
+		}
+		return candidates[i].lastSeen.Before(candidates[j].lastSeen)
+	})
+	for _, entry := range candidates[:len(t.clients)-target] {
+		delete(t.clients, entry.clientID)
+	}
 }
 
 func refillLoginTokens(state *loginClientState, now time.Time) {

--- a/services/ui/main_test.go
+++ b/services/ui/main_test.go
@@ -1239,6 +1239,62 @@ func TestHandleLoginSuccessResetsFailureCounter(t *testing.T) {
 	}
 }
 
+func TestLoginAttemptTrackerPrunesIdleClientsPeriodically(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newLoginAttemptTracker(func() time.Time { return now })
+
+	tracker.recordFailure("client-old")
+	now = now.Add(loginAttemptIdleTTL + time.Second)
+	tracker.recordFailure("client-new")
+
+	if _, ok := tracker.clients["client-old"]; ok {
+		t.Fatal("idle login attempt client was not pruned")
+	}
+	if _, ok := tracker.clients["client-new"]; !ok {
+		t.Fatal("new login attempt client missing")
+	}
+}
+
+func TestLoginAttemptTrackerDoesNotPruneOnEveryRequest(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newLoginAttemptTracker(func() time.Time { return now })
+	tracker.recordFailure("client")
+	firstPrune := tracker.lastPrune
+
+	now = now.Add(loginAttemptPruneInterval / 2)
+	tracker.recordFailure("client")
+
+	if !tracker.lastPrune.Equal(firstPrune) {
+		t.Fatalf("last prune = %s, want %s", tracker.lastPrune, firstPrune)
+	}
+}
+
+func TestLoginAttemptTrackerCapsClientsAndPreservesLockedClients(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	tracker := newLoginAttemptTracker(func() time.Time { return now })
+	tracker.clients["locked"] = &loginClientState{
+		lastSeen:    now,
+		lockedUntil: now.Add(loginLockoutDuration),
+	}
+
+	for i := 0; i < loginAttemptMaxClients; i++ {
+		now = now.Add(time.Millisecond)
+		if !tracker.allow(fmt.Sprintf("client-%d", i)) {
+			t.Fatalf("client-%d should be allowed on first attempt", i)
+		}
+	}
+
+	if got := len(tracker.clients); got > loginAttemptMaxClients {
+		t.Fatalf("login attempt clients = %d, want <= %d", got, loginAttemptMaxClients)
+	}
+	if _, ok := tracker.clients["locked"]; !ok {
+		t.Fatal("active lockout was evicted before unlocked clients")
+	}
+	if _, ok := tracker.clients["client-0"]; ok {
+		t.Fatal("oldest unlocked client was not evicted")
+	}
+}
+
 func useLoginAttemptTrackerForTest(t *testing.T) func() {
 	t.Helper()
 	previous := loginAttempts


### PR DESCRIPTION
Revives the still-applicable scope from #195 on current main.

- ports API login-attempt bounding into `services/api/auth/lockout.go` after the auth refactor
- bounds the UI tracker with the same 30-minute idle TTL and 4096-entry cap
- amortizes maintenance with periodic pruning and batched eviction
- evicts unlocked entries before active lockouts, preventing key spray from flushing lockouts
- counts and logs gateway analytics queue drops, providing the backing value for the metrics work tracked by #303

Validation:
- `go test -race -count=1 ./...` in `services/api`
- `go test -race -count=1 ./...` in `services/ui`
- `go test -race -count=1 ./...` in `services/mcp-gateway`
- pre-commit: gitleaks, gofmt, staticcheck, vet, unit tests, generated drift

This does not address the remaining #146 gaps for processor shutdown flushing or gateway SIGTERM handling.